### PR TITLE
Add nvidia-smi to example gpu-pod

### DIFF
--- a/docs/quickstart/pods/gpu-pod.yaml
+++ b/docs/quickstart/pods/gpu-pod.yaml
@@ -13,7 +13,7 @@ spec:
     - name: main
       image: ubuntu
       command: ["bash", "-c"]
-      args: ["nvidia-smi; trap 'exit 0' TERM; sleep 9000 & wait"]
+      args: ["nvidia-smi; trap 'exit 0' TERM; sleep infinity & wait"]
       resources:
         limits:
           nvidia.com/gpu: "1"

--- a/docs/quickstart/pods/gpu-pod.yaml
+++ b/docs/quickstart/pods/gpu-pod.yaml
@@ -12,7 +12,8 @@ spec:
   containers:
     - name: main
       image: ubuntu
-      args: ["sleep", "infinity"]
+      command: ["bash", "-c"]
+      args: ["nvidia-smi; trap 'exit 0' TERM; sleep 9000 & wait"]
       resources:
         limits:
           nvidia.com/gpu: "1"


### PR DESCRIPTION
This is to add classic nvidia-smi to example gpu-pod 

```
$ kubectl get pod
NAME      READY   STATUS    RESTARTS   AGE
gpu-pod   1/1     Running   0          6s

$ kubectl logs gpu-pod
Tue Apr  1 21:39:23 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.86.15              Driver Version: 570.86.15      CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GH200 96GB HBM3         On  |   00000009:01:00.0 Off |                    0 |
| N/A   37C    P0            101W /  900W |       1MiB /  97871MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```