### PR TITLE
docs: fix typo in docs/queues/README.md

### DIFF
--- a/docs/queues/README.md
+++ b/docs/queues/README.md
@@ -46,7 +46,7 @@ The `gpu` field sets the quota policy for GPU resources assigned to the queue. G
 ```
 quota: integer
 overQuotaWeight: integer
-limit: intereg
+limit: integer
 ```
 
 ### Quota (Optional)


### PR DESCRIPTION
line 49: "limit: intereg" changed to "limit:integer"