### PR TITLE
Add Dynamic Binpack/Spread Strategy via Pod Annotations

### DIFF
--- a/pkg/scheduler/plugins/nodeplacement/nodepack_test.go
+++ b/pkg/scheduler/plugins/nodeplacement/nodepack_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
@@ -41,7 +42,6 @@ func TestNodePack(t *testing.T) {
 
 	for i, testMetadata := range testsMetadata {
 		ssn, task, expectedScoreMap := buildSingleTestParams(testMetadata)
-
 		t.Run(testMetadata.name, func(t *testing.T) {
 			testScoresOfCurrentTopology(t, i, testMetadata.name, ssn, task, expectedScoreMap)
 		})
@@ -264,6 +264,10 @@ func createFakeTask(taskName string) *pod_info.PodInfo {
 	return pod_info.NewTaskInfo(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: taskName,
+			Annotations: map[string]string{
+				"kai.scheduler/placementStrategy":        "binpack",
+				commonconstants.PodGroupAnnotationForPod: taskName + "-group",
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/pkg/scheduler/plugins/nodeplacement/nodeplacement.go
+++ b/pkg/scheduler/plugins/nodeplacement/nodeplacement.go
@@ -67,15 +67,37 @@ func (pp *nodePlacementPlugin) OnSessionOpen(ssn *framework.Session) {
 }
 
 func (pp *nodePlacementPlugin) nodeOrderFn(task *pod_info.PodInfo, node *node_info.NodeInfo) (float64, error) {
-	if task != nil && task.IsCPUOnlyRequest() {
+	strategy := task.GetPlacementStrategy()
+	if task.IsCPUOnlyRequest() {
+		if strategy == pod_info.PlacementStrategySpread ||
+			(strategy == "" && pp.pluginArguments[constants.CPUResource] == constants.SpreadStrategy) {
+			return pp.cpuTaskScoreFn(task, node)
+		}
 		return pp.cpuTaskScoreFn(task, node)
+	}
+
+	// GPU case
+	if strategy == pod_info.PlacementStrategySpread ||
+		(strategy == "" && pp.pluginArguments[constants.GPUResource] == constants.SpreadStrategy) {
+		return pp.gpuTaskScoreFn(task, node)
 	}
 	return pp.gpuTaskScoreFn(task, node)
 }
 
 func (pp *nodePlacementPlugin) nodePreOrderFn(task *pod_info.PodInfo, fittingNodes []*node_info.NodeInfo) error {
-	if task != nil && task.IsCPUOnlyRequest() {
+	strategy := task.GetPlacementStrategy()
+	if task.IsCPUOnlyRequest() {
+		if strategy == pod_info.PlacementStrategySpread ||
+			(strategy == "" && pp.pluginArguments[constants.CPUResource] == constants.SpreadStrategy) {
+			return pp.cpuPreOrderFn(task, fittingNodes)
+		}
 		return pp.cpuPreOrderFn(task, fittingNodes)
+	}
+
+	// GPU case
+	if strategy == pod_info.PlacementStrategySpread ||
+		(strategy == "" && pp.pluginArguments[constants.GPUResource] == constants.SpreadStrategy) {
+		return pp.gpuPreOrderFn(task, fittingNodes)
 	}
 	return pp.gpuPreOrderFn(task, fittingNodes)
 }


### PR DESCRIPTION
This PR enables per-Pod binpack/spread scheduling via the kai.scheduler/placementStrategy annotation, 
defaulting to existing CPU/GPU configs when unset. 
A single KAI-Scheduler can now handle both training (binpack) and inference (spread) in one cluster. 
This approach improves scheduling flexibility and resource utilization for diverse AI/ML workloads.