### PR TITLE
docs: specify legacy v1 version of kubeflow-training-operator

### DIFF
--- a/docs/batch/README.md
+++ b/docs/batch/README.md
@@ -13,7 +13,7 @@ This will create 2 pods that will be scheduled separately. Both pods will either
 To run in a distributed way across multiple pods, you can use PyTorchJob.
 
 ### Prerequisites
-This requires the [training-operator](https://github.com/kubeflow/trainer) to be installed in the cluster.
+This requires the [kubeflow-training-operator-v1](https://www.kubeflow.org/docs/components/trainer/legacy-v1/) to be installed in the cluster.
 
 ### Instructions
 Apply the following command to create a sample PyTorchJob with a master pod and two worker pods:


### PR DESCRIPTION
This update corrects the documentation for PyTorchJob in batch scheduling to reflect the fact that the kubeflow-training-operator-v1 is required, rather than the v2 version. The original instructions were misleading, as the v2 version does not support the necessary functionality for scheduling jobs as described. The updated doc now correctly points to the legacy v1 version of the operator, which is compatible with gang scheduling for PyTorch jobs.