### PR TITLE
Docs hotfix: Update and rename pytorch-elasitc.yaml to pytorch-elastic.yaml

### DIFF
--- a/docs/elastic/pytorch-elastic.yaml
+++ b/docs/elastic/pytorch-elastic.yaml
@@ -5,6 +5,8 @@ apiVersion: "kubeflow.org/v1"
 kind: PyTorchJob
 metadata:
   name: elastic-example-imagenet
+  labels:
+    runai/queue: test
 spec:
   elasticPolicy:
     rdzvBackend: c10d


### PR DESCRIPTION
- runai/queue is added
- fixed the typo in the yaml name