### PR TITLE
Remove repeated active departments queue creation 

### DIFF
--- a/pkg/scheduler/actions/utils/job_order_by_queue.go
+++ b/pkg/scheduler/actions/utils/job_order_by_queue.go
@@ -210,15 +210,15 @@ func (jobsOrder *JobsOrderByQueues) buildActiveJobOrderPriorityQueues(reverseOrd
 		jobsOrder.departmentIdToDepartmentMetadata[queue.ParentQueue].queuesPriorityQueue.Push(queue)
 		log.InfraLogger.V(7).Infof("Pushed queue to department's queue priority queue, department name: <%v>, queue name: <%v>, number of active jobs in queue: <%v>, reverseOrder: <%v>",
 			queue.ParentQueue, queue.Name, jobsOrder.queueIdToQueueMetadata[queue.UID].jobsInQueue.Len(), reverseOrder)
+	}
 
-		log.InfraLogger.V(7).Infof("Building departments, reverse order: <%v>", reverseOrder)
-		jobsOrder.activeDepartments = scheduler_util.NewPriorityQueue(
-			jobsOrder.buildFuncOrderBetweenDepartmentsWithJobs(reverseOrder),
-			scheduler_util.QueueCapacityInfinite)
-		for departmentUID := range jobsOrder.departmentIdToDepartmentMetadata {
-			log.InfraLogger.V(7).Infof("active Department <%s> ", departmentUID)
-			jobsOrder.activeDepartments.Push(jobsOrder.ssn.Queues[departmentUID])
-		}
+	log.InfraLogger.V(7).Infof("Building departments, reverse order: <%v>", reverseOrder)
+	jobsOrder.activeDepartments = scheduler_util.NewPriorityQueue(
+		jobsOrder.buildFuncOrderBetweenDepartmentsWithJobs(reverseOrder),
+		scheduler_util.QueueCapacityInfinite)
+	for departmentUID := range jobsOrder.departmentIdToDepartmentMetadata {
+		log.InfraLogger.V(7).Infof("active Department <%s> ", departmentUID)
+		jobsOrder.activeDepartments.Push(jobsOrder.ssn.Queues[departmentUID])
 	}
 }
 


### PR DESCRIPTION
Created this as a test MR to see what the contribution process looks like. 

The PR moves a code block that is unnecessarily repeated under a for loop. There appears to be a bug in the `buildActiveJobOrderPriorityQueues` method. The code between lines 214-221 is incorrectly placed inside the outer for loop that iterates over `jobsOrder.ssn.Queues`. This means that for every queue, it's:
 * Creating a new activeDepartments priority queue
 * Rebuilding the entire department priority queue from scratch
 * Pushing all departments into it

Looks inefficient.