### PR TITLE
Add/amend test logging to use .TestTopologyBasic.Name

### DIFF
--- a/pkg/scheduler/actions/allocate/allocateElastic_test.go
+++ b/pkg/scheduler/actions/allocate/allocateElastic_test.go
@@ -25,6 +25,8 @@ func TestHandleElasticAllocation(t *testing.T) {
 	defer controller.Finish()
 
 	for testNumber, testMetadata := range getElasticTestsMetadata() {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		allocateAction := allocate.New()
 		allocateAction.Execute(ssn)

--- a/pkg/scheduler/actions/allocate/allocateFractionalGpu_test.go
+++ b/pkg/scheduler/actions/allocate/allocateFractionalGpu_test.go
@@ -28,6 +28,8 @@ func TestHandleFractionalGPUAllocation(t *testing.T) {
 
 	testsMetadata := getFractionalGPUTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		allocateAction := allocate.New()
 		allocateAction.Execute(ssn)

--- a/pkg/scheduler/actions/allocate/allocateGang_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGang_test.go
@@ -28,6 +28,8 @@ func TestHandleGangAllocation(t *testing.T) {
 
 func runTests(t *testing.T, testsMetadata []integration_tests_utils.TestTopologyMetadata, controller *Controller) {
 	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		allocateAction := allocate.New()
 		allocateAction.Execute(ssn)

--- a/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
@@ -27,6 +27,8 @@ func TestHandleMemoryGPUAllocation(t *testing.T) {
 
 	testsMetadata := getMemoryGPUTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		allocateAction := allocate.New()
 		allocateAction.Execute(ssn)

--- a/pkg/scheduler/actions/allocate/allocateMIG_test.go
+++ b/pkg/scheduler/actions/allocate/allocateMIG_test.go
@@ -30,6 +30,8 @@ func TestHandleMIGAllocation(t *testing.T) {
 
 	testsMetadata := getMIGTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		allocateAction := allocate.New()
 		allocateAction.Execute(ssn)

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -31,6 +31,8 @@ func TestHandleAllocation(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		allocateAction := allocate.New()
 		allocateAction.Execute(ssn)

--- a/pkg/scheduler/actions/consolidation/consolidation_test.go
+++ b/pkg/scheduler/actions/consolidation/consolidation_test.go
@@ -27,7 +27,7 @@ func TestConsolidation(t *testing.T) {
 	testsMetadata := getTestsMetadata()
 
 	for testNumber, testMetadata := range testsMetadata {
-		fmt.Printf("Running test %d/%d: %s\n", testNumber, len(testsMetadata), testMetadata.Name)
+		fmt.Printf("Running test %d/%d: %s\n", testNumber, len(testsMetadata), testMetadata.TestTopologyBasic.Name)
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		consolidationAction := consolidation.New()
 		consolidationAction.Execute(ssn)

--- a/pkg/scheduler/actions/integration_tests/integration_tests_utils/integration_tests_utils.go
+++ b/pkg/scheduler/actions/integration_tests/integration_tests_utils/integration_tests_utils.go
@@ -49,7 +49,7 @@ func RunTests(t *testing.T, testsMetadata []TestTopologyMetadata) {
 }
 
 func RunTest(t *testing.T, testMetadata TestTopologyMetadata, testNumber int, controller *Controller) {
-	t.Logf("Running test number: %v, test name: %v", testNumber, testMetadata.Name)
+	t.Logf("Running test number: %v, test name: %v", testNumber, testMetadata.TestTopologyBasic.Name)
 	ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 
 	runRoundsUntilMatch(testMetadata, controller, &ssn)

--- a/pkg/scheduler/actions/preempt/preemptGang_test.go
+++ b/pkg/scheduler/actions/preempt/preemptGang_test.go
@@ -26,6 +26,7 @@ func TestHandleGangPreempt(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getTestsGangMetadata()
 	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running Test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
 
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		preemptAction := preempt.New()

--- a/pkg/scheduler/actions/preempt/preemptMIG_test.go
+++ b/pkg/scheduler/actions/preempt/preemptMIG_test.go
@@ -26,7 +26,7 @@ func TestMIGPreempt(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getMIGTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running Test %d: %s", testNumber, testMetadata.Name)
+		t.Logf("Running Test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
 
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		preemptAction := preempt.New()

--- a/pkg/scheduler/actions/preempt/preempt_elastic_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_elastic_test.go
@@ -26,7 +26,7 @@ func TestHandlePreemptElastic(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getElasticTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running Test %d: %s", testNumber, testMetadata.Name)
+		t.Logf("Running Test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
 
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		preemptAction := preempt.New()

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -25,7 +25,7 @@ func TestHandlePreempt(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getTestsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running Test %d: %s", testNumber, testMetadata.Name)
+		t.Logf("Running Test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
 
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		preemptAction := preempt.New()

--- a/pkg/scheduler/actions/reclaim/reclaimDepartments_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaimDepartments_test.go
@@ -25,7 +25,7 @@ func TestHandleDepartmentsReclaim(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getTestsDepartmentsMetadata()
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.Name)
+		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.TestTopologyBasic.Name)
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		reclaimAction := reclaim.New()
 		reclaimAction.Execute(ssn)

--- a/pkg/scheduler/actions/reclaim/reclaimGang_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaimGang_test.go
@@ -26,7 +26,7 @@ func TestHandleGangReclaim(t *testing.T) {
 	defer controller.Finish()
 	testsMetadata := getTestsGangReclaimMetadata()
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.Name)
+		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.TestTopologyBasic.Name)
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		reclaimAction := reclaim.New()
 		reclaimAction.Execute(ssn)

--- a/pkg/scheduler/actions/reclaim/reclaimMIG_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaimMIG_test.go
@@ -29,7 +29,7 @@ func TestMIGReclaim(t *testing.T) {
 	testsMetadata := getMIGTestsMetadata()
 
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.Name)
+		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.TestTopologyBasic.Name)
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		reclaimAction := reclaim.New()
 		reclaimAction.Execute(ssn)

--- a/pkg/scheduler/actions/reclaim/reclaim_elastic_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_elastic_test.go
@@ -28,7 +28,7 @@ func TestHandleElasticReclaim(t *testing.T) {
 	testsMetadata := getTestsElasticMetadata()
 
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.Name)
+		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.TestTopologyBasic.Name)
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		reclaimAction := reclaim.New()
 		reclaimAction.Execute(ssn)

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -28,7 +28,7 @@ func TestHandleReclaim(t *testing.T) {
 	testsMetadata := getTestsMetadata()
 
 	for testNumber, testMetadata := range testsMetadata {
-		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.Name)
+		t.Logf("Running test number: %v, test name: %v,", testNumber, testMetadata.TestTopologyBasic.Name)
 		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
 		reclaimAction := reclaim.New()
 		reclaimAction.Execute(ssn)


### PR DESCRIPTION
Currently some tests are trying to read TestToplogyMetadata.Name which is empty for all tests, causing go test -v to return very non-descript test cases such as `integration_tests_utils.go:52: Running test number: 0, test name: ` Since .TestTopologyBasic.Name is set for all cases, this diff changes all log lines to that instead for now.

Now they output:
`reclaim_test.go:31: Running test number: 11, test name: 1 train job of 2 GPUs from queue0 running on node0 with deserved of 1, 2 pending jobs from queue1 - reclaim,`

