### PR TITLE
Scheduling gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+
+### Added
+- Added support for [k8s pod scheduling gates](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/)

--- a/pkg/env-tests/scheduler_test.go
+++ b/pkg/env-tests/scheduler_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			})
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
 
-			err := GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod})
+			err := GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod}, 1)
 			Expect(err).NotTo(HaveOccurred(), "Failed to group pods")
 
 			// Wait for bind request to be created instead of checking pod binding
@@ -122,7 +122,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			Expect(len(bindRequests.Items)).To(Equal(1), "Expected 1 bind request", PrettyPrintBindRequestList(bindRequests))
 		})
 
-		It("Should respect scheduling gates", func(ctx context.Context) {
+		It("Should respect scheduling gates - simple pod", func(ctx context.Context) {
 			// Create your pod as before
 			testPod := CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -136,7 +136,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			}
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
 
-			err := GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod})
+			err := GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod}, 1)
 
 			Expect(err).NotTo(HaveOccurred(), "Failed to group pods")
 			err = wait.PollUntilContextTimeout(ctx, interval, defaultTimeout, true, func(ctx context.Context) (bool, error) {
@@ -171,6 +171,74 @@ var _ = Describe("Scheduler", Ordered, func() {
 				To(Succeed(), "Failed to list bind requests")
 
 			Expect(len(bindRequests.Items)).To(Equal(1), "Expected 1 bind request", PrettyPrintBindRequestList(bindRequests))
+		})
+
+		It("Should respect scheduling gates - podgroup", func(ctx context.Context) {
+			testPod1 := CreatePodObject(testNamespace.Name, "test-pod-1", corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					constants.GpuResource: resource.MustParse("1"),
+				},
+			})
+			testPod1.Spec.SchedulingGates = []corev1.PodSchedulingGate{
+				{
+					Name: "gated",
+				},
+			}
+			Expect(ctrlClient.Create(ctx, testPod1)).To(Succeed(), "Failed to create test pod")
+
+			testPod2 := CreatePodObject(testNamespace.Name, "test-pod-2", corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					constants.GpuResource: resource.MustParse("1"),
+				},
+			})
+			testPod2.Spec.SchedulingGates = []corev1.PodSchedulingGate{
+				{
+					Name: "gated",
+				},
+			}
+			Expect(ctrlClient.Create(ctx, testPod2)).To(Succeed(), "Failed to create test pod")
+
+			err := GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod1, testPod2}, 1)
+			Expect(err).NotTo(HaveOccurred(), "Failed to group pods")
+
+			err = wait.PollUntilContextTimeout(ctx, interval, defaultTimeout, true, func(ctx context.Context) (bool, error) {
+				var events corev1.EventList
+				Expect(ctrlClient.List(ctx, &events, client.InNamespace(testNamespace.Name))).
+					To(Succeed(), "Failed to list events")
+
+				for _, event := range events.Items {
+					if event.InvolvedObject.Kind != "PodGroup" || event.Reason != "NotReady" {
+						continue
+					}
+
+					return true, nil
+				}
+
+				return false, nil
+			})
+			Expect(err).NotTo(HaveOccurred(), "Failed to wait for unready podgroup event")
+
+			ctrlClient.Get(ctx, client.ObjectKey{Name: testPod1.Name, Namespace: testNamespace.Name}, testPod1)
+			ungatedPod := testPod1.DeepCopy()
+			ungatedPod.Spec.SchedulingGates = nil
+			patch := client.MergeFrom(testPod1)
+			Expect(ctrlClient.Patch(ctx, ungatedPod, patch)).To(Succeed(), "Failed to remove scheduling gates from test pod")
+
+			err = WaitForPodScheduled(ctx, ctrlClient, testPod1.Name, testNamespace.Name, defaultTimeout, interval)
+			Expect(err).NotTo(HaveOccurred(), "Failed to wait for test pod to be scheduled")
+
+			ctrlClient.Get(ctx, client.ObjectKey{Name: testPod2.Name, Namespace: testNamespace.Name}, testPod2)
+			// expect testPod2 to not be scheduled
+			Expect(testPod2.Status.Phase).To(Equal(corev1.PodPending), "Expected test pod 2 to not be scheduled")
+
+			// ungate testPod2
+			ungatedPod2 := testPod2.DeepCopy()
+			ungatedPod2.Spec.SchedulingGates = nil
+			patch2 := client.MergeFrom(testPod2)
+			Expect(ctrlClient.Patch(ctx, ungatedPod2, patch2)).To(Succeed(), "Failed to remove scheduling gates from test pod")
+
+			err = WaitForPodScheduled(ctx, ctrlClient, testPod2.Name, testNamespace.Name, defaultTimeout, interval)
+			Expect(err).NotTo(HaveOccurred(), "Failed to wait for test pod to be scheduled")
 		})
 	})
 
@@ -221,7 +289,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			dynamicresource.UseClaim(testPod, resourceClaim)
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
 
-			err = GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod})
+			err = GroupPods(ctx, ctrlClient, testQueue.Name, "test-podgroup", []*corev1.Pod{testPod}, 1)
 			Expect(err).NotTo(HaveOccurred(), "Failed to group pods")
 
 			err = WaitForPodScheduled(ctx, ctrlClient, testPod.Name, testNamespace.Name, defaultTimeout, interval)
@@ -254,7 +322,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 				Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
 				createdPods = append(createdPods, testPod)
 
-				err = GroupPods(ctx, ctrlClient, testQueue.Name, fmt.Sprintf("test-podgroup-%d", i), []*corev1.Pod{testPod})
+				err = GroupPods(ctx, ctrlClient, testQueue.Name, fmt.Sprintf("test-podgroup-%d", i), []*corev1.Pod{testPod}, 1)
 				Expect(err).NotTo(HaveOccurred(), "Failed to group pods")
 			}
 

--- a/pkg/env-tests/utils.go
+++ b/pkg/env-tests/utils.go
@@ -125,7 +125,7 @@ func CreatePodObject(namespace, name string, resources corev1.ResourceRequiremen
 	return pod
 }
 
-func GroupPods(ctx context.Context, c client.Client, queueName, podgroupName string, pods []*corev1.Pod) error {
+func GroupPods(ctx context.Context, c client.Client, queueName, podgroupName string, pods []*corev1.Pod, minMember int32) error {
 	if len(pods) == 0 {
 		return fmt.Errorf("no pods to group")
 	}
@@ -137,7 +137,7 @@ func GroupPods(ctx context.Context, c client.Client, queueName, podgroupName str
 		},
 		Spec: schedulingv2alpha2.PodGroupSpec{
 			Queue:             queueName,
-			MinMember:         int32(len(pods)),
+			MinMember:         minMember,
 			MarkUnschedulable: ptr.To(true),
 		},
 	}

--- a/pkg/scheduler/api/pod_info/pod_info.go
+++ b/pkg/scheduler/api/pod_info/pod_info.go
@@ -326,8 +326,11 @@ func getTaskStatus(pod *v1.Pod, bindRequest *bindrequest_info.BindRequestInfo) p
 		}
 
 		if bindRequest != nil {
-
 			return pod_status.Binding
+		}
+
+		if len(pod.Spec.SchedulingGates) > 0 {
+			return pod_status.Gated
 		}
 
 		return pod_status.Pending

--- a/pkg/scheduler/api/pod_status/pod_status.go
+++ b/pkg/scheduler/api/pod_status/pod_status.go
@@ -10,6 +10,9 @@ const (
 	// Pending means the task is pending in the apiserver.
 	Pending PodStatus = 1 << iota
 
+	// Gated means the task is gated in the apiserver.
+	Gated
+
 	// Allocated means the scheduler assigns a host to it.
 	Allocated
 
@@ -46,7 +49,7 @@ const (
 const (
 	activeUsedStatuses      = Allocated | Pipelined | Binding | Bound | Running | Releasing
 	activeAllocatedStatuses = Allocated | Pipelined | Binding | Bound | Running
-	aliveStatuses           = Allocated | Pipelined | Binding | Bound | Running | Pending
+	aliveStatuses           = Allocated | Pipelined | Binding | Bound | Running | Pending | Gated
 	boundStatuses           = Allocated | Bound | Running | Releasing
 	allocatedStatuses       = Allocated | Bound | Binding | Running
 )
@@ -55,6 +58,8 @@ func (ps PodStatus) String() string {
 	switch ps {
 	case Pending:
 		return "Pending"
+	case Gated:
+		return "Gated"
 	case Allocated:
 		return "Allocated"
 	case Pipelined:

--- a/pkg/scheduler/api/pod_status/pod_status.go
+++ b/pkg/scheduler/api/pod_status/pod_status.go
@@ -3,8 +3,6 @@
 
 package pod_status
 
-import "golang.org/x/exp/slices"
-
 // PodStatus defines the status of a task/pod.
 type PodStatus int
 
@@ -44,6 +42,15 @@ const (
 	Deleted
 )
 
+// Status group constants using bitwise OR
+const (
+	activeUsedStatuses      = Allocated | Pipelined | Binding | Bound | Running | Releasing
+	activeAllocatedStatuses = Allocated | Pipelined | Binding | Bound | Running
+	aliveStatuses           = Allocated | Pipelined | Binding | Bound | Running | Pending
+	boundStatuses           = Allocated | Bound | Running | Releasing
+	allocatedStatuses       = Allocated | Bound | Binding | Running
+)
+
 func (ps PodStatus) String() string {
 	switch ps {
 	case Pending:
@@ -71,28 +78,22 @@ func (ps PodStatus) String() string {
 	}
 }
 
-var activeUsedStatuses = []PodStatus{Allocated, Pipelined, Binding, Bound, Running, Releasing}
-var activeAllocatedStatuses = []PodStatus{Allocated, Pipelined, Binding, Bound, Running}
-var aliveStatuses = []PodStatus{Allocated, Pipelined, Binding, Bound, Running, Pending}
-var boundStatuses = []PodStatus{Allocated, Bound, Running, Releasing}
-var allocatedStatuses = []PodStatus{Allocated, Bound, Binding, Running}
-
 func IsAliveStatus(statusInput PodStatus) bool {
-	return slices.Contains(aliveStatuses, statusInput)
+	return aliveStatuses&statusInput != 0
 }
 
 func IsActiveUsedStatus(statusInput PodStatus) bool {
-	return slices.Contains(activeUsedStatuses, statusInput)
+	return activeUsedStatuses&statusInput != 0
 }
 
 func IsActiveAllocatedStatus(statusInput PodStatus) bool {
-	return slices.Contains(activeAllocatedStatuses, statusInput)
+	return activeAllocatedStatuses&statusInput != 0
 }
 
 func IsPodBound(statusInput PodStatus) bool {
-	return slices.Contains(boundStatuses, statusInput)
+	return boundStatuses&statusInput != 0
 }
 
 func AllocatedStatus(status PodStatus) bool {
-	return slices.Contains(allocatedStatuses, status)
+	return allocatedStatuses&status != 0
 }

--- a/pkg/scheduler/api/pod_status/pod_status_test.go
+++ b/pkg/scheduler/api/pod_status/pod_status_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package pod_status
+
+import (
+	"testing"
+)
+
+// aliveStatuses           = Allocated | Pipelined | Binding | Bound | Running | Pending | Gated
+func TestIsAliveStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   PodStatus
+		expected bool
+	}{
+		{
+			name:     "Allocated",
+			status:   Allocated,
+			expected: true,
+		},
+		{
+			name:     "Pipelined",
+			status:   Pipelined,
+			expected: true,
+		},
+		{
+			name:     "Binding",
+			status:   Binding,
+			expected: true,
+		},
+		{
+			name:     "Bound",
+			status:   Bound,
+			expected: true,
+		},
+		{
+			name:     "Running",
+			status:   Running,
+			expected: true,
+		},
+		{
+			name:     "Pending",
+			status:   Pending,
+			expected: true,
+		},
+		{
+			name:     "Gated",
+			status:   Gated,
+			expected: true,
+		},
+		{
+			name:     "Succeeded",
+			status:   Succeeded,
+			expected: false,
+		},
+		{
+			name:     "Failed",
+			status:   Failed,
+			expected: false,
+		},
+		{
+			name:     "Deleted",
+			status:   Deleted,
+			expected: false,
+		},
+		{
+			name:     "Unknown",
+			status:   Unknown,
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsAliveStatus(test.status)
+			if result != test.expected {
+				t.Errorf("IsAliveStatus(%v) = %v, expected %v", test.status, result, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/api/podgroup_info/allocation_info.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info.go
@@ -27,7 +27,6 @@ func HasTasksToAllocate(podGroupInfo *PodGroupInfo, isRealAllocation bool) bool 
 func GetTasksToAllocate(
 	podGroupInfo *PodGroupInfo, taskOrderFn common_info.LessFn, isRealAllocation bool,
 ) []*pod_info.PodInfo {
-
 	taskPriorityQueue := getTasksToAllocateQueue(podGroupInfo, taskOrderFn, isRealAllocation)
 	maxNumOfTasksToAllocate := getNumOfTasksToAllocate(podGroupInfo, taskPriorityQueue.Len())
 

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -259,6 +259,10 @@ func (podGroupInfo *PodGroupInfo) GetNumPendingTasks() int {
 	return len(podGroupInfo.PodStatusIndex[pod_status.Pending])
 }
 
+func (podGroupInfo *PodGroupInfo) GetNumGatedTasks() int {
+	return len(podGroupInfo.PodStatusIndex[pod_status.Gated])
+}
+
 func (podGroupInfo *PodGroupInfo) GetAliveTasksRequestedGPUs() float64 {
 	tasksTotalRequestedGPUs := float64(0)
 	for _, task := range podGroupInfo.PodInfos {
@@ -282,8 +286,8 @@ func (podGroupInfo *PodGroupInfo) GetTasksActiveAllocatedReqResource() *resource
 }
 
 func (podGroupInfo *PodGroupInfo) IsReadyForScheduling() bool {
-	numAliveTasks := podGroupInfo.GetNumAliveTasks()
-	return int32(numAliveTasks) >= podGroupInfo.MinAvailable
+	validTasks := podGroupInfo.GetNumAliveTasks() - podGroupInfo.GetNumGatedTasks()
+	return int32(validTasks) >= podGroupInfo.MinAvailable
 }
 
 func (podGroupInfo *PodGroupInfo) IsPodGroupStale() bool {

--- a/pkg/scheduler/api/podgroup_info/job_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/job_info_test.go
@@ -279,6 +279,60 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 			),
 			expected: 2,
 		},
+		{
+			name: "job with multiple tasks, some gated",
+			job: NewPodGroupInfo("123",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}}),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "222",
+							Name:      "task2",
+							Namespace: "ns2",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodRunning,
+						}}),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "333",
+							Name:      "task3",
+							Namespace: "ns3",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodFailed,
+						}}),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "444",
+							Name:      "task4",
+							Namespace: "ns4",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						},
+						Spec: v1.PodSpec{
+							SchedulingGates: []v1.PodSchedulingGate{
+								{
+									Name: "gated",
+								},
+							},
+						},
+					}),
+			),
+			expected: 2,
+		},
 	}
 
 	for _, test := range tests {
@@ -364,6 +418,50 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodFailed,
 						}}),
+			),
+			expected: 1,
+		},
+		{
+			name: "job with multiple tasks, some gated",
+			job: NewPodGroupInfo("123",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}}),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "222",
+							Name:      "task2",
+							Namespace: "ns2",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodRunning,
+						}}),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "333",
+							Name:      "task3",
+							Namespace: "ns3",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodFailed,
+						},
+						Spec: v1.PodSpec{
+							SchedulingGates: []v1.PodSchedulingGate{
+								{
+									Name: "gated",
+								},
+							},
+						},
+					}),
 			),
 			expected: 1,
 		},

--- a/pkg/scheduler/api/podgroup_info/job_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/job_info_test.go
@@ -331,7 +331,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 					}),
 			),
-			expected: 2,
+			expected: 3,
 		},
 	}
 
@@ -339,6 +339,177 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 		result := test.job.GetNumAliveTasks()
 		if test.expected != result {
 			t.Errorf("GetNumAliveTasks failed. test '%s'. expected: %v, actual: %v",
+				test.name, test.expected, result)
+		}
+	}
+}
+
+func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
+	tests := []struct {
+		name         string
+		job          *PodGroupInfo
+		minAvailable int32
+		expected     bool
+	}{
+		{
+			name: "job with pending task",
+			job: NewPodGroupInfo("test-pg",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}})),
+			minAvailable: 1,
+			expected:     true,
+		},
+		{
+			name: "job with gated task",
+			job: NewPodGroupInfo("test-pg",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						},
+						Spec: v1.PodSpec{
+							SchedulingGates: []v1.PodSchedulingGate{
+								{
+									Name: "gated",
+								},
+							},
+						},
+					},
+				),
+			),
+			minAvailable: 1,
+			expected:     false,
+		},
+		{
+			name: "job with pending task, minAvailable 2",
+			job: NewPodGroupInfo("test-pg",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}})),
+			minAvailable: 2,
+			expected:     false,
+		},
+		{
+			name: "job with pending & gated tasks",
+			job: NewPodGroupInfo("test-pg",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}},
+				),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "222",
+							Name:      "task2",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}},
+				),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "333",
+							Name:      "task3",
+							Namespace: "ns1",
+						},
+						Spec: v1.PodSpec{
+							SchedulingGates: []v1.PodSchedulingGate{
+								{
+									Name: "gated",
+								},
+							},
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}},
+				),
+			),
+			minAvailable: 2,
+			expected:     true,
+		},
+		{
+			name: "job with pending & gated tasks",
+			job: NewPodGroupInfo("test-pg",
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "111",
+							Name:      "task1",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}},
+				),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "222",
+							Name:      "task2",
+							Namespace: "ns1",
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}},
+				),
+				pod_info.NewTaskInfo(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "333",
+							Name:      "task3",
+							Namespace: "ns1",
+						},
+						Spec: v1.PodSpec{
+							SchedulingGates: []v1.PodSchedulingGate{
+								{
+									Name: "gated",
+								},
+							},
+						},
+						Status: v1.PodStatus{
+							Phase: v1.PodPending,
+						}},
+				),
+			),
+			minAvailable: 3,
+			expected:     false,
+		},
+	}
+
+	for _, test := range tests {
+		test.job.MinAvailable = test.minAvailable
+		result := test.job.IsReadyForScheduling()
+		if result != test.expected {
+			t.Errorf("IsReadyForScheduling failed. test '%s'. expected: %v, actual: %v",
 				test.name, test.expected, result)
 		}
 	}

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -156,10 +156,6 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 		su.recordStaleJobEvent(job)
 	}
 
-	if job.GetNumPendingTasks() == 0 {
-		return nil
-	}
-
 	if !job.IsReadyForScheduling() {
 		su.recordJobNotReadyEvent(job)
 		return nil
@@ -214,8 +210,8 @@ func (su *defaultStatusUpdater) recordStaleJobEvent(job *podgroup_info.PodGroupI
 
 func (su *defaultStatusUpdater) recordJobNotReadyEvent(job *podgroup_info.PodGroupInfo) {
 	su.recorder.Eventf(job.PodGroup, v1.EventTypeNormal, "NotReady",
-		fmt.Sprintf("Job is not ready for scheduling. Waiting for %d pods, currently %d existing",
-			job.MinAvailable, job.GetNumAliveTasks()))
+		fmt.Sprintf("Job is not ready for scheduling. Waiting for %d pods, currently %d exist, %d are gated",
+			job.MinAvailable, job.GetNumAliveTasks(), job.GetNumGatedTasks()))
 }
 
 func (su *defaultStatusUpdater) markPodGroupUnschedulable(job *podgroup_info.PodGroupInfo, message string) bool {

--- a/test/e2e/modules/resources/rd/pod_group/pod_group.go
+++ b/test/e2e/modules/resources/rd/pod_group/pod_group.go
@@ -83,7 +83,7 @@ func IsNotReadyForScheduling(event *v1.Event) bool {
 		return false
 	}
 	match, err := regexp.MatchString(
-		"Job is not ready for scheduling. Waiting for \\d pods, currently \\d existing",
+		"Job is not ready for scheduling. Waiting for \\d pods, currently \\d exist, \\d are gated",
 		event.Message)
 	Expect(err).To(Succeed())
 	return match


### PR DESCRIPTION
See https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/ & #63 

We want to respect k8s pod scheduling gates, which are used to delay pending pods from being considered for scheduling until other conditions in the cluster are met.

For podgroups, gated pods will not count towards "minMember". So, for example, a podgroup with minMember=4, 4 pending pods, with one of them being gated - will be considered not ready for scheduling. However, if the podgroup has enough ungated pods to satisfy minMember - it will schedule those pods. Additional pods will get scheduled as they become ungated.