### PR TITLE
scheduler: bugfix: Make pod_scenario_builder build scenarios for rest of elastic job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Queue order function now takes into account potential victims, resulting in better reclaim scenarios.
+
+### Fixes
+- Fixed preempt/reclaim of elastic workloads only taking one pod.

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -77,6 +77,16 @@ func (asb *PodAccumulatedScenarioBuilder) GetNextScenario() *solverscenario.ByNo
 	// Jump over recorded victims in potential victims generation
 	for _, potentialVictimTask := range potentialVictimTasks {
 		if _, ok := asb.recordedVictimsTasks[potentialVictimTask.UID]; ok {
+			var remainingTasks []*pod_info.PodInfo
+			for _, task := range nextVictimJob.PodInfos {
+				if _, ok := asb.recordedVictimsTasks[task.UID]; !ok {
+					remainingTasks = append(remainingTasks, task)
+				}
+			}
+			if len(remainingTasks) != 0 {
+				jobToPush := nextVictimJob.CloneWithTasks(remainingTasks)
+				asb.victimsJobsQueue.PushJob(jobToPush)
+			}
 			return asb.GetNextScenario()
 		}
 	}

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -77,6 +77,9 @@ func (asb *PodAccumulatedScenarioBuilder) GetNextScenario() *solverscenario.ByNo
 	// Jump over recorded victims in potential victims generation
 	for _, potentialVictimTask := range potentialVictimTasks {
 		if _, ok := asb.recordedVictimsTasks[potentialVictimTask.UID]; ok {
+			// If any of the tasks of the victim job are recorded victims
+			// we still want to evaluate the job again if there are tasks
+			// that are not recorded victims yet, like elastic jobs
 			var remainingTasks []*pod_info.PodInfo
 			for _, task := range nextVictimJob.PodInfos {
 				if _, ok := asb.recordedVictimsTasks[task.UID]; !ok {

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
@@ -175,7 +175,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 				Expect(len(sn.PotentialVictimsTasks())).To(Equal(potentialVictimsPerScenario[numberOfGeneratedScenarios]))
 				numberOfGeneratedScenarios += 1
 			}
-
+			Expect(numberOfGeneratedScenarios).To(Equal(len(potentialVictimsPerScenario)))
 		})
 	})
 
@@ -260,6 +260,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 				Expect(len(sn.PotentialVictimsTasks())).To(Equal(potentialVictimsPerScenario[numberOfGeneratedScenarios]))
 				numberOfGeneratedScenarios += 1
 			}
+			Expect(numberOfGeneratedScenarios).To(Equal(len(potentialVictimsPerScenario)))
 		})
 	})
 })

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
@@ -109,7 +109,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 	})
 
 	Context("with recorded victims", func() {
-		It("All scenarios have the same recorded victims", func() {
+		It("returns scenarios that have the same recorded victims", func() {
 			ssn, _ = initializeSession(3, 2)
 			for _, podGroupInfo := range ssn.PodGroupInfos {
 				podGroupInfo.MinAvailable = int32(len(podGroupInfo.PodInfos))
@@ -143,7 +143,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 			Expect(numberOfGeneratedScenarios).To(Equal(2))
 		})
 
-		It("Returned scenarios have correct number of potential victims", func() {
+		It("returns scenarios that have correct number of potential victims", func() {
 			ssn, _ = initializeSession(3, 2)
 			for _, podGroupInfo := range ssn.PodGroupInfos {
 				podGroupInfo.MinAvailable = int32(len(podGroupInfo.PodInfos))
@@ -180,7 +180,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 	})
 
 	Context("with recorded victims that are elastic", func() {
-		It("All scenarios have the same recorded victims", func() {
+		It("returns scenarios that have the same recorded victims", func() {
 			// run 1 job with 3 tasks, set minAvailable to 1 for elastic
 			ssn, _ = initializeSession(1, 3)
 			minAvailable := 1
@@ -221,7 +221,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 			Expect(numberOfGeneratedScenarios).To(Equal(3))
 		})
 
-		It("Returned scenarios have correct number of potential victims", func() {
+		It("returns scenarios that have correct number of potential victims", func() {
 			// run 1 job with 4 tasks, set minAvailable to 2 for elastic
 			ssn, _ = initializeSession(1, 4)
 			minAvailable := 2

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
@@ -136,7 +136,6 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 
 			numberOfGeneratedScenarios := 0
 			for sn := scenarioBuilder.GetCurrentScenario(); sn != nil; sn = scenarioBuilder.GetNextScenario() {
-				fmt.Printf("scenario: %v\n", sn)
 				Expect(len(sn.RecordedVictimsJobs())).To(Equal(len(recordedVictimsJobs)))
 				numberOfGeneratedScenarios += 1
 			}
@@ -161,7 +160,7 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 			var recordedVictimsJobs []*podgroup_info.PodGroupInfo
 
 			podGroupIndex := 0
-			// Only the first pod group with the last task is recordedVictim from first run
+			// Only the first pod group with the last task is recordedVictimJobs
 			for _, podGroupInfo := range ssn.PodGroupInfos {
 				if podGroupIndex == 0 {
 					podIndex := 0
@@ -184,7 +183,6 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 
 			numberOfGeneratedScenarios := 0
 			for sn := scenarioBuilder.GetCurrentScenario(); sn != nil; sn = scenarioBuilder.GetNextScenario() {
-				fmt.Printf("scenario: %v\n", sn)
 				Expect(len(sn.RecordedVictimsJobs())).To(Equal(len(recordedVictimsJobs)))
 				numberOfGeneratedScenarios += 1
 			}

--- a/test/e2e/suites/reclaim/reclaim_elastic_test.go
+++ b/test/e2e/suites/reclaim/reclaim_elastic_test.go
@@ -186,4 +186,45 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 			return len(pods.Items) == 0
 		})
 	})
+
+	It("Reclaim elastic job partially for a distributed job", func(ctx context.Context) {
+		testCtx = testcontext.GetConnectivity(ctx, Default)
+		parentQueue, reclaimeeQueue, reclaimerQueue = createQueues(3, 1, 2)
+		reclaimeeQueue.Spec.Resources.GPU.OverQuotaWeight = 0
+		testCtx.InitQueues([]*v2.Queue{parentQueue, reclaimeeQueue, reclaimerQueue})
+		reclaimeeNamespace = queue.GetConnectedNamespaceToQueue(reclaimeeQueue)
+
+		// reclaimee job
+		reclaimeePodRequirements := v1.ResourceRequirements{
+			Limits: map[v1.ResourceName]resource.Quantity{
+				constants.GpuResource: resource.MustParse("1"),
+			},
+		}
+		reclaimeePodGroup, reclaimeePods := pod_group.CreateWithPods(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
+			"elastic-reclaimee-job", reclaimeeQueue, 3, nil,
+			reclaimeePodRequirements)
+		wait.ForPodsScheduled(ctx, testCtx.ControllerClient, reclaimeeNamespace, reclaimeePods)
+
+		// reclaimer job
+		reclaimerPodRequirements := v1.ResourceRequirements{
+			Limits: map[v1.ResourceName]resource.Quantity{
+				constants.GpuResource: resource.MustParse("1"),
+			},
+		}
+		_, reclaimerPods := pod_group.CreateDistributedJob(
+			ctx, testCtx.KubeClientset, testCtx.ControllerClient,
+			reclaimerQueue, 2, reclaimerPodRequirements, "",
+		)
+		reclaimerNamespace := queue.GetConnectedNamespaceToQueue(reclaimerQueue)
+		wait.ForPodsScheduled(ctx, testCtx.ControllerClient, reclaimerNamespace, reclaimerPods)
+
+		// verify results
+		wait.ForPodsWithCondition(ctx, testCtx.ControllerClient, func(watch.Event) bool {
+			pods, err := testCtx.KubeClientset.CoreV1().Pods(reclaimeeNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", podGroupLabelName, reclaimeePodGroup.Name),
+			})
+			Expect(err).To(Succeed())
+			return len(pods.Items) == 0
+		})
+	})
 })

--- a/test/e2e/suites/reclaim/reclaim_elastic_test.go
+++ b/test/e2e/suites/reclaim/reclaim_elastic_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 				LabelSelector: fmt.Sprintf("%s=%s", podGroupLabelName, reclaimeePodGroup.Name),
 			})
 			Expect(err).To(Succeed())
-			return len(pods.Items) == 0
+			return len(pods.Items) == 1
 		})
 	})
 })


### PR DESCRIPTION
While going through the solvers, @bugra-gedik-nv noticed a potential bug in pod_scenario_builder, where we jump to the next scenario if any of the potentialVictimTasks are already in recordedVictimTasks.
https://github.com/NVIDIA/KAI-Scheduler/blob/main/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go#L77-L82

When an elastic job is the victim, `GetTasksToEvict` will only return the last task from reverse TaskOrderFn of a victim until the job has equal or less than `MinAvailable` tasks to consider for scenario (the `jobHasMoreTasks = false` situation).

https://github.com/NVIDIA/KAI-Scheduler/blob/main/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go#L71-L82

When you have a reclaimer/preemptor with at least 2 tasks to schedule and no free nodes, we would successfully solve for the first task in job_solver.go by calling `solvePartialJob`, and `recordedVictimJobs` is now populated with an elastic job representation with 1 task. But when solving for 2 tasks in the next iteration of `solvePartialJob`,  the first call to `GetNextScenario()` with `recordedVictimJobs` populated  with the elastic job representation with 1 pod would match the first pod in `potentialVictimTasks` from `GetTasksToEvict()` and directly call  `GetNextScenario()` internally. 
However, because we already popped the full elastic job off `victimsJobsQueue`, the next scenario will no longer evaluate any of the other pods in that elastic job and move on to another job in the victim queue.

In the scenario where the elastic job is the only victim, no further scenario is presented and solver would consider the scenario unsolvable even though the elastic job victim could give up more tasks.

More generalized: it would mean elastic jobs can currently only have 1 pod preempted each scheduling loop.

The proposed solution is when a victimJob popped of the queue has any task that is already part of reportedVictims, we construct a job representative with all remaining tasks that are not reportedVictims, and if the number of remainingTasks is non-zero we push that job back onto the victimQueue before calling GetNextScenario.