### PR TITLE
refactor(scheduler): patch pod labels concurrently

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -8,17 +8,16 @@ import (
 	"testing"
 
 	. "go.uber.org/mock/gomock"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions/allocate"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions/integration_tests/integration_tests_utils"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/constants"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/k8s_utils"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
@@ -1787,18 +1786,16 @@ func TestHandleElasticJobCommitFailure(t *testing.T) {
 		},
 		controller,
 	)
-	k8s_utils.Helpers = &failingK8sUtils{k8s_utils.Helpers}
+	ssn.Cache = &failingBindCache{Cache: ssn.Cache}
 
 	allocateAction := allocate.New()
 	allocateAction.Execute(ssn)
 }
 
-type failingK8sUtils struct {
-	k8s_utils.Interface
+type failingBindCache struct {
+	cache.Cache
 }
 
-func (f *failingK8sUtils) PatchPodAnnotationsAndLabelsInterface(
-	_ kubernetes.Interface, _ *v1.Pod, _, _ map[string]interface{},
-) error {
+func (f *failingBindCache) Bind(podInfo *pod_info.PodInfo, hostname string) error {
 	return fmt.Errorf("create pod error")
 }

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -224,8 +224,19 @@ func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string) erro
 	startTime := time.Now()
 	defer metrics.UpdateTaskBindDuration(startTime)
 
-	err := sc.createBindRequest(taskInfo, hostname)
-	return sc.StatusUpdater.Bound(taskInfo.Pod, hostname, err, sc.getNodPoolName())
+	log.InfraLogger.V(3).Infof(
+		"Creating bind request for task <%v/%v> to node <%v> gpuGroup: <%v>, requires: <%v> GPUs",
+		taskInfo.Namespace, taskInfo.Name, hostname, taskInfo.GPUGroups, taskInfo.ResReq)
+	bindRequestError := sc.createBindRequest(taskInfo, hostname)
+
+	if bindRequestError == nil {
+		labelsPatch := sc.nodePoolLabelsChange(taskInfo.Pod.Labels)
+		if len(labelsPatch) > 0 {
+			sc.StatusUpdater.PatchPodLabels(taskInfo.Pod, labelsPatch)
+		}
+	}
+
+	return sc.StatusUpdater.Bound(taskInfo.Pod, hostname, bindRequestError, sc.getNodPoolName())
 }
 
 // +kubebuilder:rbac:groups="scheduling.run.ai",resources=bindrequests,verbs=create;update;patch
@@ -274,6 +285,18 @@ func (sc *SchedulerCache) getNodPoolName() string {
 		return sc.schedulingNodePoolParams.NodePoolLabelValue
 	}
 	return "default"
+}
+
+func (sc *SchedulerCache) nodePoolLabelsChange(currentLabels map[string]string) map[string]any {
+	labels := map[string]any{}
+	if sc.schedulingNodePoolParams.NodePoolLabelKey == "" {
+		return labels
+	}
+	if value, found := currentLabels[sc.schedulingNodePoolParams.NodePoolLabelKey]; found && value == sc.schedulingNodePoolParams.NodePoolLabelValue {
+		return labels
+	}
+	labels[sc.schedulingNodePoolParams.NodePoolLabelKey] = sc.schedulingNodePoolParams.NodePoolLabelValue
+	return labels
 }
 
 func (sc *SchedulerCache) String() string {

--- a/pkg/scheduler/cache/status_updater/interface.go
+++ b/pkg/scheduler/cache/status_updater/interface.go
@@ -20,6 +20,7 @@ type Interface interface {
 	Evicted(evictedPodGroup *enginev2alpha2.PodGroup, evictionMetadata eviction_info.EvictionMetadata, message string)
 	Bound(pod *v1.Pod, hostname string, bindError error, nodePoolName string) error
 	Pipelined(pod *v1.Pod, message string)
+	PatchPodLabels(pod *v1.Pod, labels map[string]interface{})
 	RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error
 
 	Run(stopCh <-chan struct{})


### PR DESCRIPTION
To support clusters with very large scale we want to move the patching of the pod node pool labels to happen concurrently in the background instead of blocking the scheduler loop.