### PR TITLE
Remove requirement for Worker when using PyTorchJob

### DIFF
--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	ReplicaSpecName = "pytorchReplicaSpecs"
-	WorkerName      = "Worker"
 )
 
 type PyTorchGrouper struct {
@@ -36,7 +35,7 @@ func (ptg *PyTorchGrouper) Name() string {
 func (ptg *PyTorchGrouper) GetPodGroupMetadata(
 	topOwner *unstructured.Unstructured, pod *v1.Pod, _ ...*metav1.PartialObjectMetadata,
 ) (*podgroup.Metadata, error) {
-	podGroupMetadata, err := ptg.KubeflowDistributedGrouper.GetPodGroupMetadata(topOwner, pod, ReplicaSpecName, []string{WorkerName})
+	podGroupMetadata, err := ptg.KubeflowDistributedGrouper.GetPodGroupMetadata(topOwner, pod, ReplicaSpecName, []string{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, if I launch a PyTorchJob with just a "Master" pod, it will fail as a "Worker" pod is a requirement. It should not be a requirement.

It is also possible to launch just "Worker" pods without a "Master" pod (see [this flag](https://docs.run.ai/v2.19/Researcher/cli-reference/runai-submit-dist-pytorch/#-no-master) as an example).

Ultimately I am removing the requirement to have a "Worker" pod: there will be no requirement to have either a "Master" or "Worker" pod.