### PR TITLE
minruntime Plugin

### DIFF
--- a/deployments/kai-scheduler/templates/services/scheduler-configmap.yaml
+++ b/deployments/kai-scheduler/templates/services/scheduler-configmap.yaml
@@ -25,6 +25,7 @@ data:
             arguments:
               cpu: {{ .Values.scheduler.placementStrategy }}
               gpu: {{ .Values.scheduler.placementStrategy }}
+          - name: minruntime
 kind: ConfigMap
 metadata:
   labels:

--- a/docs/plugins/minruntime.md
+++ b/docs/plugins/minruntime.md
@@ -1,0 +1,121 @@
+# MinRuntime Plugin
+
+## Overview
+
+The MinRuntime plugin for KAI-Scheduler provides runtime protection for jobs by preventing preemption or resource reclamation of jobs until they have run for a specified minimum time duration. This ensures workloads can complete critical initialization or checkpointing before being interrupted.
+
+## Key Features
+
+- **Preemption Protection**: Prevents jobs from being preempted until they have run for a specified minimum duration
+- **Reclamation Protection**: Prevents elastic jobs from having resources reclaimed until they have run for a specified minimum duration
+- **Queue-based Configuration**: Configure different minimum runtime durations for different queues in your scheduling hierarchy
+- **Hierarchical Inheritance**: Minimum runtime settings cascade down from parent queues to leaf queues
+- **Flexible Resolution Methods**: Two methods for reclaim minimum runtime resolution:
+  - Queue-based: Evaluates the min-runtime protection based on the victim's queue configuration
+  - LCA (Lowest Common Ancestor): Uses the common ancestor of reclaimer and victim queues to determine min-runtime protection
+
+## Usage
+
+The minruntime plugin is configured in two ways:
+
+1. **Queue Definition**: Set minimum runtime values in Queue configurations
+2. **Plugin Arguments**: Configure default values and resolution methods in the scheduler configuration
+
+### Queue Configuration
+
+Queues can specify the following minimum runtime parameters:
+
+- `preemptMinRuntime`: Minimum runtime before a job in this queue can be preempted
+- `reclaimMinRuntime`: Minimum runtime before a job in this queue can have resources reclaimed
+
+Example Queue definition:
+
+```yaml
+apiVersion: scheduling.run.ai/v2
+kind: Queue
+metadata:
+  name: production
+spec:
+  preemptMinRuntime: "20s"
+  reclaimMinRuntime: "30s"
+```
+
+### Plugin Configuration
+
+In the scheduler configuration (`scheduler-config` ConfigMap), add the minruntime plugin with its arguments:
+
+```yaml
+tiers:
+- plugins:
+  # other plugins...
+  - name: minruntime
+    arguments:
+      defaultPreemptMinRuntime: "10m"
+      defaultReclaimMinRuntime: "10m"
+      reclaimResolveMethod: "lca"  # or "queue"
+```
+
+### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `defaultPreemptMinRuntime` | Default minimum runtime before preemption if not specified in queue | "0s" |
+| `defaultReclaimMinRuntime` | Default minimum runtime before resource reclamation if not specified in queue | "0s" |
+| `reclaimResolveMethod` | Method to resolve reclaim minimum runtime ("lca" or "queue") | "lca" |
+
+0s means workloads are instantly reclaimable/preemptible.
+
+## Resolution Methods
+
+### Preemption Resolution
+
+For preemption, the minimum runtime is determined by starting from the victim's queue and walking up the queue hierarchy until a `preemptMinRuntime` value is found.
+
+### Reclamation Resolution
+
+For reclamation, two methods are supported:
+
+1. **Queue-based Resolution** (`reclaimResolveMethod: "queue"`):
+   - Similar to preemption, looks at the victim's queue and walks up the hierarchy until a `reclaimMinRuntime` value is found.
+   - If no value is found at all, use the default value for the plugin.
+
+2. **LCA Resolution** (`reclaimResolveMethod: "lca"`):
+   - Identifies the Lowest Common Ancestor (LCA) in the queue hierarchy between the preemptor and victim
+   - Walks one step down from the LCA towards the victim and uses that queue's `reclaimMinRuntime` value
+   - If no value is found, moves up towards the root queue until one is found.
+   - If no value is found at all, use the default value for the plugin.
+
+The LCA method is the default method if none is specified. The purpose of the LCA method is to follow how policies might be set for queue hierarchy, allowing users in sub-queues to set min-runtime values that are honored by their siblings, whilst not affecting cousin queues.
+
+## Elastic Jobs Handling
+
+For elastic jobs (where `MinAvailable < len(PodInfos)`), the plugin:
+
+1. Allows the job to be considered for preemption/reclamation in the filter phase
+2. Validates in the scenario validator phase that the job will maintain its minimum number of pods if min-runtime has not been reached.
+
+## Implementation Details
+
+The plugin implements the following functions:
+
+- `preemptFilterFn`: Filters victims that shouldn't be preempted due to minimum runtime
+- `reclaimFilterFn`: Filters victims that shouldn't have resources reclaimed due to minimum runtime
+- `preemptScenarioValidatorFn`: Validates preemption scenarios for elastic jobs
+- `reclaimScenarioValidatorFn`: Validates reclamation scenarios for elastic jobs
+
+## Example Workflow
+
+1. A job starts running in a queue with `reclaimMinRuntime: "30s"`
+2. At 20 seconds of runtime, another job attempts to reclaim resources
+3. The minruntime plugin identifies that the minimum runtime has not been reached
+4. The victim job is protected from reclamation until it runs for at least 30 seconds
+
+## Caching
+
+The plugin maintains caches to improve performance:
+- `preemptMinRuntimeCache`: Caches preemption minimum runtime values by queue
+- `reclaimMinRuntimeCache`: Caches reclamation minimum runtime values by queue pair
+- `preemptProtectionCache`: Tracks jobs protected from preemption
+- `reclaimProtectionCache`: Tracks jobs protected from reclamation
+
+These caches are reset at the beginning of each scheduling session.

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -12,7 +12,6 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/reclaimer_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/metrics"
@@ -48,9 +47,7 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 
 	for !jobsOrderByQueues.IsEmpty() {
 		job := jobsOrderByQueues.PopNextJob()
-
-		reclaimerInfo := buildReclaimerInfo(ssn, job)
-		if !ssn.CanReclaimResources(reclaimerInfo) {
+		if !ssn.CanReclaimResources(job) {
 			continue
 		}
 
@@ -69,7 +66,7 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 			}
 		}
 		metrics.IncPodgroupsConsideredByAction()
-		succeeded, statement, reclaimeeTasksNames := ra.attemptToReclaimForSpecificJob(ssn, job, reclaimerInfo)
+		succeeded, statement, reclaimeeTasksNames := ra.attemptToReclaimForSpecificJob(ssn, job)
 		if succeeded {
 			metrics.IncPodgroupScheduledByAction()
 			log.InfraLogger.V(3).Infof(
@@ -88,7 +85,7 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 }
 
 func (ra *reclaimAction) attemptToReclaimForSpecificJob(
-	ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo, reclaimerInfo *reclaimer_info.ReclaimerInfo,
+	ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo,
 ) (bool, *framework.Statement, []string) {
 	queue := ssn.Queues[reclaimer.Queue]
 	resReq := podgroup_info.GetTasksToAllocateInitResource(reclaimer, ssn.TaskOrderFn, false)
@@ -100,30 +97,19 @@ func (ra *reclaimAction) attemptToReclaimForSpecificJob(
 	feasibleNodes := common.FeasibleNodesForJob(maps.Values(ssn.Nodes), reclaimer)
 	solver := solvers.NewJobsSolver(
 		feasibleNodes,
-		reclaimableScenarioCheck(ssn, reclaimerInfo),
+		reclaimableScenarioCheck(ssn, reclaimer),
 		getOrderedVictimsQueue(ssn, reclaimer),
 		framework.Reclaim)
 	return solver.Solve(ssn, reclaimer)
 }
 
 func reclaimableScenarioCheck(ssn *framework.Session,
-	reclaimerInfo *reclaimer_info.ReclaimerInfo) solvers.SolutionValidator {
+	reclaimer *podgroup_info.PodGroupInfo) solvers.SolutionValidator {
 	return func(
 		_ *podgroup_info.PodGroupInfo,
 		victimJobs []*podgroup_info.PodGroupInfo,
 		victimTasks []*pod_info.PodInfo) bool {
-		return ssn.ReclaimScenarioValidator(reclaimerInfo, victimJobs, victimTasks)
-	}
-}
-
-func buildReclaimerInfo(ssn *framework.Session, reclaimerJob *podgroup_info.PodGroupInfo) *reclaimer_info.ReclaimerInfo {
-	return &reclaimer_info.ReclaimerInfo{
-		Name:          reclaimerJob.Name,
-		Namespace:     reclaimerJob.Namespace,
-		Queue:         reclaimerJob.Queue,
-		IsPreemptable: reclaimerJob.IsPreemptibleJob(ssn.IsInferencePreemptible()),
-		RequiredResources: podgroup_info.GetTasksToAllocateInitResource(
-			reclaimerJob, ssn.TaskOrderFn, false),
+		return ssn.ReclaimScenarioValidator(reclaimer, victimJobs, victimTasks)
 	}
 }
 

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/reclaimer_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
@@ -20,16 +19,13 @@ type PredicateFn func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo, *node_info
 type PrePredicateFn func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo) error
 
 // CanReclaimResourcesFn is a function that determines if a reclaimer can get more resources
-type CanReclaimResourcesFn func(reclaimerInfo *reclaimer_info.ReclaimerInfo) bool
+type CanReclaimResourcesFn func(pendingJob *podgroup_info.PodGroupInfo) bool
 
-// VictimFilterFn is a function which filters out jobs that cannot a victim candidate for a specific reclaimer.
+// VictimFilterFn is a function which filters out jobs that cannot a victim candidate for a specific reclaimer/preemptor.
 type VictimFilterFn func(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool
 
-// ScenarioValidatorFn is a function which determines the validity of a reclaim scenario.
-type ScenarioValidatorFn func(reclaimerInfo *reclaimer_info.ReclaimerInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool
-
-// PreemptScenarioValidatorFn is a function which determines the validity of a preempt scenario.
-type PreemptScenarioValidatorFn func(preemptor *podgroup_info.PodGroupInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool
+// ScenarioValidatorFn is a function which determines the validity of a scenario.
+type ScenarioValidatorFn func(pendingJob *podgroup_info.PodGroupInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool
 
 // QueueResource is a function which returns the resource of a queue.
 type QueueResource func(*queue_info.QueueInfo) *resource_info.ResourceRequirements

--- a/pkg/scheduler/conf_util/scheduler_conf_util.go
+++ b/pkg/scheduler/conf_util/scheduler_conf_util.go
@@ -38,6 +38,7 @@ tiers:
     arguments:
       cpu: binpack
       gpu: binpack
+  - name: minruntime
 `
 
 func ResolveConfigurationFromFile(confPath string) (*conf.SchedulerConfiguration, error) {

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -50,8 +50,8 @@ type Session struct {
 	CanReclaimResourcesFns                []api.CanReclaimResourcesFn
 	ReclaimVictimFilterFns                []api.VictimFilterFn
 	PreemptVictimFilterFns                []api.VictimFilterFn
-	ReclaimScenarioValidators             []api.ScenarioValidatorFn
-	PreemptScenarioValidators             []api.PreemptScenarioValidatorFn
+	ReclaimScenarioValidatorFns           []api.ScenarioValidatorFn
+	PreemptScenarioValidatorFns           []api.ScenarioValidatorFn
 	OnJobSolutionStartFns                 []api.OnJobSolutionStartFn
 	GetQueueAllocatedResourcesFns         []api.QueueResource
 	GetQueueDeservedResourcesFns          []api.QueueResource

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -12,7 +12,6 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/reclaimer_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
 )
@@ -68,14 +67,18 @@ func (ssn *Session) AddCanReclaimResourcesFn(crf api.CanReclaimResourcesFn) {
 }
 
 func (ssn *Session) AddReclaimScenarioValidatorFn(rf api.ScenarioValidatorFn) {
-	ssn.ReclaimScenarioValidators = append(ssn.ReclaimScenarioValidators, rf)
+	ssn.ReclaimScenarioValidatorFns = append(ssn.ReclaimScenarioValidatorFns, rf)
 }
 
-func (ssn *Session) AddReclaimeeFilterFn(rf api.VictimFilterFn) {
+func (ssn *Session) AddPreemptScenarioValidatorFn(rf api.ScenarioValidatorFn) {
+	ssn.PreemptScenarioValidatorFns = append(ssn.PreemptScenarioValidatorFns, rf)
+}
+
+func (ssn *Session) AddReclaimVictimFilterFn(rf api.VictimFilterFn) {
 	ssn.ReclaimVictimFilterFns = append(ssn.ReclaimVictimFilterFns, rf)
 }
 
-func (ssn *Session) CanReclaimResources(reclaimer *reclaimer_info.ReclaimerInfo) bool {
+func (ssn *Session) CanReclaimResources(reclaimer *podgroup_info.PodGroupInfo) bool {
 	for _, canReclaimFn := range ssn.CanReclaimResourcesFns {
 		return canReclaimFn(reclaimer)
 	}
@@ -94,11 +97,11 @@ func (ssn *Session) ReclaimVictimFilter(reclaimer *podgroup_info.PodGroupInfo, v
 }
 
 func (ssn *Session) ReclaimScenarioValidator(
-	reclaimer *reclaimer_info.ReclaimerInfo,
+	reclaimer *podgroup_info.PodGroupInfo,
 	reclaimees []*podgroup_info.PodGroupInfo,
 	victimsTasks []*pod_info.PodInfo,
 ) bool {
-	for _, rf := range ssn.ReclaimScenarioValidators {
+	for _, rf := range ssn.ReclaimScenarioValidatorFns {
 		if !rf(reclaimer, reclaimees, victimsTasks) {
 			return false
 		}
@@ -122,7 +125,7 @@ func (ssn *Session) PreemptScenarioValidator(
 	victimJobs []*podgroup_info.PodGroupInfo,
 	victimTasks []*pod_info.PodInfo,
 ) bool {
-	for _, pf := range ssn.PreemptScenarioValidators {
+	for _, pf := range ssn.PreemptScenarioValidatorFns {
 		if !pf(preemptor, victimJobs, victimTasks) {
 			return false
 		}

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/gpusharingorder"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/gpuspread"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/kubeflow"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/minruntime"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/nodeavailability"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/nodeplacement"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/nominatednode"
@@ -44,6 +45,7 @@ func InitDefaultPlugins() {
 
 	// Plugins for Queues
 	framework.RegisterPluginBuilder("proportion", proportion.New)
+	framework.RegisterPluginBuilder("minruntime", minruntime.New)
 
 	// Other Plugins
 	framework.RegisterPluginBuilder("snapshot", snapshot.New)

--- a/pkg/scheduler/plugins/minruntime/minruntime.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime.go
@@ -102,6 +102,7 @@ func (mr *minruntimePlugin) OnSessionClose(ssn *framework.Session) {
 func (mr *minruntimePlugin) reclaimFilterFn(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
 	protected := mr.isReclaimMinRuntimeProtected(pendingJob, victim)
 	// always return true for elastic jobs, but cache the result for scenario validator
+	log.InfraLogger.V(3).Infof("preemptFilterFn: pendingJob: %s, victim: %s, protected: %t", pendingJob.Name, victim.Name, protected)
 	if victim.MinAvailable < int32(len(victim.PodInfos)) {
 		return true
 	}
@@ -112,8 +113,8 @@ func (mr *minruntimePlugin) reclaimFilterFn(pendingJob *podgroup_info.PodGroupIn
 func (mr *minruntimePlugin) preemptFilterFn(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
 	protected := mr.isPreemptMinRuntimeProtected(pendingJob, victim)
 	// always return true for elastic jobs, but cache the result for scenario validator
+	log.InfraLogger.V(3).Infof("preemptFilterFn: pendingJob: %s, victim: %s, protected: %t", pendingJob.Name, victim.Name, protected)
 	if victim.MinAvailable < int32(len(victim.PodInfos)) {
-
 		return true
 	}
 	return !protected

--- a/pkg/scheduler/plugins/minruntime/minruntime.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
@@ -13,13 +15,22 @@ import (
 const (
 	defaultReclaimMinRuntimeConfig = "defaultReclaimMinRuntime"
 	defaultPreemptMinRuntimeConfig = "defaultPreemptMinRuntime"
-	actionTypeReclaim              = "reclaim"
-	actionTypePreempt              = "preempt"
+	reclaimResolveMethod           = "reclaimResolveMethod"
+	resolveMethodLCA               = "lca"
+	resolveMethodQueue             = "queue"
 )
 
 type minruntimePlugin struct {
 	defaultReclaimMinRuntime *metav1.Duration
 	defaultPreemptMinRuntime *metav1.Duration
+	reclaimResolveMethod     string
+	queues                   map[common_info.QueueID]*queue_info.QueueInfo
+
+	preemptMinRuntimeCache map[common_info.QueueID]metav1.Duration
+	reclaimMinRuntimeCache map[common_info.QueueID]map[common_info.QueueID]metav1.Duration
+
+	preemptProtectionCache map[common_info.PodGroupID]map[common_info.PodGroupID]bool
+	reclaimProtectionCache map[common_info.PodGroupID]map[common_info.PodGroupID]bool
 }
 
 func New(arguments map[string]string) framework.Plugin {
@@ -40,9 +51,11 @@ func New(arguments map[string]string) framework.Plugin {
 				duration = time.Duration(0 * time.Second)
 			}
 			plugin.defaultPreemptMinRuntime = &metav1.Duration{Duration: duration}
+		case reclaimResolveMethod:
+			plugin.reclaimResolveMethod = value
 		}
-	}
 
+	}
 	// Initialize with default values if not provided
 	if plugin.defaultReclaimMinRuntime == nil {
 		plugin.defaultReclaimMinRuntime = &metav1.Duration{Duration: time.Duration(0 * time.Second)}
@@ -50,7 +63,11 @@ func New(arguments map[string]string) framework.Plugin {
 	if plugin.defaultPreemptMinRuntime == nil {
 		plugin.defaultPreemptMinRuntime = &metav1.Duration{Duration: time.Duration(0 * time.Second)}
 	}
-
+	if plugin.reclaimResolveMethod == "" {
+		plugin.reclaimResolveMethod = resolveMethodLCA
+	}
+	plugin.preemptProtectionCache = make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool)
+	plugin.reclaimProtectionCache = make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool)
 	return plugin
 }
 
@@ -59,156 +76,153 @@ func (mr *minruntimePlugin) Name() string {
 }
 
 func (mr *minruntimePlugin) OnSessionOpen(ssn *framework.Session) {
-	// TODO: add IsPreemptibleFn
+	mr.queues = ssn.Queues
+	ssn.AddReclaimVictimFilterFn(mr.reclaimFilterFn)
+	ssn.AddPreemptVictimFilterFn(mr.preemptFilterFn)
+	ssn.AddReclaimScenarioValidatorFn(mr.reclaimScenarioValidatorFn)
+	ssn.AddPreemptScenarioValidatorFn(mr.preemptScenarioValidatorFn)
 }
 
 func (mr *minruntimePlugin) OnSessionClose(ssn *framework.Session) {
+	mr.queues = nil
+	mr.preemptProtectionCache = nil
+	mr.reclaimProtectionCache = nil
 }
 
-// GetMinRuntime resolves the applicable min-runtime for reclaims and preemptions
-// based on the provided action type and queues
-func (mr *minruntimePlugin) GetMinRuntime(
-	actionType string,
-	preemptorQueue *queue_info.QueueInfo,
-	preempteeQueue *queue_info.QueueInfo,
-	queues map[common_info.QueueID]*queue_info.QueueInfo,
-) *metav1.Duration {
-	// Handle preemptions (preemptor and preemptee are within the same leaf-queue)
-	if actionType == actionTypePreempt {
-		return mr.getPreemptMinRuntime(preempteeQueue, queues)
+func (mr *minruntimePlugin) reclaimFilterFn(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+	protected := mr.isReclaimMinRuntimeProtected(pendingJob, victim)
+	// always return true for elastic jobs, but cache the result for scenario validator
+	if victim.MinAvailable < int32(len(victim.PodInfos)) {
+		return true
 	}
 
-	// Handle reclaims (preemptor and preemptee are in different queues)
-	if actionType == actionTypeReclaim {
-		return mr.getReclaimMinRuntime(preemptorQueue, preempteeQueue, queues)
-	}
-
-	// If action type is unknown, return default reclaim min runtime
-	return mr.defaultReclaimMinRuntime
+	return !protected
 }
 
-// getPreemptMinRuntime resolves min-runtime for preemptions
-// Starting from the leaf-queue, walk the tree until the first defined preempt-min-runtime is set and use that
-func (mr *minruntimePlugin) getPreemptMinRuntime(
-	queue *queue_info.QueueInfo,
-	queues map[common_info.QueueID]*queue_info.QueueInfo,
-) *metav1.Duration {
-	// Start with the provided leaf queue
-	currentQueue := queue
+func (mr *minruntimePlugin) preemptFilterFn(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+	protected := mr.isPreemptMinRuntimeProtected(pendingJob, victim)
+	// always return true for elastic jobs, but cache the result for scenario validator
+	if victim.MinAvailable < int32(len(victim.PodInfos)) {
 
-	// Walk up the tree until we find a set preempt-min-runtime or reach the root
-	for currentQueue != nil {
-		if currentQueue.PreemptMinRuntime != nil {
-			return currentQueue.PreemptMinRuntime
-		}
-
-		// Move to parent queue if it exists
-		if currentQueue.ParentQueue != "" {
-			parentQueue, found := queues[currentQueue.ParentQueue]
-			if found {
-				currentQueue = parentQueue
-				continue
-			}
-		}
-
-		// Break if no more parent queues
-		break
+		return true
 	}
-
-	// If no preempt-min-runtime is set in the queue tree, use default
-	return mr.defaultPreemptMinRuntime
+	return !protected
 }
 
-// getReclaimMinRuntime resolves min-runtime for reclaims
-// 1. Resolve the lowest common ancestor (LCA) between the leaf-queues of preemptor and preemptee
-// 2. Walk 1 step down to the child of the LCA that is an ancestor to the preemptee's leaf queue (or is the leaf queue)
-// 3. Use the reclaim-min-runtime from this queue, if it is set. Otherwise move back up towards root of tree
-func (mr *minruntimePlugin) getReclaimMinRuntime(
-	preemptorQueue *queue_info.QueueInfo,
-	preempteeQueue *queue_info.QueueInfo,
-	queues map[common_info.QueueID]*queue_info.QueueInfo,
-) *metav1.Duration {
-	// Get hierarchy paths for both queues
-	preemptorPath := mr.getQueueHierarchyPath(preemptorQueue, queues)
-	preempteePath := mr.getQueueHierarchyPath(preempteeQueue, queues)
-
-	// Find the lowest common ancestor (LCA)
-	lcaIndex := 0
-	minLength := min(len(preemptorPath), len(preempteePath))
-
-	for i := 0; i < minLength; i++ {
-		if preemptorPath[i].UID != preempteePath[i].UID {
-			break
-		}
-		lcaIndex = i
-	}
-
-	// If we found a common ancestor
-	if lcaIndex < len(preemptorPath) && lcaIndex < len(preempteePath) &&
-		preemptorPath[lcaIndex].UID == preempteePath[lcaIndex].UID {
-		// If there's a path down from LCA to preemptee
-		if lcaIndex+1 < len(preempteePath) {
-			// Walk 1 step down to the child of the LCA that is an ancestor to the preemptee's leaf queue
-			childQueue := preempteePath[lcaIndex+1]
-
-			// Check if this queue has reclaim-min-runtime set
-			if childQueue.ReclaimMinRuntime != nil {
-				return childQueue.ReclaimMinRuntime
-			}
-
-			// Otherwise move back up towards root and select first available override
-			for i := lcaIndex; i >= 0; i-- {
-				if preempteePath[i].ReclaimMinRuntime != nil {
-					return preempteePath[i].ReclaimMinRuntime
-				}
-			}
-		} else {
-			// If LCA is the preemptee queue itself, check its reclaim-min-runtime
-			lca := preempteePath[lcaIndex]
-			if lca.ReclaimMinRuntime != nil {
-				return lca.ReclaimMinRuntime
-			}
-
-			// Otherwise move up towards root
-			for i := lcaIndex - 1; i >= 0; i-- {
-				if preempteePath[i].ReclaimMinRuntime != nil {
-					return preempteePath[i].ReclaimMinRuntime
-				}
+func (mr *minruntimePlugin) reclaimScenarioValidatorFn(reclaimer *podgroup_info.PodGroupInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool {
+	for _, victim := range victims {
+		protected := mr.isReclaimMinRuntimeProtected(reclaimer, victim)
+		if protected {
+			numVictimTasks := countVictimTasks(victim, tasks)
+			currentlyRunning := victim.GetActivelyRunningTasksCount()
+			if victim.MinAvailable > currentlyRunning-numVictimTasks {
+				return false
 			}
 		}
 	}
-
-	// If no reclaim-min-runtime is found in the hierarchy, use default
-	return mr.defaultReclaimMinRuntime
+	return true
 }
 
-// getQueueHierarchyPath returns the queue hierarchy from root to the specified queue
-func (mr *minruntimePlugin) getQueueHierarchyPath(
-	queue *queue_info.QueueInfo,
-	queues map[common_info.QueueID]*queue_info.QueueInfo,
-) []*queue_info.QueueInfo {
-	var hierarchyPath []*queue_info.QueueInfo
-
-	// Start with the queue itself
-	currentQueue := queue
-
-	// Build the path from queue to root
-	for currentQueue != nil {
-		// Add current queue to the path (at beginning to maintain root->leaf order)
-		hierarchyPath = append([]*queue_info.QueueInfo{currentQueue}, hierarchyPath...)
-
-		// If queue has a parent, add it to the path
-		if currentQueue.ParentQueue != "" {
-			parentQueue, found := queues[currentQueue.ParentQueue]
-			if found {
-				currentQueue = parentQueue
-				continue
+func (mr *minruntimePlugin) preemptScenarioValidatorFn(preemptor *podgroup_info.PodGroupInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool {
+	for _, victim := range victims {
+		protected := mr.isPreemptMinRuntimeProtected(preemptor, victim)
+		if protected {
+			numVictimTasks := countVictimTasks(victim, tasks)
+			currentlyRunning := victim.GetActivelyRunningTasksCount()
+			if victim.MinAvailable > currentlyRunning-numVictimTasks {
+				return false
 			}
 		}
+	}
+	return true
+}
 
-		// Break if no more parents (reached root)
-		break
+func (mr *minruntimePlugin) isReclaimMinRuntimeProtected(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+	if mr.reclaimProtectionCache[pendingJob.UID][victim.UID] {
+		return true
+	}
+	// Get the appropriate queue objects for both jobs
+	pendingQueue, foundPending := mr.getQueueForJob(pendingJob)
+	victimQueue, foundVictim := mr.getQueueForJob(victim)
+
+	// If we can't find the queues, use default min runtime
+	var minRuntime metav1.Duration
+	if !foundPending || !foundVictim {
+		minRuntime = *mr.defaultReclaimMinRuntime
+	} else {
+		minRuntime = mr.getReclaimMinRuntime(mr.reclaimResolveMethod, pendingQueue, victimQueue)
 	}
 
-	return hierarchyPath
+	// If the victim's last start time plus minimum runtime is greater than current time,
+	// the victim is protected from reclaim
+	if victim.LastStartTimestamp != nil && !victim.LastStartTimestamp.IsZero() {
+		protectedUntil := victim.LastStartTimestamp.Add(minRuntime.Duration)
+		if time.Now().Before(protectedUntil) {
+			mr.cacheReclaimProtection(pendingJob, victim)
+			return true
+		}
+	}
+	return false
+}
+
+func (mr *minruntimePlugin) isPreemptMinRuntimeProtected(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+	if mr.preemptProtectionCache[pendingJob.UID][victim.UID] {
+		return true
+	}
+
+	// Get the victim's queue
+	victimQueue, found := mr.getQueueForJob(victim)
+
+	// If we can't find the queue, use default min runtime
+	var minRuntime metav1.Duration
+	if !found {
+		minRuntime = *mr.defaultPreemptMinRuntime
+	} else {
+		minRuntime = mr.getPreemptMinRuntime(victimQueue)
+	}
+
+	// If the victim's last start time plus minimum runtime is greater than current time,
+	// the victim is protected from preemption
+	if victim.LastStartTimestamp != nil && !victim.LastStartTimestamp.IsZero() {
+		protectedUntil := victim.LastStartTimestamp.Add(minRuntime.Duration)
+		if time.Now().Before(protectedUntil) {
+			mr.cachePreemptProtection(pendingJob, victim)
+			return true
+		}
+	}
+
+	return false
+}
+
+func (mr *minruntimePlugin) cachePreemptProtection(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) {
+	if mr.preemptProtectionCache[pendingJob.UID] == nil {
+		mr.preemptProtectionCache[pendingJob.UID] = make(map[common_info.PodGroupID]bool)
+	}
+	mr.preemptProtectionCache[pendingJob.UID][victim.UID] = true
+}
+
+func (mr *minruntimePlugin) cacheReclaimProtection(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) {
+	if mr.reclaimProtectionCache[pendingJob.UID] == nil {
+		mr.reclaimProtectionCache[pendingJob.UID] = make(map[common_info.PodGroupID]bool)
+	}
+	mr.reclaimProtectionCache[pendingJob.UID][victim.UID] = true
+}
+
+func (mr *minruntimePlugin) getQueueForJob(job *podgroup_info.PodGroupInfo) (*queue_info.QueueInfo, bool) {
+	if mr.queues == nil {
+		return nil, false
+	}
+
+	queue, found := mr.queues[job.Queue]
+	return queue, found
+}
+
+func countVictimTasks(victim *podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) int32 {
+	count := int32(0)
+	for _, task := range tasks {
+		if task.Job == victim.UID {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/scheduler/plugins/minruntime/minruntime.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime.go
@@ -1,0 +1,214 @@
+package minruntime
+
+import (
+	"time"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultReclaimMinRuntimeConfig = "defaultReclaimMinRuntime"
+	defaultPreemptMinRuntimeConfig = "defaultPreemptMinRuntime"
+	actionTypeReclaim              = "reclaim"
+	actionTypePreempt              = "preempt"
+)
+
+type minruntimePlugin struct {
+	defaultReclaimMinRuntime *metav1.Duration
+	defaultPreemptMinRuntime *metav1.Duration
+}
+
+func New(arguments map[string]string) framework.Plugin {
+	plugin := &minruntimePlugin{}
+	for key, value := range arguments {
+		switch key {
+		case defaultReclaimMinRuntimeConfig:
+			duration, err := time.ParseDuration(value)
+			if err != nil {
+				log.InfraLogger.Errorf("Failed to parse %v: %v, using default value 0", key, err)
+				duration = time.Duration(0 * time.Second)
+			}
+			plugin.defaultReclaimMinRuntime = &metav1.Duration{Duration: duration}
+		case defaultPreemptMinRuntimeConfig:
+			duration, err := time.ParseDuration(value)
+			if err != nil {
+				log.InfraLogger.Errorf("Failed to parse %v: %v, using default value 0", key, err)
+				duration = time.Duration(0 * time.Second)
+			}
+			plugin.defaultPreemptMinRuntime = &metav1.Duration{Duration: duration}
+		}
+	}
+
+	// Initialize with default values if not provided
+	if plugin.defaultReclaimMinRuntime == nil {
+		plugin.defaultReclaimMinRuntime = &metav1.Duration{Duration: time.Duration(0 * time.Second)}
+	}
+	if plugin.defaultPreemptMinRuntime == nil {
+		plugin.defaultPreemptMinRuntime = &metav1.Duration{Duration: time.Duration(0 * time.Second)}
+	}
+
+	return plugin
+}
+
+func (mr *minruntimePlugin) Name() string {
+	return "minruntime"
+}
+
+func (mr *minruntimePlugin) OnSessionOpen(ssn *framework.Session) {
+	// TODO: add IsPreemptibleFn
+}
+
+func (mr *minruntimePlugin) OnSessionClose(ssn *framework.Session) {
+}
+
+// GetMinRuntime resolves the applicable min-runtime for reclaims and preemptions
+// based on the provided action type and queues
+func (mr *minruntimePlugin) GetMinRuntime(
+	actionType string,
+	preemptorQueue *queue_info.QueueInfo,
+	preempteeQueue *queue_info.QueueInfo,
+	queues map[common_info.QueueID]*queue_info.QueueInfo,
+) *metav1.Duration {
+	// Handle preemptions (preemptor and preemptee are within the same leaf-queue)
+	if actionType == actionTypePreempt {
+		return mr.getPreemptMinRuntime(preempteeQueue, queues)
+	}
+
+	// Handle reclaims (preemptor and preemptee are in different queues)
+	if actionType == actionTypeReclaim {
+		return mr.getReclaimMinRuntime(preemptorQueue, preempteeQueue, queues)
+	}
+
+	// If action type is unknown, return default reclaim min runtime
+	return mr.defaultReclaimMinRuntime
+}
+
+// getPreemptMinRuntime resolves min-runtime for preemptions
+// Starting from the leaf-queue, walk the tree until the first defined preempt-min-runtime is set and use that
+func (mr *minruntimePlugin) getPreemptMinRuntime(
+	queue *queue_info.QueueInfo,
+	queues map[common_info.QueueID]*queue_info.QueueInfo,
+) *metav1.Duration {
+	// Start with the provided leaf queue
+	currentQueue := queue
+
+	// Walk up the tree until we find a set preempt-min-runtime or reach the root
+	for currentQueue != nil {
+		if currentQueue.PreemptMinRuntime != nil {
+			return currentQueue.PreemptMinRuntime
+		}
+
+		// Move to parent queue if it exists
+		if currentQueue.ParentQueue != "" {
+			parentQueue, found := queues[currentQueue.ParentQueue]
+			if found {
+				currentQueue = parentQueue
+				continue
+			}
+		}
+
+		// Break if no more parent queues
+		break
+	}
+
+	// If no preempt-min-runtime is set in the queue tree, use default
+	return mr.defaultPreemptMinRuntime
+}
+
+// getReclaimMinRuntime resolves min-runtime for reclaims
+// 1. Resolve the lowest common ancestor (LCA) between the leaf-queues of preemptor and preemptee
+// 2. Walk 1 step down to the child of the LCA that is an ancestor to the preemptee's leaf queue (or is the leaf queue)
+// 3. Use the reclaim-min-runtime from this queue, if it is set. Otherwise move back up towards root of tree
+func (mr *minruntimePlugin) getReclaimMinRuntime(
+	preemptorQueue *queue_info.QueueInfo,
+	preempteeQueue *queue_info.QueueInfo,
+	queues map[common_info.QueueID]*queue_info.QueueInfo,
+) *metav1.Duration {
+	// Get hierarchy paths for both queues
+	preemptorPath := mr.getQueueHierarchyPath(preemptorQueue, queues)
+	preempteePath := mr.getQueueHierarchyPath(preempteeQueue, queues)
+
+	// Find the lowest common ancestor (LCA)
+	lcaIndex := 0
+	minLength := min(len(preemptorPath), len(preempteePath))
+
+	for i := 0; i < minLength; i++ {
+		if preemptorPath[i].UID != preempteePath[i].UID {
+			break
+		}
+		lcaIndex = i
+	}
+
+	// If we found a common ancestor
+	if lcaIndex < len(preemptorPath) && lcaIndex < len(preempteePath) &&
+		preemptorPath[lcaIndex].UID == preempteePath[lcaIndex].UID {
+		// If there's a path down from LCA to preemptee
+		if lcaIndex+1 < len(preempteePath) {
+			// Walk 1 step down to the child of the LCA that is an ancestor to the preemptee's leaf queue
+			childQueue := preempteePath[lcaIndex+1]
+
+			// Check if this queue has reclaim-min-runtime set
+			if childQueue.ReclaimMinRuntime != nil {
+				return childQueue.ReclaimMinRuntime
+			}
+
+			// Otherwise move back up towards root and select first available override
+			for i := lcaIndex; i >= 0; i-- {
+				if preempteePath[i].ReclaimMinRuntime != nil {
+					return preempteePath[i].ReclaimMinRuntime
+				}
+			}
+		} else {
+			// If LCA is the preemptee queue itself, check its reclaim-min-runtime
+			lca := preempteePath[lcaIndex]
+			if lca.ReclaimMinRuntime != nil {
+				return lca.ReclaimMinRuntime
+			}
+
+			// Otherwise move up towards root
+			for i := lcaIndex - 1; i >= 0; i-- {
+				if preempteePath[i].ReclaimMinRuntime != nil {
+					return preempteePath[i].ReclaimMinRuntime
+				}
+			}
+		}
+	}
+
+	// If no reclaim-min-runtime is found in the hierarchy, use default
+	return mr.defaultReclaimMinRuntime
+}
+
+// getQueueHierarchyPath returns the queue hierarchy from root to the specified queue
+func (mr *minruntimePlugin) getQueueHierarchyPath(
+	queue *queue_info.QueueInfo,
+	queues map[common_info.QueueID]*queue_info.QueueInfo,
+) []*queue_info.QueueInfo {
+	var hierarchyPath []*queue_info.QueueInfo
+
+	// Start with the queue itself
+	currentQueue := queue
+
+	// Build the path from queue to root
+	for currentQueue != nil {
+		// Add current queue to the path (at beginning to maintain root->leaf order)
+		hierarchyPath = append([]*queue_info.QueueInfo{currentQueue}, hierarchyPath...)
+
+		// If queue has a parent, add it to the path
+		if currentQueue.ParentQueue != "" {
+			parentQueue, found := queues[currentQueue.ParentQueue]
+			if found {
+				currentQueue = parentQueue
+				continue
+			}
+		}
+
+		// Break if no more parents (reached root)
+		break
+	}
+
+	return hierarchyPath
+}

--- a/pkg/scheduler/plugins/minruntime/minruntime_suite_test.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime_suite_test.go
@@ -1,0 +1,13 @@
+package minruntime
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMinruntime(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Minruntime Plugin Suite")
+}

--- a/pkg/scheduler/plugins/minruntime/minruntime_test.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime_test.go
@@ -1,0 +1,347 @@
+package minruntime
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("MinRuntime Plugin", func() {
+	var (
+		plugin                 *minruntimePlugin
+		queues                 map[common_info.QueueID]*queue_info.QueueInfo
+		defaultPreemptDuration *metav1.Duration
+		defaultReclaimDuration *metav1.Duration
+	)
+
+	// Helper function to create a PodGroupInfo with a specific last start timestamp
+	createPodGroup := func(uid common_info.PodGroupID, queue common_info.QueueID, lastStartTime *time.Time, minAvailable int32, podsCount int) *podgroup_info.PodGroupInfo {
+		pg := &podgroup_info.PodGroupInfo{
+			UID:            uid,
+			Queue:          queue,
+			MinAvailable:   minAvailable,
+			PodInfos:       make(pod_info.PodsMap),
+			PodStatusIndex: make(map[pod_status.PodStatus]pod_info.PodsMap),
+			NodesFitErrors: make(map[common_info.PodID]*common_info.FitErrors),
+		}
+
+		if lastStartTime != nil {
+			pg.LastStartTimestamp = lastStartTime
+		}
+
+		// Add pods to the pod group
+		for i := 0; i < podsCount; i++ {
+			podID := common_info.PodID(fmt.Sprintf("%s-pod-%d", uid, i))
+			podInfo := &pod_info.PodInfo{
+				UID:    podID,
+				Job:    uid,
+				Status: pod_status.Running,
+			}
+			pg.PodInfos[podID] = podInfo
+
+			// Initialize the PodStatusIndex map for this status if it doesn't exist
+			if _, found := pg.PodStatusIndex[pod_status.Running]; !found {
+				pg.PodStatusIndex[pod_status.Running] = make(pod_info.PodsMap)
+			}
+			pg.PodStatusIndex[pod_status.Running][podID] = podInfo
+		}
+
+		return pg
+	}
+
+	BeforeEach(func() {
+		// Set up test data
+		queues = createTestQueues()
+		defaultPreemptDuration = &metav1.Duration{Duration: 5 * time.Second}
+		defaultReclaimDuration = &metav1.Duration{Duration: 3 * time.Second}
+
+		// Initialize the plugin
+		plugin = &minruntimePlugin{
+			queues:                   queues,
+			defaultPreemptMinRuntime: defaultPreemptDuration,
+			defaultReclaimMinRuntime: defaultReclaimDuration,
+			reclaimResolveMethod:     resolveMethodLCA,
+			preemptProtectionCache:   make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool),
+			reclaimProtectionCache:   make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool),
+
+			preemptMinRuntimeCache: make(map[common_info.QueueID]metav1.Duration),
+			reclaimMinRuntimeCache: make(map[common_info.QueueID]map[common_info.QueueID]metav1.Duration),
+		}
+	})
+
+	AfterEach(func() {
+		plugin.preemptProtectionCache = make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool)
+		plugin.reclaimProtectionCache = make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool)
+		plugin.preemptMinRuntimeCache = make(map[common_info.QueueID]metav1.Duration)
+		plugin.reclaimMinRuntimeCache = make(map[common_info.QueueID]map[common_info.QueueID]metav1.Duration)
+	})
+
+	Describe("preemptFilterFn", func() {
+		Context("when victim is protected by min-runtime", func() {
+			It("should return false for non-elastic job", func() {
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job from prod-team2 queue that started recently
+				// Using prod-team2 with preempt min runtime of 15s
+				now := time.Now()
+				recentStart := now.Add(-10 * time.Second) // Started 10 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 1)
+
+				// The preempt min runtime for prod-team2 is 15s, and the job started 10s ago
+				// so it should be protected
+				result := plugin.preemptFilterFn(pendingJob, victim)
+				Expect(result).To(BeFalse(), "Job 'victim-job' should be protected from preemption")
+			})
+
+			It("should return true for elastic job but cache the result", func() {
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create an elastic victim job (MinAvailable < running pods)
+				now := time.Now()
+				recentStart := now.Add(-10 * time.Second) // Started 10 seconds ago
+				victim := createPodGroup("elastic-victim", "prod-team2", &recentStart, 1, 3)
+
+				result := plugin.preemptFilterFn(pendingJob, victim)
+				Expect(result).To(BeTrue(), "Elastic job should allow preemption")
+
+				// Check that the victim was cached
+				Expect(plugin.preemptProtectionCache).To(HaveKey(pendingJob.UID))
+				Expect(plugin.preemptProtectionCache[pendingJob.UID]).To(HaveKey(victim.UID))
+			})
+		})
+
+		Context("when victim is not protected by min-runtime", func() {
+			It("should return true if victim started long ago", func() {
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job that started a long time ago
+				longAgo := time.Now().Add(-30 * time.Second) // Started 30 seconds ago
+				victim := createPodGroup("old-victim", "prod-team2", &longAgo, 1, 1)
+
+				// The preempt min runtime for prod-team2 is 15s, so 30s is past protection period
+				result := plugin.preemptFilterFn(pendingJob, victim)
+				Expect(result).To(BeTrue(), "Job 'old-victim' should not be protected from preemption")
+			})
+
+			It("should return true if victim has no start time", func() {
+				// Create a pending job
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job with no start time
+				victim := createPodGroup("no-start-victim", "prod-team2", nil, 1, 1)
+
+				result := plugin.preemptFilterFn(pendingJob, victim)
+				Expect(result).To(BeTrue(), "Job with no start time should not be protected")
+			})
+		})
+	})
+
+	Describe("reclaimFilterFn", func() {
+		Context("when victim is protected by min-runtime", func() {
+			It("should return false for non-elastic job", func() {
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job from prod-team2 queue that started recently
+				// Using prod-team2 with reclaim min runtime of 35s
+				now := time.Now()
+				recentStart := now.Add(-20 * time.Second) // Started 20 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 1)
+
+				// The reclaim min runtime for prod-team2 is 35s, and the job started 20s ago
+				// so it should be protected
+				result := plugin.reclaimFilterFn(pendingJob, victim)
+				Expect(result).To(BeFalse(), "Job 'victim-job' should be protected from reclaim")
+			})
+
+			It("should return true for elastic job but cache the result", func() {
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create an elastic victim job (MinAvailable < running pods)
+				now := time.Now()
+				recentStart := now.Add(-20 * time.Second) // Started 20 seconds ago
+				victim := createPodGroup("elastic-victim", "prod-team2", &recentStart, 1, 3)
+
+				result := plugin.reclaimFilterFn(pendingJob, victim)
+				Expect(result).To(BeTrue(), "Elastic job should allow reclaim")
+
+				// Check that the victim was cached
+				Expect(plugin.reclaimProtectionCache).To(HaveKey(pendingJob.UID))
+				Expect(plugin.reclaimProtectionCache[pendingJob.UID]).To(HaveKey(victim.UID))
+			})
+		})
+
+		Context("when victim is not protected by min-runtime", func() {
+			It("should return true if victim started long ago", func() {
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job that started a long time ago
+				longAgo := time.Now().Add(-40 * time.Second) // Started 40 seconds ago
+				victim := createPodGroup("old-victim", "prod-team2", &longAgo, 1, 1)
+
+				// The reclaim min runtime for prod-team2 is 35s, so 40s is past protection period
+				result := plugin.reclaimFilterFn(pendingJob, victim)
+				Expect(result).To(BeTrue(), "Job 'old-victim' should not be protected from reclaim")
+			})
+		})
+
+		Context("when using different resolve methods", func() {
+			It("should use LCA method when configured", func() {
+				plugin.reclaimResolveMethod = resolveMethodLCA
+
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job from prod-team2 queue that started recently
+				now := time.Now()
+				recentStart := now.Add(-20 * time.Second) // Started 20 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 1)
+
+				// With LCA method, the reclaim min runtime for different top-level queues
+				// is determined by prod's value (30s)
+				result := plugin.reclaimFilterFn(pendingJob, victim)
+				Expect(result).To(BeFalse(), "Job should be protected with LCA method")
+			})
+
+			It("should use queue method when configured", func() {
+				plugin.reclaimResolveMethod = resolveMethodQueue
+
+				// Create a pending job from dev-team1 queue
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job from prod-team2 queue that started recently
+				now := time.Now()
+				recentStart := now.Add(-20 * time.Second) // Started 20 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 1)
+
+				// With queue method, the reclaim min runtime is prod-team2's value (35s)
+				result := plugin.reclaimFilterFn(pendingJob, victim)
+				Expect(result).To(BeFalse(), "Job should be protected with queue method")
+			})
+		})
+	})
+
+	Describe("preemptScenarioValidatorFn", func() {
+		Context("when validating preemption scenario for elastic jobs", func() {
+			It("should return true if not enough tasks are being preempted", func() {
+				// Create a pending job from dev-team1 queue
+				preemptor := createPodGroup("preemptor-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job that is elastic (minAvailable = 1, pods = 3)
+				now := time.Now()
+				recentStart := now.Add(-10 * time.Second) // Started 10 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 3)
+
+				// Create a list of pods to be preempted - only 1 pod from the victim
+				victimPod := &pod_info.PodInfo{
+					UID:    "victim-job-pod-0",
+					Job:    victim.UID,
+					Status: pod_status.Running,
+				}
+				tasks := []*pod_info.PodInfo{victimPod}
+
+				// Since minAvailable=1 and we have 3 pods total, preempting 1 pod should be fine
+				result := plugin.preemptScenarioValidatorFn(preemptor, []*podgroup_info.PodGroupInfo{victim}, tasks)
+				Expect(result).To(BeTrue(), "Should allow preemption of one pod from elastic job")
+			})
+
+			It("should return false if too many tasks would be preempted", func() {
+				// Create a pending job from dev-team1 queue
+				preemptor := createPodGroup("preemptor-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job that is elastic (minAvailable = 2, pods = 3)
+				now := time.Now()
+				recentStart := now.Add(-10 * time.Second) // Started 10 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 2, 3)
+
+				// Create a list of pods to be preempted - 2 pods from the victim
+				victimPods := []*pod_info.PodInfo{
+					{
+						UID:    "victim-job-pod-0",
+						Job:    victim.UID,
+						Status: pod_status.Running,
+					},
+					{
+						UID:    "victim-job-pod-1",
+						Job:    victim.UID,
+						Status: pod_status.Running,
+					},
+				}
+
+				// Since minAvailable=2 and we have 3 pods total, preempting 2 pods shouldn't be allowed
+				result := plugin.preemptScenarioValidatorFn(preemptor, []*podgroup_info.PodGroupInfo{victim}, victimPods)
+				Expect(result).To(BeFalse(), "Should not allow preemption of too many pods from elastic job")
+			})
+		})
+	})
+
+	Describe("reclaimScenarioValidatorFn", func() {
+		Context("when validating reclaim scenario for elastic jobs", func() {
+			It("should return true if not enough tasks are being reclaimed", func() {
+				// Create a pending job from dev-team1 queue
+				reclaimer := createPodGroup("reclaimer-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job that is elastic (minAvailable = 1, pods = 3)
+				now := time.Now()
+				recentStart := now.Add(-20 * time.Second) // Started 20 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 3)
+
+				// Create a list of pods to be reclaimed - only 1 pod from the victim
+				victimPod := &pod_info.PodInfo{
+					UID:    "victim-job-pod-0",
+					Job:    victim.UID,
+					Status: pod_status.Running,
+				}
+				tasks := []*pod_info.PodInfo{victimPod}
+
+				// Since minAvailable=1 and we have 3 pods total, reclaiming 1 pod should be fine
+				result := plugin.reclaimScenarioValidatorFn(reclaimer, []*podgroup_info.PodGroupInfo{victim}, tasks)
+				Expect(result).To(BeTrue(), "Should allow reclaiming of one pod from elastic job")
+			})
+
+			It("should return false if too many tasks would be reclaimed", func() {
+				// Create a pending job from dev-team1 queue
+				reclaimer := createPodGroup("reclaimer-job", "dev-team1", nil, 1, 1)
+
+				// Create a victim job that is elastic (minAvailable = 2, pods = 3)
+				now := time.Now()
+				recentStart := now.Add(-20 * time.Second) // Started 20 seconds ago
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 2, 3)
+
+				// First cache this victim as protected by reclaim min runtime
+				plugin.reclaimFilterFn(reclaimer, victim)
+
+				// Create a list of pods to be reclaimed - 2 pods from the victim
+				victimPods := []*pod_info.PodInfo{
+					{
+						UID:    "victim-job-pod-0",
+						Job:    victim.UID,
+						Status: pod_status.Running,
+					},
+					{
+						UID:    "victim-job-pod-1",
+						Job:    victim.UID,
+						Status: pod_status.Running,
+					},
+				}
+
+				// Since minAvailable=2 and we have 3 pods total, reclaiming 2 pods shouldn't be allowed
+				result := plugin.reclaimScenarioValidatorFn(reclaimer, []*podgroup_info.PodGroupInfo{victim}, victimPods)
+				Expect(result).To(BeFalse(), "Should not allow reclaim of too many pods from elastic job")
+			})
+		})
+	})
+})

--- a/pkg/scheduler/plugins/minruntime/resolver.go
+++ b/pkg/scheduler/plugins/minruntime/resolver.go
@@ -1,0 +1,241 @@
+package minruntime
+
+import (
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getPreemptMinRuntime resolves min-runtime for preemptions
+// Starting from the leaf-queue, walk the tree until the first defined preempt-min-runtime is set and use that
+func (mr *minruntimePlugin) getPreemptMinRuntime(
+	queue *queue_info.QueueInfo,
+) metav1.Duration {
+	if queue == nil {
+		return *mr.defaultPreemptMinRuntime
+	}
+
+	if minRuntime, ok := mr.preemptMinRuntimeCache[queue.UID]; ok {
+		return minRuntime
+	}
+
+	// Start with the provided leaf queue
+	currentQueue := queue
+
+	// Walk up the tree until we find a set preempt-min-runtime or reach the root
+	for currentQueue != nil {
+		if currentQueue.PreemptMinRuntime != nil {
+			mr.preemptMinRuntimeCache[queue.UID] = *currentQueue.PreemptMinRuntime
+			return *currentQueue.PreemptMinRuntime
+		}
+
+		// Move to parent queue if it exists
+		if currentQueue.ParentQueue != "" {
+			parentQueue, found := mr.queues[currentQueue.ParentQueue]
+			if found {
+				currentQueue = parentQueue
+				continue
+			}
+		}
+
+		// Break if no more parent queues
+		break
+	}
+
+	// If no preempt-min-runtime is set in the queue tree, use default
+	mr.preemptMinRuntimeCache[queue.UID] = *mr.defaultPreemptMinRuntime
+	return *mr.defaultPreemptMinRuntime
+}
+
+// getReclaimMinRuntime resolves min-runtime for reclaims
+// Depending on the resolveMethod, it will use either:
+// 1. queue: Starting from the leaf-queue, walk the tree (similar to preempt)
+// 2. lca: Use the lowest common ancestor approach
+func (mr *minruntimePlugin) getReclaimMinRuntime(
+	resolveMethod string,
+	preemptorQueue *queue_info.QueueInfo,
+	preempteeQueue *queue_info.QueueInfo,
+) metav1.Duration {
+	if preemptorQueue == nil || preempteeQueue == nil {
+		return *mr.defaultReclaimMinRuntime
+	}
+
+	if minRuntime, ok := mr.reclaimMinRuntimeCache[preemptorQueue.UID][preempteeQueue.UID]; ok {
+		return minRuntime
+	}
+
+	// If method is LCA, use the LCA-based algorithm
+	if resolveMethod == resolveMethodLCA {
+		return mr.getReclaimMinRuntimeLCA(preemptorQueue, preempteeQueue)
+	}
+
+	// Otherwise, use queue-based approach (similar to preempt)
+	// Start with the provided leaf queue
+	currentQueue := preempteeQueue
+
+	// Walk up the tree until we find a set reclaim-min-runtime or reach the root
+	for currentQueue != nil {
+		if currentQueue.ReclaimMinRuntime != nil {
+			return *currentQueue.ReclaimMinRuntime
+		}
+
+		// Move to parent queue if it exists
+		if currentQueue.ParentQueue != "" {
+			parentQueue, found := mr.queues[currentQueue.ParentQueue]
+			if found {
+				currentQueue = parentQueue
+				continue
+			}
+		}
+
+		// Break if no more parent queues
+		break
+	}
+
+	// If no reclaim-min-runtime is set in the queue tree, use default
+	return *mr.defaultReclaimMinRuntime
+}
+
+// getReclaimMinRuntimeLCA resolves min-runtime for reclaims using the LCA method
+// 1. Resolve the lowest common ancestor (LCA) between the leaf-queues of preemptor and preemptee
+// 2. Walk 1 step down to the child of the LCA that is an ancestor to the preemptee's leaf queue (or is the leaf queue)
+// 3. Use the reclaim-min-runtime from this queue, if it is set. Otherwise move back up towards root of tree
+//
+// Note: Top-level queues (with empty parent) are treated as siblings with an implicit shadow parent
+func (mr *minruntimePlugin) getReclaimMinRuntimeLCA(
+	preemptorQueue *queue_info.QueueInfo,
+	preempteeQueue *queue_info.QueueInfo,
+) metav1.Duration {
+	if preemptorQueue == nil || preempteeQueue == nil {
+		return *mr.defaultReclaimMinRuntime
+	}
+
+	// Get hierarchy paths for both queues
+	preemptorPath := mr.getQueueHierarchyPath(preemptorQueue)
+	preempteePath := mr.getQueueHierarchyPath(preempteeQueue)
+
+	// Handle case where both queues are from different top-level hierarchies
+	// Consider them as siblings with a shadow parent
+	if len(preemptorPath) > 0 && len(preempteePath) > 0 {
+		topLevelPreemptor := preemptorPath[0]
+		topLevelPreemptee := preempteePath[0]
+
+		// If both are top-level queues (empty parent) and different
+		if topLevelPreemptor.ParentQueue == "" && topLevelPreemptee.ParentQueue == "" &&
+			topLevelPreemptor.UID != topLevelPreemptee.UID {
+
+			// For different top-level queues:
+			// The LCA is the implicit shadow parent at level -1 (doesn't exist in path)
+			// So we'd want to look at the top-level queue (first in path) that's the ancestor
+			// of the preemptee, which is preempteePath[0]
+
+			// Check if the top-level preemptee queue has reclaim-min-runtime set
+			if topLevelPreemptee.ReclaimMinRuntime != nil {
+				mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *topLevelPreemptee.ReclaimMinRuntime)
+				return *topLevelPreemptee.ReclaimMinRuntime
+			}
+
+			// No value in hierarchy, use default
+			mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *mr.defaultReclaimMinRuntime)
+			return *mr.defaultReclaimMinRuntime
+		}
+	}
+
+	// Find the lowest common ancestor (LCA)
+	lcaIndex := 0
+	minLength := min(len(preemptorPath), len(preempteePath))
+
+	for i := 0; i < minLength; i++ {
+		if preemptorPath[i].UID != preempteePath[i].UID {
+			break
+		}
+		lcaIndex = i
+	}
+
+	// If we found a common ancestor
+	if lcaIndex < len(preemptorPath) && lcaIndex < len(preempteePath) &&
+		preemptorPath[lcaIndex].UID == preempteePath[lcaIndex].UID {
+
+		lca := preemptorPath[lcaIndex]
+
+		// If there's a path down from LCA to preemptee
+		if lcaIndex+1 < len(preempteePath) {
+			// Walk 1 step down to the child of the LCA that is an ancestor to the preemptee's leaf queue
+			childQueue := preempteePath[lcaIndex+1]
+
+			// Check if this queue has reclaim-min-runtime set
+			if childQueue.ReclaimMinRuntime != nil {
+				mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *childQueue.ReclaimMinRuntime)
+				return *childQueue.ReclaimMinRuntime
+			}
+
+			// Otherwise move back up towards root and select first available override
+			for i := lcaIndex; i >= 0; i-- {
+				if preempteePath[i].ReclaimMinRuntime != nil {
+					mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *preempteePath[i].ReclaimMinRuntime)
+					return *preempteePath[i].ReclaimMinRuntime
+				}
+			}
+		} else {
+			// If LCA is the preemptee queue itself, check its reclaim-min-runtime
+			if lca.ReclaimMinRuntime != nil {
+				mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *lca.ReclaimMinRuntime)
+				return *lca.ReclaimMinRuntime
+			}
+
+			// Otherwise move up towards root
+			for i := lcaIndex - 1; i >= 0; i-- {
+				if preempteePath[i].ReclaimMinRuntime != nil {
+					mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *preempteePath[i].ReclaimMinRuntime)
+					return *preempteePath[i].ReclaimMinRuntime
+				}
+			}
+		}
+	}
+
+	// If no reclaim-min-runtime is found in the hierarchy, use default
+	mr.cacheReclaimMinRuntime(preemptorQueue, preempteeQueue, *mr.defaultReclaimMinRuntime)
+	return *mr.defaultReclaimMinRuntime
+}
+
+// getQueueHierarchyPath returns the queue hierarchy from top-level queue to the specified queue
+// Note: For top-level queues (empty parent), the path will only contain the queue itself
+func (mr *minruntimePlugin) getQueueHierarchyPath(
+	queue *queue_info.QueueInfo,
+) []*queue_info.QueueInfo {
+	var hierarchyPath []*queue_info.QueueInfo
+
+	// Start with the queue itself
+	currentQueue := queue
+
+	// Build the path from queue to parent
+	for currentQueue != nil {
+		// Add current queue to the path (at beginning to maintain parent->child order)
+		hierarchyPath = append([]*queue_info.QueueInfo{currentQueue}, hierarchyPath...)
+
+		// If queue has a parent, add it to the path
+		if currentQueue.ParentQueue != "" {
+			parentQueue, found := mr.queues[currentQueue.ParentQueue]
+			if found {
+				currentQueue = parentQueue
+				continue
+			}
+		}
+
+		// Break if no more parents (reached top-level)
+		break
+	}
+
+	return hierarchyPath
+}
+
+func (mr *minruntimePlugin) cacheReclaimMinRuntime(preemptorQueue *queue_info.QueueInfo, preempteeQueue *queue_info.QueueInfo, minRuntime metav1.Duration) {
+	if mr.reclaimMinRuntimeCache == nil {
+		return
+	}
+
+	if mr.reclaimMinRuntimeCache[preemptorQueue.UID] == nil {
+		mr.reclaimMinRuntimeCache[preemptorQueue.UID] = make(map[common_info.QueueID]metav1.Duration)
+	}
+	mr.reclaimMinRuntimeCache[preemptorQueue.UID][preempteeQueue.UID] = minRuntime
+}

--- a/pkg/scheduler/plugins/minruntime/resolver_test.go
+++ b/pkg/scheduler/plugins/minruntime/resolver_test.go
@@ -1,0 +1,408 @@
+package minruntime
+
+import (
+	"time"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("MinRuntime Resolver", func() {
+	var (
+		queues                 map[common_info.QueueID]*queue_info.QueueInfo
+		plugin                 *minruntimePlugin
+		defaultPreemptDuration *metav1.Duration
+		defaultReclaimDuration *metav1.Duration
+	)
+
+	BeforeEach(func() {
+		queues = createTestQueues()
+		defaultPreemptDuration = &metav1.Duration{Duration: 2 * time.Second}
+		defaultReclaimDuration = &metav1.Duration{Duration: 1 * time.Second}
+
+		plugin = &minruntimePlugin{
+			queues:                   queues,
+			defaultPreemptMinRuntime: defaultPreemptDuration,
+			defaultReclaimMinRuntime: defaultReclaimDuration,
+			preemptMinRuntimeCache:   make(map[common_info.QueueID]metav1.Duration),
+			reclaimMinRuntimeCache:   make(map[common_info.QueueID]map[common_info.QueueID]metav1.Duration),
+		}
+	})
+
+	AfterEach(func() {
+		// Reset the caches after each test
+		plugin.preemptMinRuntimeCache = make(map[common_info.QueueID]metav1.Duration)
+		plugin.reclaimMinRuntimeCache = make(map[common_info.QueueID]map[common_info.QueueID]metav1.Duration)
+	})
+
+	Describe("getPreemptMinRuntime", func() {
+		Context("when queue has a set value (prod-team2)", func() {
+			It("should return the queue's value", func() {
+				result := plugin.getPreemptMinRuntime(queues["prod-team2"])
+				Expect(result).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
+			})
+		})
+
+		Context("when queue inherits from parent (prod-team1 from prod)", func() {
+			It("should return the parent's value", func() {
+				result := plugin.getPreemptMinRuntime(queues["prod-team1"])
+				Expect(result).To(Equal(metav1.Duration{Duration: 20 * time.Second}))
+			})
+		})
+
+		Context("when queue inherits from parent (dev-team1 from dev)", func() {
+			It("should return the parent's value", func() {
+				result := plugin.getPreemptMinRuntime(queues["dev-team1"])
+				Expect(result).To(Equal(metav1.Duration{Duration: 5 * time.Second}))
+			})
+		})
+
+		Context("when top-level queue has a set value (prod)", func() {
+			It("should return the queue's value", func() {
+				result := plugin.getPreemptMinRuntime(queues["prod"])
+				Expect(result).To(Equal(metav1.Duration{Duration: 20 * time.Second}))
+			})
+		})
+
+		Context("when research queue has a set value", func() {
+			It("should return the queue's value", func() {
+				result := plugin.getPreemptMinRuntime(queues["research"])
+				Expect(result).To(Equal(metav1.Duration{Duration: 4 * time.Second}))
+			})
+		})
+
+		Context("when no queue is found", func() {
+			It("should return the default value", func() {
+				nonexistentQueue := &queue_info.QueueInfo{UID: "nonexistent", ParentQueue: "also-nonexistent"}
+				result := plugin.getPreemptMinRuntime(nonexistentQueue)
+				Expect(result).To(Equal(*defaultPreemptDuration))
+			})
+		})
+	})
+
+	Describe("getReclaimMinRuntime with queue method", func() {
+		Context("when victim queue has a set value (pendingJob:dev-team1, victim:prod-team2)", func() {
+			It("should return the victim queue's value", func() {
+				result := plugin.getReclaimMinRuntime(
+					resolveMethodQueue,
+					queues["dev-team1"],
+					queues["prod-team2"],
+				)
+				Expect(result).To(Equal(metav1.Duration{Duration: 35 * time.Second}))
+			})
+		})
+
+		Context("when victim queue inherits from parent (pendingJob:dev-team1, victim:dev-team2)", func() {
+			It("should return the victim's parent value", func() {
+				result := plugin.getReclaimMinRuntime(
+					resolveMethodQueue,
+					queues["dev-team1"],
+					queues["dev-team2"],
+				)
+				Expect(result).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
+			})
+		})
+
+		Context("when victim queue is not found (pendingJob:dev-team1, victim:nonexistent)", func() {
+			It("should return the default value", func() {
+				nonexistentQueue := &queue_info.QueueInfo{UID: "nonexistent", ParentQueue: "also-nonexistent"}
+				result := plugin.getReclaimMinRuntime(
+					resolveMethodQueue,
+					queues["dev-team1"],
+					nonexistentQueue,
+				)
+				Expect(result).To(Equal(*defaultReclaimDuration))
+			})
+		})
+	})
+
+	Describe("getReclaimMinRuntimeLCA", func() {
+		Context("when pendingJob and victim are in different top-level queues (pendingJob:dev-team1, victim:prod-team2)", func() {
+			It("should use the top-level victim queue's value", func() {
+				result := plugin.getReclaimMinRuntimeLCA(
+					queues["dev-team1"],
+					queues["prod-team2"],
+				)
+				// Should use the prod queue's value (30s) since it's the top-level ancestor of prod-team2
+				Expect(result).To(Equal(metav1.Duration{Duration: 30 * time.Second}))
+			})
+		})
+
+		Context("when LCA is dev and victim is dev-team1 with ReclaimMinRuntime set (pendingJob:dev-team2, victim:dev-team1)", func() {
+			It("should return the victim's value", func() {
+				result := plugin.getReclaimMinRuntimeLCA(
+					queues["dev-team2"],
+					queues["dev-team1"],
+				)
+				Expect(result.Duration).To(BeNumerically("==", 8*time.Second))
+			})
+		})
+
+		Context("when LCA is prod and victim is prod-team2 with ReclaimMinRuntime set (pendingJob:prod-team1, victim:prod-team2)", func() {
+			It("should return the victim's value", func() {
+				result := plugin.getReclaimMinRuntimeLCA(
+					queues["prod-team1"],
+					queues["prod-team2"],
+				)
+				Expect(result).To(Equal(metav1.Duration{Duration: 35 * time.Second}))
+			})
+		})
+
+		Context("when pendingJob and victim are the same queue (pendingJob:prod-team2, victim:prod-team2)", func() {
+			It("should return the queue's own value", func() {
+				result := plugin.getReclaimMinRuntimeLCA(
+					queues["prod-team2"],
+					queues["prod-team2"],
+				)
+				Expect(result).To(Equal(metav1.Duration{Duration: 35 * time.Second}))
+			})
+		})
+
+		Context("when research queue is victim (pendingJob:dev-team1, victim:research-project)", func() {
+			It("should use research queue's value from the top-level ancestor", func() {
+				result := plugin.getReclaimMinRuntimeLCA(
+					queues["dev-team1"],
+					queues["research-project"],
+				)
+				Expect(result).To(Equal(metav1.Duration{Duration: 6 * time.Second}))
+			})
+		})
+	})
+
+	Describe("getQueueHierarchyPath", func() {
+		It("should return correct path for top-level queue (dev)", func() {
+			result := plugin.getQueueHierarchyPath(queues["dev"])
+			resultUIDs := extractUIDs(result)
+			Expect(resultUIDs).To(Equal([]common_info.QueueID{"dev"}))
+		})
+
+		It("should return correct path for leaf queue (dev-team1)", func() {
+			result := plugin.getQueueHierarchyPath(queues["dev-team1"])
+			resultUIDs := extractUIDs(result)
+			Expect(resultUIDs).To(Equal([]common_info.QueueID{"dev", "dev-team1"}))
+		})
+
+		It("should return correct path for different branch leaf queue (prod-team2)", func() {
+			result := plugin.getQueueHierarchyPath(queues["prod-team2"])
+			resultUIDs := extractUIDs(result)
+			Expect(resultUIDs).To(Equal([]common_info.QueueID{"prod", "prod-team2"}))
+		})
+
+		It("should return correct path for research project queue", func() {
+			result := plugin.getQueueHierarchyPath(queues["research-project"])
+			resultUIDs := extractUIDs(result)
+			Expect(resultUIDs).To(Equal([]common_info.QueueID{"research", "research-project"}))
+		})
+
+		It("should handle queues with non-existent parent", func() {
+			orphanQueue := &queue_info.QueueInfo{UID: "orphan", ParentQueue: "nonexistent"}
+			result := plugin.getQueueHierarchyPath(orphanQueue)
+			resultUIDs := extractUIDs(result)
+			Expect(resultUIDs).To(Equal([]common_info.QueueID{"orphan"}))
+		})
+	})
+
+	Describe("getReclaimMinRuntime with both methods", func() {
+		It("should return different values for different methods (pendingJob:dev-team1, victim:prod-team2)", func() {
+			preemptorQueue := queues["dev-team1"]
+			preempteeQueue := queues["prod-team2"]
+
+			queueResult := plugin.getReclaimMinRuntime(resolveMethodQueue, preemptorQueue, preempteeQueue)
+			Expect(queueResult).To(Equal(metav1.Duration{Duration: 35 * time.Second}))
+
+			lcaResult := plugin.getReclaimMinRuntime(resolveMethodLCA, preemptorQueue, preempteeQueue)
+			// Should use prod's value (30s) since it's the top-level ancestor in the shadow parent tree
+			Expect(lcaResult).To(Equal(metav1.Duration{Duration: 30 * time.Second}))
+		})
+
+		It("should handle different hierarchies with the research queue (pendingJob:dev-team1, victim:research-project)", func() {
+			preemptorQueue := queues["dev-team1"]
+			preempteeQueue := queues["research-project"]
+
+			queueResult := plugin.getReclaimMinRuntime(resolveMethodQueue, preemptorQueue, preempteeQueue)
+			Expect(queueResult).To(Equal(metav1.Duration{Duration: 9 * time.Second}))
+
+			lcaResult := plugin.getReclaimMinRuntime(resolveMethodLCA, preemptorQueue, preempteeQueue)
+			Expect(lcaResult).To(Equal(metav1.Duration{Duration: 6 * time.Second}))
+		})
+	})
+
+	Describe("Edge cases", func() {
+		Context("with empty queue map", func() {
+			It("should handle empty queue map gracefully (pendingJob:dev-team1, victim:prod-team2)", func() {
+				emptyPlugin := &minruntimePlugin{
+					queues:                   nil,
+					defaultPreemptMinRuntime: defaultPreemptDuration,
+					defaultReclaimMinRuntime: defaultReclaimDuration,
+					preemptMinRuntimeCache:   make(map[common_info.QueueID]metav1.Duration),
+					reclaimMinRuntimeCache:   make(map[common_info.QueueID]map[common_info.QueueID]metav1.Duration),
+				}
+
+				result := emptyPlugin.getQueueHierarchyPath(queues["dev-team1"])
+				Expect(result).To(HaveLen(1))
+
+				preemptResult := emptyPlugin.getPreemptMinRuntime(queues["dev-team1"])
+				Expect(preemptResult).To(Equal(*defaultPreemptDuration))
+
+				reclaimResult := emptyPlugin.getReclaimMinRuntime(resolveMethodLCA, queues["dev-team1"], queues["prod-team2"])
+				Expect(reclaimResult).To(Equal(*defaultReclaimDuration))
+			})
+		})
+
+		Context("with nil queue", func() {
+			It("should handle nil queue gracefully", func() {
+				preemptResult := plugin.getPreemptMinRuntime(nil)
+				Expect(preemptResult).To(Equal(*defaultPreemptDuration))
+
+				reclaimResult := plugin.getReclaimMinRuntimeLCA(nil, nil)
+				Expect(reclaimResult).To(Equal(*defaultReclaimDuration))
+			})
+		})
+
+		Context("with orphaned victim queue (pendingJob:dev-team1, victim:orphan)", func() {
+			It("should use plugin default value when ancestor is missing", func() {
+				orphanQueue := &queue_info.QueueInfo{
+					UID:               "orphan",
+					ParentQueue:       "nonexistent",
+					ReclaimMinRuntime: &metav1.Duration{Duration: 7 * time.Second},
+				}
+
+				result := plugin.getReclaimMinRuntimeLCA(queues["dev-team1"], orphanQueue)
+				// With the updated shadow parent approach, should use orphan's own value (7s)
+				Expect(result.Duration).To(BeNumerically("==", 1*time.Second))
+			})
+		})
+
+		Context("with top-level victim queue having no reclaim min runtime (pendingJob:dev-team1, victim:leaf)", func() {
+			It("should fall back to default value", func() {
+				// Create a top-level queue with no reclaim min runtime
+				noReclaimQueue := &queue_info.QueueInfo{
+					UID:               "no-reclaim",
+					ParentQueue:       "",
+					ReclaimMinRuntime: nil,
+				}
+
+				// Create a leaf queue under this top-level queue
+				leafQueue := &queue_info.QueueInfo{
+					UID:               "leaf",
+					ParentQueue:       "no-reclaim",
+					ReclaimMinRuntime: nil,
+				}
+
+				// Add these queues to a test plugin
+				testQueues := map[common_info.QueueID]*queue_info.QueueInfo{
+					"no-reclaim": noReclaimQueue,
+					"leaf":       leafQueue,
+				}
+
+				testPlugin := &minruntimePlugin{
+					queues:                   testQueues,
+					defaultReclaimMinRuntime: defaultReclaimDuration,
+				}
+
+				// Test LCA between queue from different hierarchies
+				result := testPlugin.getReclaimMinRuntimeLCA(queues["dev-team1"], leafQueue)
+				Expect(result).To(Equal(*defaultReclaimDuration))
+			})
+		})
+	})
+})
+
+// Helper function to extract UIDs from queue hierarchy path
+func extractUIDs(queuePath []*queue_info.QueueInfo) []common_info.QueueID {
+	resultUIDs := make([]common_info.QueueID, len(queuePath))
+	for i, q := range queuePath {
+		resultUIDs[i] = q.UID
+	}
+	return resultUIDs
+}
+
+func createTestQueues() map[common_info.QueueID]*queue_info.QueueInfo {
+	dev := &queue_info.QueueInfo{
+		UID:               "dev",
+		Name:              "Development Queue",
+		ParentQueue:       "",
+		ChildQueues:       []common_info.QueueID{"dev-team1", "dev-team2"},
+		PreemptMinRuntime: &metav1.Duration{Duration: 5 * time.Second},
+		ReclaimMinRuntime: &metav1.Duration{Duration: 10 * time.Second}, // Adding reclaim min runtime
+	}
+
+	prod := &queue_info.QueueInfo{
+		UID:               "prod",
+		Name:              "Production Queue",
+		ParentQueue:       "",
+		ChildQueues:       []common_info.QueueID{"prod-team1", "prod-team2"},
+		PreemptMinRuntime: &metav1.Duration{Duration: 20 * time.Second},
+		ReclaimMinRuntime: &metav1.Duration{Duration: 30 * time.Second},
+	}
+
+	// Add a third queue for research
+	research := &queue_info.QueueInfo{
+		UID:               "research",
+		Name:              "Research Queue",
+		ParentQueue:       "",
+		ChildQueues:       []common_info.QueueID{"research-project"},
+		PreemptMinRuntime: &metav1.Duration{Duration: 4 * time.Second},
+		ReclaimMinRuntime: &metav1.Duration{Duration: 6 * time.Second},
+	}
+
+	devTeam1 := &queue_info.QueueInfo{
+		UID:               "dev-team1",
+		Name:              "Dev Team 1",
+		ParentQueue:       "dev",
+		ChildQueues:       []common_info.QueueID{},
+		PreemptMinRuntime: nil, // Not set, should inherit from parent
+		ReclaimMinRuntime: &metav1.Duration{Duration: 8 * time.Second},
+	}
+
+	devTeam2 := &queue_info.QueueInfo{
+		UID:               "dev-team2",
+		Name:              "Dev Team 2",
+		ParentQueue:       "dev",
+		ChildQueues:       []common_info.QueueID{},
+		PreemptMinRuntime: &metav1.Duration{Duration: 3 * time.Second},
+		ReclaimMinRuntime: nil, // Not set, should inherit from parent/resolver rules
+	}
+
+	prodTeam1 := &queue_info.QueueInfo{
+		UID:               "prod-team1",
+		Name:              "Prod Team 1",
+		ParentQueue:       "prod",
+		ChildQueues:       []common_info.QueueID{},
+		PreemptMinRuntime: nil, // Not set, should inherit from parent
+		ReclaimMinRuntime: &metav1.Duration{Duration: 25 * time.Second},
+	}
+
+	prodTeam2 := &queue_info.QueueInfo{
+		UID:               "prod-team2",
+		Name:              "Prod Team 2",
+		ParentQueue:       "prod",
+		ChildQueues:       []common_info.QueueID{},
+		PreemptMinRuntime: &metav1.Duration{Duration: 15 * time.Second},
+		ReclaimMinRuntime: &metav1.Duration{Duration: 35 * time.Second},
+	}
+
+	// Add a research project queue
+	researchProject := &queue_info.QueueInfo{
+		UID:               "research-project",
+		Name:              "Research Project",
+		ParentQueue:       "research",
+		ChildQueues:       []common_info.QueueID{},
+		PreemptMinRuntime: &metav1.Duration{Duration: 7 * time.Second},
+		ReclaimMinRuntime: &metav1.Duration{Duration: 9 * time.Second},
+	}
+
+	return map[common_info.QueueID]*queue_info.QueueInfo{
+		"dev":              dev,
+		"prod":             prod,
+		"research":         research,
+		"dev-team1":        devTeam1,
+		"dev-team2":        devTeam2,
+		"prod-team1":       prodTeam1,
+		"prod-team2":       prodTeam2,
+		"research-project": researchProject,
+	}
+}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -37,9 +37,10 @@ type proportionPlugin struct {
 	queues              map[common_info.QueueID]*rs.QueueAttributes
 	jobSimulationQueues map[common_info.QueueID]*rs.QueueAttributes
 	// Arguments given for the plugin
-	pluginArguments   map[string]string
-	taskOrderFunc     common_info.LessFn
-	reclaimablePlugin *rec.Reclaimable
+	pluginArguments        map[string]string
+	taskOrderFunc          common_info.LessFn
+	reclaimablePlugin      *rec.Reclaimable
+	isInferencePreemptible bool
 }
 
 func New(arguments map[string]string) framework.Plugin {
@@ -58,7 +59,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	pp.calculateResourcesProportion(ssn)
 	pp.taskOrderFunc = ssn.TaskOrderFn
 	pp.reclaimablePlugin = rec.New(ssn.IsInferencePreemptible(), pp.taskOrderFunc)
-
+	pp.isInferencePreemptible = ssn.IsInferencePreemptible()
 	capacityPolicy := cp.New(pp.queues, ssn.IsInferencePreemptible())
 	ssn.AddQueueOrderFn(pp.queueOrder)
 	ssn.AddCanReclaimResourcesFn(pp.CanReclaimResourcesFn)
@@ -91,15 +92,17 @@ func (pp *proportionPlugin) OnJobSolutionStartFn() {
 	}
 }
 
-func (pp *proportionPlugin) CanReclaimResourcesFn(reclaimer *reclaimer_info.ReclaimerInfo) bool {
-	return pp.reclaimablePlugin.CanReclaimResources(pp.queues, reclaimer)
+func (pp *proportionPlugin) CanReclaimResourcesFn(reclaimer *podgroup_info.PodGroupInfo) bool {
+	reclaimerInfo := pp.buildReclaimerInfo(reclaimer)
+	return pp.reclaimablePlugin.CanReclaimResources(pp.queues, reclaimerInfo)
 }
 
 func (pp *proportionPlugin) reclaimableFn(
-	reclaimer *reclaimer_info.ReclaimerInfo,
+	reclaimer *podgroup_info.PodGroupInfo,
 	reclaimees []*podgroup_info.PodGroupInfo,
 	_ []*pod_info.PodInfo,
 ) bool {
+	reclaimerInfo := pp.buildReclaimerInfo(reclaimer)
 	totalVictimsResources := make(map[common_info.QueueID][]*resource_info.Resource)
 	for _, jobTaskGroup := range reclaimees {
 		totalJobResources := resource_info.EmptyResource()
@@ -113,7 +116,7 @@ func (pp *proportionPlugin) reclaimableFn(
 		)
 	}
 
-	return pp.reclaimablePlugin.Reclaimable(pp.jobSimulationQueues, reclaimer, totalVictimsResources)
+	return pp.reclaimablePlugin.Reclaimable(pp.jobSimulationQueues, reclaimerInfo, totalVictimsResources)
 }
 
 func (pp *proportionPlugin) calculateResourcesProportion(ssn *framework.Session) {
@@ -178,6 +181,17 @@ func (pp *proportionPlugin) createQueueAttributes(ssn *framework.Session) {
 	pp.createQueueResourceAttrs(ssn)
 	pp.updateQueuesCurrentResourceUsage(ssn)
 	pp.setFairShare()
+}
+
+func (pp *proportionPlugin) buildReclaimerInfo(reclaimerJob *podgroup_info.PodGroupInfo) *reclaimer_info.ReclaimerInfo {
+	return &reclaimer_info.ReclaimerInfo{
+		Name:          reclaimerJob.Name,
+		Namespace:     reclaimerJob.Namespace,
+		Queue:         reclaimerJob.Queue,
+		IsPreemptable: reclaimerJob.IsPreemptibleJob(pp.isInferencePreemptible),
+		RequiredResources: podgroup_info.GetTasksToAllocateInitResource(
+			reclaimerJob, pp.taskOrderFunc, false),
+	}
 }
 
 func (pp *proportionPlugin) createQueueResourceAttrs(ssn *framework.Session) {

--- a/test/e2e/suites/reclaim/reclaim_elastic_test.go
+++ b/test/e2e/suites/reclaim/reclaim_elastic_test.go
@@ -7,6 +7,7 @@ package reclaim
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -191,6 +192,47 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 		testCtx = testcontext.GetConnectivity(ctx, Default)
 		parentQueue, reclaimeeQueue, reclaimerQueue = createQueues(3, 1, 2)
 		reclaimeeQueue.Spec.Resources.GPU.OverQuotaWeight = 0
+		testCtx.InitQueues([]*v2.Queue{parentQueue, reclaimeeQueue, reclaimerQueue})
+		reclaimeeNamespace = queue.GetConnectedNamespaceToQueue(reclaimeeQueue)
+
+		// reclaimee job
+		reclaimeePodRequirements := v1.ResourceRequirements{
+			Limits: map[v1.ResourceName]resource.Quantity{
+				constants.GpuResource: resource.MustParse("1"),
+			},
+		}
+		reclaimeePodGroup, reclaimeePods := pod_group.CreateWithPods(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
+			"elastic-reclaimee-job", reclaimeeQueue, 3, nil,
+			reclaimeePodRequirements)
+		wait.ForPodsScheduled(ctx, testCtx.ControllerClient, reclaimeeNamespace, reclaimeePods)
+
+		// reclaimer job
+		reclaimerPodRequirements := v1.ResourceRequirements{
+			Limits: map[v1.ResourceName]resource.Quantity{
+				constants.GpuResource: resource.MustParse("1"),
+			},
+		}
+		_, reclaimerPods := pod_group.CreateDistributedJob(
+			ctx, testCtx.KubeClientset, testCtx.ControllerClient,
+			reclaimerQueue, 2, reclaimerPodRequirements, "",
+		)
+		reclaimerNamespace := queue.GetConnectedNamespaceToQueue(reclaimerQueue)
+		wait.ForPodsScheduled(ctx, testCtx.ControllerClient, reclaimerNamespace, reclaimerPods)
+
+		// verify results
+		wait.ForPodsWithCondition(ctx, testCtx.ControllerClient, func(watch.Event) bool {
+			pods, err := testCtx.KubeClientset.CoreV1().Pods(reclaimeeNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", podGroupLabelName, reclaimeePodGroup.Name),
+			})
+			Expect(err).To(Succeed())
+			return len(pods.Items) == 1
+		})
+	})
+	It("Reclaim elastic job with min runtime partially for a distributed job", func(ctx context.Context) {
+		testCtx = testcontext.GetConnectivity(ctx, Default)
+		parentQueue, reclaimeeQueue, reclaimerQueue = createQueues(3, 1, 2)
+		reclaimeeQueue.Spec.Resources.GPU.OverQuotaWeight = 0
+		reclaimeeQueue.Spec.ReclaimMinRuntime = &metav1.Duration{Duration: 1 * time.Minute}
 		testCtx.InitQueues([]*v2.Queue{parentQueue, reclaimeeQueue, reclaimerQueue})
 		reclaimeeNamespace = queue.GetConnectedNamespaceToQueue(reclaimeeQueue)
 


### PR DESCRIPTION
This implements a plugin that protects jobs with minruntime.

The e2e tests are not completed yet and will currently fail, but we can start reviewing the rest of the code while it gets fixed.

Refactored the plugins so that ReclaimerInfo isnt needed anywhere, and proportion plugin builds that datastructure inside itself, then cleaned up the naming of the functions and added a missing one.

For the plugin, it implements the rough design we talked about, with a few extra bits such as being able to select which resolver type to use for reclaims (LCA method or victim queue).

Added 2 types of caches both for resolving min-runtime between queues and also checking if jobs are protected or not. This should reduce the amount of double-resolving that could happen for elastic workloads, but also for other jobs.

Also, made most e2e functions have a period of steady state (needed for the minruntime, but good for the rest). This ensures we didnt hit a state on one scheduling loop and then regressed the next one. Will be extra important as we start implementing more advanced prioritization etc.

Closes #136

TODO: fix e2e tests, add changelog