### PR TITLE
refactor out reclaimerinfo from API

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/reclaimer_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
@@ -20,16 +19,13 @@ type PredicateFn func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo, *node_info
 type PrePredicateFn func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo) error
 
 // CanReclaimResourcesFn is a function that determines if a reclaimer can get more resources
-type CanReclaimResourcesFn func(reclaimerInfo *reclaimer_info.ReclaimerInfo) bool
+type CanReclaimResourcesFn func(reclaimer *podgroup_info.PodGroupInfo) bool
 
-// VictimFilterFn is a function which filters out jobs that cannot a victim candidate for a specific reclaimer.
+// VictimFilterFn is a function which filters out jobs that cannot a victim candidate for a specific reclaimer/preemptor.
 type VictimFilterFn func(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool
 
-// ScenarioValidatorFn is a function which determines the validity of a reclaim scenario.
-type ScenarioValidatorFn func(reclaimerInfo *reclaimer_info.ReclaimerInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool
-
-// PreemptScenarioValidatorFn is a function which determines the validity of a preempt scenario.
-type PreemptScenarioValidatorFn func(preemptor *podgroup_info.PodGroupInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool
+// ScenarioValidatorFn is a function which determines the validity of a scenario.
+type ScenarioValidatorFn func(pendingJob *podgroup_info.PodGroupInfo, victims []*podgroup_info.PodGroupInfo, tasks []*pod_info.PodInfo) bool
 
 // QueueResource is a function which returns the resource of a queue.
 type QueueResource func(*queue_info.QueueInfo) *resource_info.ResourceRequirements

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -50,8 +50,8 @@ type Session struct {
 	CanReclaimResourcesFns                []api.CanReclaimResourcesFn
 	ReclaimVictimFilterFns                []api.VictimFilterFn
 	PreemptVictimFilterFns                []api.VictimFilterFn
-	ReclaimScenarioValidators             []api.ScenarioValidatorFn
-	PreemptScenarioValidators             []api.PreemptScenarioValidatorFn
+	ReclaimScenarioValidatorFns           []api.ScenarioValidatorFn
+	PreemptScenarioValidatorFns           []api.ScenarioValidatorFn
 	OnJobSolutionStartFns                 []api.OnJobSolutionStartFn
 	GetQueueAllocatedResourcesFns         []api.QueueResource
 	GetQueueDeservedResourcesFns          []api.QueueResource


### PR DESCRIPTION
This breaks out the changes from #162 regarding some smaller refactors and eliminating ReclaimerInfo from the plugin API, as RequiredResources is specific to proportion plugin only.

The main concern raised by @romanbaron was that ReclaimerInfo.RequiredResources need to be calculated on un-simulated PodGroupInfo.

From my investigation in https://github.com/NVIDIA/KAI-Scheduler/pull/162#pullrequestreview-2863519568, because podGroupInfo now has a cache for `GetTasksToAllocateInitResource`, RequiredResources will always be based on unsimulated results because it is called before job solver gets its hand on the podgroupinfo, which caches the end result for the rest of the scheduler cycle: https://github.com/NVIDIA/KAI-Scheduler/blob/6a1fc6571af1dcacf9f6baf08bf87717c4fafa56/pkg/scheduler/actions/reclaim/reclaim.go#L94


Similarly, CanReclaimResources uses an early fresh off the queue version of job that has not gone through simulations yet.