### PR TITLE
cdi flag added

### DIFF
--- a/deployments/kai-scheduler/templates/services/binder.yaml
+++ b/deployments/kai-scheduler/templates/services/binder.yaml
@@ -28,6 +28,7 @@ spec:
             - "--resource-reservation-pod-image={{ .Values.global.registry }}/{{ .Values.binder.resourceReservationImage.name }}:{{ .Chart.Version }}"
             - "--metrics-bind-address=:{{ .Values.binder.ports.metricsPort }}"
             - "--gpu-sharing-enabled={{ .Values.global.gpuSharing }}"
+            - "--cdi-enabled={{ .Values.global.cdi }}"
           {{- if .Values.binder.additionalArgs }}
             {{- toYaml .Values.binder.additionalArgs | nindent 12 }}
           {{- end }}

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -6,6 +6,7 @@ global:
   securityContext: {}
   imagePullSecrets: []
   gpuSharing: false
+  cdi: false
   clusterAutoscaling: false
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
Related to #47 
I didn't find how to enable cdi when installing the chart, and it's required to use kai in gke.