### PR TITLE
binder cdi flag added

### DIFF
--- a/deployments/kai-scheduler/templates/services/binder.yaml
+++ b/deployments/kai-scheduler/templates/services/binder.yaml
@@ -28,6 +28,7 @@ spec:
             - "--resource-reservation-pod-image={{ .Values.global.registry }}/{{ .Values.binder.resourceReservationImage.name }}:{{ .Chart.Version }}"
             - "--metrics-bind-address=:{{ .Values.binder.ports.metricsPort }}"
             - "--gpu-sharing-enabled={{ .Values.global.gpuSharing }}"
+            - "--cdi-enabled={{ .Values.binder.cdi }}"
           {{- if .Values.binder.additionalArgs }}
             {{- toYaml .Values.binder.additionalArgs | nindent 12 }}
           {{- end }}

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -46,6 +46,7 @@ binder:
     requests:
       cpu: "250m"
       memory: "128Mi"
+  cdi: false
 
 scheduler:
   image:


### PR DESCRIPTION
Related to https://github.com/NVIDIA/KAI-Scheduler/issues/47
I didn't find how to enable cdi when installing the chart, and it's required to use kai in gke.