### PR TITLE
Add plugin for Grove PodGangs

### DIFF
--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -85,6 +85,8 @@ func NewPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 	sparkGrouper := spark.NewSparkGrouper(defaultGrouper)
 	podJobGrouper := podjob.NewPodJobGrouper(defaultGrouper, sparkGrouper)
 
+	podgangGrouper := podgang.NewPodGangGrouper(defaultGrouper)
+
 	table := map[metav1.GroupVersionKind]grouper.Grouper{
 		{
 			Group:   "apps",
@@ -236,6 +238,11 @@ func NewPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 			Version: "v1",
 			Kind:    "SPOTRequest",
 		}: spotrequest.NewSpotRequestGrouper(defaultGrouper),
+		{
+			Group:   "scheduler.grove.io",
+			Version: "v1alpha1",
+			Kind:    "PodGang",
+		}: podgangGrouper,
 	}
 
 	skipTopOwnerGrouper := skiptopowner.NewSkipTopOwnerGrouper(kubeClient, defaultGrouper, table)

--- a/pkg/podgrouper/podgrouper/plugins/podgang/podgang_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/podgang/podgang_grouper.go
@@ -1,0 +1,72 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package podgang
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgroup"
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
+)
+
+type PodGangGrouper struct {
+	*defaultgrouper.DefaultGrouper
+}
+
+func NewPodGangGrouper(defaultGrouper *defaultgrouper.DefaultGrouper) *PodGangGrouper {
+	return &PodGangGrouper{
+		defaultGrouper,
+	}
+}
+
+func (pgg *PodGangGrouper) Name() string {
+	return "PodGang Grouper"
+}
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=patch;update;create
+
+func (pgg *PodGangGrouper) GetPodGroupMetadata(
+	topOwner *unstructured.Unstructured, pod *v1.Pod, _ ...*metav1.PartialObjectMetadata,
+) (*podgroup.Metadata, error) {
+	metadata, err := pgg.DefaultGrouper.GetPodGroupMetadata(topOwner, pod)
+	if err != nil {
+		return nil, err
+	}
+
+	priorityClassName, found, err := unstructured.NestedString(topOwner.Object, "spec", "priorityClassName")
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		metadata.PriorityClassName = priorityClassName
+	}
+
+	minAvailable := 0
+	pgs, found, err := unstructured.NestedSlice(topOwner.Object, "spec", "podgroups")
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range pgs {
+		pgr, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid podgang structure")
+		}
+		minReplicas, found, err := unstructured.NestedInt64(pgr, "minReplicas")
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			minAvailable += minReplicas
+		}
+	}
+	metadata.MinAvailable = int32(minAvailable)
+
+	return metadata, nil
+}

--- a/pkg/podgrouper/podgrouper/plugins/podgang/podgang_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/podgang/podgang_grouper_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package podgang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
+)
+
+const (
+	queueLabelKey    = "kai.scheduler/queue"
+	nodePoolLabelKey = "kai.scheduler/node-pool"
+)
+
+func TestGetPodGroupMetadata(t *testing.T) {
+	podgang := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "PodGang",
+			"apiVersion": "scheduler.grove.io/v1alpha1",
+			"metadata": map[string]interface{}{
+				"name":      "pgs1",
+				"namespace": "test-ns",
+				"uid":       "1",
+				"labels": map[string]interface{}{
+					"test_label": "test_value",
+				},
+				"annotations": map[string]interface{}{
+					"test_annotation": "test_value",
+				},
+			},
+			"spec": map[string]interface{}{
+				"podgroups": []map[string]interface{}{
+					{
+						"podReferences": []map[string]interface{}{
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pga1"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pga2"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pga3"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pga4"
+							},
+						},
+						"minReplicas": 4,
+					},
+					{
+						"podReferences": []map[string]interface{}{
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgb1"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgb2"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgb3"
+							},
+						},
+						"minReplicas": 3,
+					},
+					{
+						"podReferences": []map[string]interface{}{
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgc1"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgc2"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgc3"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgc4"
+							},
+							{
+								"namespace": "test-ns"
+								"name": "pgs1-pgc5"
+							},
+						},
+						"minReplicas": 5,
+					},
+				},
+				"priorityClassName": "inference",
+			},
+		},
+	}
+
+	pod1 := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pgs1-pga1",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				queueLabelKey: "test_queue",
+			},
+			UID: "3",
+		},
+		Spec:   v1.PodSpec{},
+		Status: v1.PodStatus{},
+	}
+
+	grouper := NewPodGangGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	metadata, err := grouper.GetPodGroupMetadata(podgang, pod1)
+	assert.Nil(t, err)
+	assert.Equal(t, 12, metadata.minAvailable)
+	assert.Equal(t, constants.InferencePriorityClass, metadata.PriorityClassName)
+	assert.Equal(t, "test_queue", metadata.Queue)
+}


### PR DESCRIPTION
This PR creates a PodGrouper plugin for Grove PodGangs. The Grove PodGang API can be found here:
https://github.com/NVIDIA/grove/blob/main/scheduler/api/core/v1alpha1/podgang.go

The plugin builds on top of defaultgrouper and then sets values for priorityClassName and minAvailable in the KAI podgroup. Currently, the KAI PodGroup is a represents a logically flattened Grove PodGang structure. Hence, the value for minAvailable in the KAI PodGroup is the sum of all the minReplicas from the slice of PodGroups defined in the Grove PodGang.