### PR TITLE
Scheduler status update unitest improvment

### DIFF
--- a/pkg/scheduler/cache/status_updater/pod_group_status_sync_test.go
+++ b/pkg/scheduler/cache/status_updater/pod_group_status_sync_test.go
@@ -185,6 +185,15 @@ var _ = Describe("Status Updater - Pod Groups Syncing", func() {
 			podGroupsFromCluster = append(podGroupsFromCluster, podGroup.DeepCopy())
 		}
 
+		Eventually(func() int {
+			numberOfPodGroupInFlight := 0
+			statusUpdater.inFlightPodGroups.Range(func(key any, value any) bool {
+				numberOfPodGroupInFlight += 1
+				return true
+			})
+			return numberOfPodGroupInFlight
+		}, time.Second*20, time.Millisecond*50).Should(Equal(0))
+
 		statusUpdater.SyncPodGroupsWithPendingUpdates(podGroupsFromCluster)
 
 		// check that the inFlight and applied pod groups cache are empty


### PR DESCRIPTION
Wait for the pod group updates to be applied before Running the first PodGroupSync in the "should clear update cache after it syncs with pods groups that are updated" unitest