### PR TITLE
pod labels for pre and post install hooks

### DIFF
--- a/deployments/kai-scheduler/templates/services/post-install-hook.yaml
+++ b/deployments/kai-scheduler/templates/services/post-install-hook.yaml
@@ -13,6 +13,9 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        app: post-install-hook
     spec:
       serviceAccountName: webhookmanager
       restartPolicy: Never

--- a/deployments/kai-scheduler/templates/services/pre-install-hook.yaml
+++ b/deployments/kai-scheduler/templates/services/pre-install-hook.yaml
@@ -13,6 +13,9 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        app: pre-install-hook
     spec:
       serviceAccountName: webhookmanager
       restartPolicy: Never


### PR DESCRIPTION
The `Job` for these have metadata labels but the spec is missing the same.  It is useful to have the same labels on the pods so you can do things like, for example, attach cilium policy predictably to the pods that are created by the job.