### PR TITLE
Fix default_status_updater so Annotation updates are properly applied

### DIFF
--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -524,7 +524,7 @@ func TestDefaultStatusUpdater_RecordJobStatusEvent(t *testing.T) {
 				},
 			},
 			expectedEventActions:      []string{},
-			expectedInFlightPodGroups: 0,
+			expectedInFlightPodGroups: 1,
 			expectedInFlightPods:      0,
 		},
 		{

--- a/pkg/scheduler/plugins/minruntime/minruntime.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime.go
@@ -38,6 +38,9 @@ type minruntimePlugin struct {
 
 func parseMinRuntime(arguments map[string]string, minRuntimeConfig string) metav1.Duration {
 	minRuntime := arguments[minRuntimeConfig]
+	if len(minRuntime) == 0 {
+		return metav1.Duration{Duration: 0 * time.Second}
+	}
 	duration, err := time.ParseDuration(minRuntime)
 	if err != nil {
 		log.InfraLogger.Errorf("Failed to parse %v (%v): %v, using default value 0s", minRuntimeConfig, minRuntime, err)
@@ -54,7 +57,10 @@ func New(arguments map[string]string) framework.Plugin {
 
 	validResolveMethods := []string{resolveMethodLCA, resolveMethodQueue}
 	plugin.reclaimResolveMethod = arguments[reclaimResolveMethod]
-	if len(plugin.reclaimResolveMethod) == 0 || !slices.Contains(validResolveMethods, plugin.reclaimResolveMethod) {
+	if len(plugin.reclaimResolveMethod) == 0 {
+		plugin.reclaimResolveMethod = resolveMethodLCA
+	}
+	if !slices.Contains(validResolveMethods, plugin.reclaimResolveMethod) {
 		log.InfraLogger.Errorf("Invalid reclaim resolve method %v, using default value %v", plugin.reclaimResolveMethod, resolveMethodLCA)
 		plugin.reclaimResolveMethod = resolveMethodLCA
 	}

--- a/pkg/scheduler/plugins/minruntime/resolver.go
+++ b/pkg/scheduler/plugins/minruntime/resolver.go
@@ -58,7 +58,6 @@ func (r *resolver) resolvePreemptMinRuntime(
 			minRuntime = *currentQueue.PreemptMinRuntime
 			break
 		}
-
 		currentQueue = r.queues[currentQueue.ParentQueue]
 	}
 
@@ -107,18 +106,7 @@ func (r *resolver) resolveReclaimMinRuntimeQueue(
 			minRuntime = *currentQueue.ReclaimMinRuntime
 			break
 		}
-
-		// Move to parent queue if it exists
-		if currentQueue.ParentQueue != "" {
-			parentQueue, found := r.queues[currentQueue.ParentQueue]
-			if found {
-				currentQueue = parentQueue
-				continue
-			}
-		}
-
-		// Break if no more parent queues
-		break
+		currentQueue = r.queues[currentQueue.ParentQueue]
 	}
 
 	// If no reclaim-min-runtime is set in the queue tree, use default
@@ -180,7 +168,7 @@ func (r *resolver) resolveReclaimMinRuntimeLCA(
 		lcaIndex++
 	}
 
-	duration := r.defaultPreemptMinRuntime
+	duration := r.defaultReclaimMinRuntime
 
 	// From the current LCA or child of LCA, move up towards root and select first available override
 	for i := lcaIndex; i >= 0; i-- {
@@ -209,18 +197,7 @@ func (r *resolver) getQueueHierarchyPath(
 	for currentQueue != nil {
 		// Add current queue to the path (at beginning to maintain parent->child order)
 		hierarchyPath = append([]*queue_info.QueueInfo{currentQueue}, hierarchyPath...)
-
-		// If queue has a parent, add it to the path
-		if currentQueue.ParentQueue != "" {
-			parentQueue, found := r.queues[currentQueue.ParentQueue]
-			if found {
-				currentQueue = parentQueue
-				continue
-			}
-		}
-
-		// Break if no more parents (reached top-level)
-		break
+		currentQueue = r.queues[currentQueue.ParentQueue]
 	}
 
 	return hierarchyPath

--- a/test/e2e/modules/utils/logs.go
+++ b/test/e2e/modules/utils/logs.go
@@ -38,7 +38,7 @@ func LogClusterState(client runtimeClient.WithWatch, logger logr.Logger) {
 	if err != nil {
 		return
 	}
-	logger.Info(fmt.Sprintf("Falied test cluster state - E2e pods: \n%v", podListPrinting(e2ePods)))
+	logger.Info(fmt.Sprintf("Failed test cluster state - E2e pods: \n%v", podListPrinting(e2ePods)))
 }
 
 func podListPrinting(podList *v1.PodList) string {
@@ -58,7 +58,7 @@ func podListPrinting(podList *v1.PodList) string {
 		for _, condition := range pod.Status.Conditions {
 			if condition.Type == v1.PodScheduled && condition.Status == v1.ConditionFalse {
 				podListRepresentationString.WriteString(
-					fmt.Sprintf("\tScheduling falied: %s\n", condition.Message),
+					fmt.Sprintf("\tScheduling failed: %s\n", condition.Message),
 				)
 			}
 		}

--- a/test/e2e/suites/reclaim/reclaim_test.go
+++ b/test/e2e/suites/reclaim/reclaim_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Reclaim", Ordered, func() {
 			testCtx = testcontext.GetConnectivity(ctx, Default)
 			parentQueue, reclaimeeQueue, reclaimerQueue := createQueues(4, 1, 0)
 			reclaimerQueue.Spec.Priority = pointer.Int(constants.DefaultQueuePriority + 1)
-			reclaimeeQueue.Spec.ReclaimMinRuntime = &metav1.Duration{Duration: 90 * time.Second}
+			reclaimeeQueue.Spec.ReclaimMinRuntime = &metav1.Duration{Duration: 60 * time.Second}
 			testCtx.InitQueues([]*v2.Queue{parentQueue, reclaimeeQueue, reclaimerQueue})
 
 			pod := createPod(ctx, testCtx, reclaimeeQueue, 1)


### PR DESCRIPTION
This fixes the issue introduced in https://github.com/NVIDIA/KAI-Scheduler/commit/ac873ab1c77472d27c181f2b3d21b727274f5cfd that causes LastStartTimestamp and StaleTimestamp to not be patched in when the entire podgroup is scheduled at once. 

Also fixes minruntime using the wrong default value for reclaims, and cleans up the code to be leaner and error less (old code would print errors when default values were not set, which would log errors on every scheduling loop. Now if they arent set we just assume the hardcoded defaults).