### PR TITLE
ignore EINVAL when flushing logs

### DIFF
--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -49,7 +49,8 @@ var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum
 
 func flushLogs() {
 	if err := log.InfraLogger.Sync(); err != nil &&
-		!errors.Is(err, syscall.ENOTTY) { // https://github.com/uber-go/zap/issues/991#issuecomment-962098428
+		!errors.Is(err, syscall.ENOTTY) && // https://github.com/uber-go/zap/issues/991#issuecomment-962098428
+		!errors.Is(err, syscall.EINVAL) {  // https://github.com/uber-go/zap/issues/328
 		fmt.Fprintf(os.Stderr, "failed to flush logs: %v\n", err)
 	}
 }


### PR DESCRIPTION
Running the `scheduler` in EKS, every 5 mins an error is logging:

```
failed to flush logs: sync /dev/stderr: invalid argument
```

https://github.com/uber-go/zap/issues/328 details the pain here which comes down to stderr not being syncable in all environments.