### PR TITLE
fix coverage report for prs from forks

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -39,17 +39,39 @@ jobs:
     name: Code Coverage Report
     runs-on: ubuntu-latest
     needs: validate-and-test
-    permissions:
-      contents: read
-      actions: read
-      pull-requests: write
+    outputs:
+      report: ${{ steps.coverage_reporter.outputs.coverage_report }}
     steps:
       - uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682
+        id: coverage_reporter
         with:
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "coverage.out"
           root-package: "github.com/NVIDIA/KAI-scheduler"
           github-baseline-workflow-ref: update-coverage-badge.yaml
+          skip-comment: true
+
+  upload-report:
+    name: Upload Coverage Report For Commenting
+    runs-on: ubuntu-latest
+    needs: code-coverage-report
+    steps:
+      - name: Save coverage report to file
+        env:
+          REPORT_BODY: ${{ needs.code-coverage-report.outputs.report }}
+        run: echo "$REPORT_BODY" > coverage-report.txt
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-for-comment
+          path: coverage-report.txt
+      - name: Save PR number
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number-for-comment
+          path: pr_number.txt
 
   build:
     name: Build

--- a/.github/workflows/post-coverage-comment.yaml
+++ b/.github/workflows/post-coverage-comment.yaml
@@ -1,0 +1,46 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+name: KAI Scheduler - Post Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["KAI Scheduler - Pull Request"]
+    types:
+      - completed
+
+jobs:
+  post-coverage-comment:
+    name: Post Coverage Comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report-for-comment
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number-for-comment
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = fs.readFileSync('pr_number.txt', 'utf8').trim();
+            const reportBody = fs.readFileSync('coverage-report.txt', 'utf8');
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: reportBody
+            }); 


### PR DESCRIPTION
based on the issues raised here:
https://github.com/fgrosse/go-coverage-report/issues/15#issuecomment-2053744419
and the solution suggested here:
https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/