### PR TITLE
fix: pod group controller fails on missing priority class

### DIFF
--- a/pkg/podgroupcontroller/utilities/pod-group/preemptible_test.go
+++ b/pkg/podgroupcontroller/utilities/pod-group/preemptible_test.go
@@ -110,8 +110,8 @@ func TestIsPreemptibleJob(t *testing.T) {
 					},
 				},
 			},
-			false,
 			true,
+			false,
 		},
 		{
 			"Custom preemptable class",


### PR DESCRIPTION
When a PodGroup is created with a PriorityClass that doesn't exist the current behavior will just fail the pod group controller from updating the status. We will want it to at least update the resources status if possible and mark the podGroup as preemptible because this is how the scheduler treats it