### PR TITLE
Fix priorityclass not namespaced (#279)

### DIFF
--- a/pkg/podgroupcontroller/controllers/status_updater_test.go
+++ b/pkg/podgroupcontroller/controllers/status_updater_test.go
@@ -76,8 +76,7 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
@@ -137,8 +136,7 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
@@ -205,15 +203,13 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 100,
 					},
@@ -273,15 +269,13 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 100,
 					},
@@ -346,15 +340,13 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 100,
 					},
@@ -423,15 +415,13 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 100,
 					},
@@ -494,15 +484,13 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 100,
 					},
@@ -565,15 +553,13 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 100,
 					},
@@ -636,8 +622,7 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
@@ -718,8 +703,7 @@ func Test_handlePodGroupStatus(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},

--- a/pkg/podgroupcontroller/utilities/pod-group/preemptible.go
+++ b/pkg/podgroupcontroller/utilities/pod-group/preemptible.go
@@ -42,7 +42,7 @@ func getPodGroupPriority(ctx context.Context, podGroup *v2alpha2.PodGroup, kubeC
 	priorityClass := schedulingv1.PriorityClass{}
 	err := kubeClient.Get(
 		ctx,
-		types.NamespacedName{Namespace: podGroup.Namespace, Name: podGroup.Spec.PriorityClassName},
+		types.NamespacedName{Name: podGroup.Spec.PriorityClassName},
 		&priorityClass,
 	)
 	if err != nil {

--- a/pkg/podgroupcontroller/utilities/pod-group/preemptible_test.go
+++ b/pkg/podgroupcontroller/utilities/pod-group/preemptible_test.go
@@ -41,15 +41,13 @@ func TestIsPreemptibleJob(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 125,
 					},
@@ -72,15 +70,13 @@ func TestIsPreemptibleJob(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c1",
-							Namespace: "n1",
+							Name: "c1",
 						},
 						Value: 75,
 					},
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c2",
 						},
 						Value: 125,
 					},
@@ -103,8 +99,7 @@ func TestIsPreemptibleJob(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c2",
-							Namespace: "n1",
+							Name: "c3",
 						},
 						Value: 125,
 					},
@@ -127,8 +122,7 @@ func TestIsPreemptibleJob(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c3",
-							Namespace: "n1",
+							Name: "c3",
 						},
 						Value: 83,
 					},
@@ -151,8 +145,7 @@ func TestIsPreemptibleJob(t *testing.T) {
 				[]client.Object{
 					&schedulingv1.PriorityClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "c3",
-							Namespace: "n1",
+							Name: "c3",
 						},
 						Value: 200,
 					},


### PR DESCRIPTION
cherry pick of https://github.com/NVIDIA/KAI-Scheduler/pull/279
* priority classes are not namespaced - little fix
