### PR TITLE
Added rbac for Grove PodCliqueScalingGroup

### DIFF
--- a/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -125,6 +125,7 @@ rules:
   - grove.io
   resources:
   - podcliques
+  - podcliquescalinggroups
   - podgangsets
   verbs:
   - get
@@ -134,6 +135,7 @@ rules:
   - grove.io
   resources:
   - podcliques/finalizers
+  - podcliquescalinggroups/finalizers
   - podgangsets/finalizers
   verbs:
   - create

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -41,6 +41,8 @@ func (gg *GroveGrouper) Name() string {
 // +kubebuilder:rbac:groups=grove.io,resources=podgangsets/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques/finalizers,verbs=patch;update;create
+// +kubebuilder:rbac:groups=grove.io,resources=podcliquescalinggroups,verbs=get;list;watch
+// +kubebuilder:rbac:groups=grove.io,resources=podcliquescalinggroups/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=scheduler.grove.io,resources=podgangs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=scheduler.grove.io,resources=podgangs/finalizers,verbs=patch;update;create
 


### PR DESCRIPTION
When a PodClique is part of a PodCliqueScalingGroup, the PCSG resource will be owner reference[0].