### PR TITLE
Remove unnecessary deepcopy to optimize performance

### DIFF
--- a/pkg/scheduler/cache/cluster_info/cluster_info.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info.go
@@ -378,7 +378,7 @@ func (c *ClusterInfo) getNodeToPodInfosMap(allPods []*v1.Pod, bindRequests bindr
 	nodeReservationPodInfosMap := map[string][]*pod_info.PodInfo{}
 	for _, pod := range allPods {
 		podBindRequest := bindRequests.GetBindRequestForPod(pod)
-		podInfo := pod_info.NewTaskInfoWithBindRequest(pod.DeepCopy(), podBindRequest)
+		podInfo := pod_info.NewTaskInfoWithBindRequest(pod, podBindRequest)
 
 		if pod_info.IsResourceReservationTask(podInfo.Pod) {
 			podInfos := nodeReservationPodInfosMap[podInfo.NodeName]


### PR DESCRIPTION
This PR can partially optimize this [issue](https://github.com/NVIDIA/KAI-Scheduler/issues/315).

After testing, under the same environment (cluster with 4000+ nodes and 140000+ pods), the snapshot analysis time can be reduced from around 2 seconds to around 1 second.