### PR TITLE
v0.6 cherrypick of https://github.com/NVIDIA/KAI-Scheduler/pull/313

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v0.6.8] - 2025-07-13
+
+### Fixed
+- Fixed a miscalculation where cpu/memory releasing resources were considered idle when requesting GPU fraction/memory
+
 ## [v0.6.7] - 2025-07-07
+
 ### Added
 - Added LeaderWorkerSet support in the podGrouper. Each replica will be given a separate podGroup.
 

--- a/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
@@ -182,5 +182,69 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 				},
 			},
 		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Pending job requests gpu memory while other job terminates",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                  "pending_job-0",
+						RequiredGpuMemory:     50,
+						RequiredMemoryPerTask: 1500,
+						Priority:              constants.PriorityBuildNumber,
+						QueueName:             "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:     pod_status.Pending,
+								GPUGroups: []string{"0"},
+							},
+						},
+					},
+					{
+						Name:                  "running_job-0",
+						RequiredMemoryPerTask: 1000,
+						Priority:              constants.PriorityBuildNumber,
+						QueueName:             "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:     pod_status.Releasing,
+								GPUGroups: []string{"0"},
+								NodeName:  "node0",
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs:      1,
+						CPUMemory: 2000,
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:         "queue0",
+						DeservedGPUs: 1,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"pending_job-0": {
+						Status:         pod_status.Pipelined,
+						MemoryRequired: 1500,
+						GPUGroups:      []string{"0"},
+					},
+					"running_job-0": {
+						Status:         pod_status.Releasing,
+						GPUGroups:      []string{"0"},
+						MemoryRequired: 1000,
+						NodeName:       "node0",
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds:      0,
+						NumberOfPipelineActions: 1,
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/scheduler/api/node_info/gpu_sharing_node_info.go
+++ b/pkg/scheduler/api/node_info/gpu_sharing_node_info.go
@@ -329,10 +329,6 @@ func (ni *NodeInfo) getGpuMemoryFractionalOnNode(memory int64) float64 {
 	return math.Ceil(exactFraction*100) / 100
 }
 
-func (ni *NodeInfo) taskAllocatableOnNonAllocatedNonGPUResources(pod *pod_info.PodInfo) bool {
-	return pod.ResReq.BaseResource.LessEqual(&ni.NonAllocatedResources().BaseResource)
-}
-
 func (ni *NodeInfo) fractionTaskGpusAllocatableDeviceCount(pod *pod_info.PodInfo) int64 {
 	matchingGpuGroupsCount := int64(0)
 	for gpuGroup := range ni.UsedSharedGPUsMemory {

--- a/pkg/scheduler/api/node_info/node_info.go
+++ b/pkg/scheduler/api/node_info/node_info.go
@@ -299,7 +299,7 @@ func (ni *NodeInfo) isTaskAllocatableOnNonAllocatedResources(
 		return ni.lessEqualTaskToNodeResources(task.ResReq, nodeNonAllocatedResources)
 	}
 
-	if !ni.taskAllocatableOnNonAllocatedNonGPUResources(task) {
+	if !task.ResReq.BaseResource.LessEqual(&nodeNonAllocatedResources.BaseResource) {
 		return false
 	}
 


### PR DESCRIPTION
Fixed a miscalculation where cpu/memory releasing resources were considered idle when requesting GPU fraction/memory