### PR TITLE
Natasha/add queue metrics

### DIFF
--- a/cmd/queuecontroller/app/app.go
+++ b/cmd/queuecontroller/app/app.go
@@ -21,8 +21,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/queuecontroller/controllers"
+	"github.com/NVIDIA/KAI-scheduler/pkg/queuecontroller/metrics"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -47,9 +49,14 @@ func Run() error {
 
 	initLogger()
 
+	metrics.InitMetrics(opts.MetricsNamespace, opts.QueueLabelToMetricLabel.Get(), opts.QueueLabelToDefaultMetricValue.Get())
+
 	var err error
 	options := ctrl.Options{
-		Scheme:           scheme,
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: opts.MetricsAddress,
+		},
 		LeaderElection:   opts.EnableLeaderElection,
 		LeaderElectionID: "42ece193.run.ai",
 	}

--- a/cmd/queuecontroller/app/options.go
+++ b/cmd/queuecontroller/app/options.go
@@ -5,14 +5,31 @@ package app
 
 import (
 	"flag"
+
+	kaiflags "github.com/NVIDIA/KAI-scheduler/pkg/common/flags"
+)
+
+const (
+	defaultSchedulingQueueLabelKey = "kai.scheduler/queue"
+	defaultMetricsNamespace        = "kai"
+	defaultMetricsAddress          = ":8080"
 )
 
 type Options struct {
 	EnableLeaderElection    bool
 	SchedulingQueueLabelKey string
+
+	MetricsAddress                 string
+	MetricsNamespace               string
+	QueueLabelToMetricLabel        kaiflags.StringMapFlag
+	QueueLabelToDefaultMetricValue kaiflags.StringMapFlag
 }
 
 func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	fs.StringVar(&o.SchedulingQueueLabelKey, "queue-label-key", "kai.scheduler/queue", "Scheduling queue label key name")
+	fs.StringVar(&o.SchedulingQueueLabelKey, "queue-label-key", defaultSchedulingQueueLabelKey, "Scheduling queue label key name.")
+	fs.StringVar(&o.MetricsAddress, "metrics-listen-address", defaultMetricsAddress, "The address the metrics endpoint binds to.")
+	fs.StringVar(&o.MetricsNamespace, "metrics-namespace", defaultMetricsNamespace, "Metrics namespace.")
+	fs.Var(&o.QueueLabelToMetricLabel, "queue-label-to-metric-label", "Map of queue label keys to metric label keys, e.g. 'foo=bar,baz=qux'.")
+	fs.Var(&o.QueueLabelToDefaultMetricValue, "queue-label-to-default-metric-value", "Map of queue label keys to default metric values, in case the label doesn't exist on the queue, e.g. 'foo=1,baz=0'.")
 }

--- a/pkg/common/flags/flags_test.go
+++ b/pkg/common/flags/flags_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestCommonFlags(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "common flags tests")
+}
+
+var _ = Describe("StringMapFlag", func() {
+	It("parses an empty string as an empty map", func() {
+		var m StringMapFlag
+		Expect(m.Set("")).To(Succeed())
+		Expect(m.Get()).To(BeEmpty())
+	})
+
+	It("parses a single key=value pair", func() {
+		var m StringMapFlag
+		Expect(m.Set("foo=bar")).To(Succeed())
+		Expect(m.Get()).To(HaveKeyWithValue("foo", "bar"))
+		Expect(len(m.Get())).To(Equal(1))
+	})
+
+	It("parses multiple key=value pairs", func() {
+		var m StringMapFlag
+		Expect(m.Set("foo=bar,baz=qux")).To(Succeed())
+		Expect(m.Get()).To(HaveKeyWithValue("foo", "bar"))
+		Expect(m.Get()).To(HaveKeyWithValue("baz", "qux"))
+		Expect(len(m.Get())).To(Equal(2))
+	})
+
+	It("overwrites duplicate keys with the last value", func() {
+		var m StringMapFlag
+		Expect(m.Set("foo=bar,foo=baz")).To(Succeed())
+		Expect(m.Get()).To(HaveKeyWithValue("foo", "baz"))
+		Expect(len(m.Get())).To(Equal(1))
+	})
+
+	It("returns an error for invalid input", func() {
+		var m StringMapFlag
+		err := m.Set("foo,bar=baz")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("String() returns the correct string representation", func() {
+		var m StringMapFlag
+		err := m.Set("foo=bar,baz=qux")
+		Expect(err).ToNot(HaveOccurred())
+		str := m.String()
+		// Accept either order
+		Expect([]string{str, reversePairs(str)}).To(ContainElement("foo=bar,baz=qux"))
+	})
+})
+
+// Helper to reverse the order of pairs in a comma-separated string
+func reversePairs(s string) string {
+	pairs := []rune(s)
+	for i, j := 0, len(pairs)-1; i < j; i, j = i+1, j-1 {
+		pairs[i], pairs[j] = pairs[j], pairs[i]
+	}
+	return string(pairs)
+}

--- a/pkg/common/flags/string_map.go
+++ b/pkg/common/flags/string_map.go
@@ -1,0 +1,46 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+type StringMapFlag map[string]string
+
+func (m *StringMapFlag) Get() map[string]string {
+	if *m == nil {
+		return make(map[string]string)
+	}
+	return *m
+}
+
+func (m *StringMapFlag) String() string {
+	// Convert map to string: key1=val1,key2=val2
+	var pairs []string
+	for k, v := range *m {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(pairs, ",")
+}
+
+func (m *StringMapFlag) Set(value string) error {
+	// Convert string to map: key1=val1,key2=val2
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	if value == "" {
+		return nil
+	}
+	pairs := strings.Split(value, ",")
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("invalid map item: %q", pair)
+		}
+		(*m)[kv[0]] = kv[1]
+	}
+	return nil
+}

--- a/pkg/queuecontroller/controllers/queue_controller.go
+++ b/pkg/queuecontroller/controllers/queue_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/queuecontroller/common"
 	"github.com/NVIDIA/KAI-scheduler/pkg/queuecontroller/controllers/childqueues_updater"
 	"github.com/NVIDIA/KAI-scheduler/pkg/queuecontroller/controllers/resource_updater"
+	"github.com/NVIDIA/KAI-scheduler/pkg/queuecontroller/metrics"
 )
 
 // QueueReconciler reconciles a Queue object
@@ -72,6 +73,8 @@ func (r *QueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch status for queue %s, error: %v", queue.Name, err)
 	}
+
+	metrics.SetQueueMetrics(queue)
 
 	return ctrl.Result{}, err
 }

--- a/pkg/queuecontroller/controllers/queue_controller.go
+++ b/pkg/queuecontroller/controllers/queue_controller.go
@@ -55,7 +55,12 @@ func (r *QueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	queue := &v2.Queue{}
 	err := r.Get(ctx, req.NamespacedName, queue)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		ignoreNotFoundErr := client.IgnoreNotFound(err)
+		if ignoreNotFoundErr == nil {
+			// If the queue is not found, reset its metrics
+			metrics.ResetQueueMetrics(queue.Name)
+		}
+		return ctrl.Result{}, ignoreNotFoundErr
 	}
 	originalQueue := queue.DeepCopy()
 

--- a/pkg/queuecontroller/metrics/metrics.go
+++ b/pkg/queuecontroller/metrics/metrics.go
@@ -1,0 +1,162 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto" // auto-registry collectors in default registry
+
+	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
+)
+
+const (
+	milliCpuToCpuDivider       = 1000
+	megabytesToBytesMultiplier = 1000000
+	unlimitedQuota             = float64(-1)
+)
+
+var (
+	queueInfo         *prometheus.GaugeVec
+	queueDeservedGPUs *prometheus.GaugeVec
+	queueQuotaCPU     *prometheus.GaugeVec
+	queueQuotaMemory  *prometheus.GaugeVec
+
+	additionalQueueLabelKeys       []string
+	queueLabelToDefaultMetricValue map[string]string
+)
+
+func init() {
+	InitMetrics("", map[string]string{}, map[string]string{})
+}
+
+// InitMetrics initializes the metrics for the queue controller.
+// params:
+//
+//	namespace: the Prometheus namespace for the metrics
+//	queueLabelToMetricLabelMap: a map of queue label keys to metric label keys
+//	queueLabelToDefaultMetricValueMap: a map of queue label keys to default metric values
+//
+// For example, if a queue has a label "priority" with value "high",
+// and you want to use it as a metric label "queue_priority",
+// with a default value of "normal" if the label is not present,
+// you would pass:
+// queueLabelToMetricLabelMap        = map[string]string{"priority": "queue_priority"}
+// queueLabelToDefaultMetricValueMap = map[string]string{"priority": "normal"}
+func InitMetrics(namespace string, queueLabelToMetricLabelMap, queueLabelToDefaultMetricValueMap map[string]string) {
+	additionalMetricLabels := make([]string, 0, len(queueLabelToMetricLabelMap))
+
+	for queueLabelKey, metricLabel := range queueLabelToMetricLabelMap {
+		additionalQueueLabelKeys = append(additionalQueueLabelKeys, queueLabelKey)
+		additionalMetricLabels = append(additionalMetricLabels, metricLabel)
+	}
+
+	queueLabelToDefaultMetricValue = queueLabelToDefaultMetricValueMap
+
+	queueInfo = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "queue_info",
+			Help:      "Queues info",
+		}, append([]string{"queue_name", "gpu_guaranteed_quota", "cpu_quota", "memory_quota"}, additionalMetricLabels...),
+	)
+
+	queueDeservedGPUs = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "queue_deserved_gpus",
+			Help:      "Queue deserved GPUs",
+		}, append([]string{"queue_name"}, additionalMetricLabels...),
+	)
+
+	queueQuotaCPU = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "queue_quota_cpu_cores",
+			Help:      "Queue quota CPU",
+		}, append([]string{"queue_name"}, additionalMetricLabels...),
+	)
+
+	queueQuotaMemory = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "queue_quota_memory_bytes",
+			Help:      "Queue quota memory",
+		}, append([]string{"queue_name"}, additionalMetricLabels...),
+	)
+}
+
+func SetQueueMetrics(queue *v2.Queue) {
+	if queue == nil {
+		return
+	}
+
+	additionalMetricLabelValues := getAdditionalMetricLabelValues(queue.Labels)
+
+	queueName := queue.Name
+	gpuQuota := getGpuQuota(queue.Spec.Resources)
+	cpuQuota := getCpuQuota(queue.Spec.Resources)
+	memoryQuota := getMemoryQuota(queue.Spec.Resources)
+
+	queueInfoMetricValues := append([]string{queueName,
+		strconv.FormatFloat(gpuQuota, 'f', -1, 64),
+		strconv.FormatFloat(cpuQuota, 'f', -1, 64),
+		strconv.FormatInt(int64(memoryQuota), 10)}, additionalMetricLabelValues...)
+	queueQuotaMetricValues := append([]string{queueName}, additionalMetricLabelValues...)
+
+	queueInfo.WithLabelValues(queueInfoMetricValues...).Set(1)
+	queueDeservedGPUs.WithLabelValues(queueQuotaMetricValues...).Set(gpuQuota)
+	queueQuotaCPU.WithLabelValues(queueQuotaMetricValues...).Set(cpuQuota)
+	queueQuotaMemory.WithLabelValues(queueQuotaMetricValues...).Set(memoryQuota)
+
+}
+
+func getGpuQuota(queueSpecResources *v2.QueueResources) float64 {
+	if queueSpecResources == nil {
+		return float64(0)
+	}
+	return queueSpecResources.GPU.Quota
+}
+
+func getCpuQuota(queueSpecResources *v2.QueueResources) float64 {
+	if queueSpecResources == nil {
+		return float64(0)
+	}
+	cpuQuota := queueSpecResources.CPU.Quota
+	if cpuQuota == unlimitedQuota {
+		return unlimitedQuota
+	}
+	return queueSpecResources.CPU.Quota / milliCpuToCpuDivider
+}
+
+func getMemoryQuota(queueSpecResources *v2.QueueResources) float64 {
+	if queueSpecResources == nil {
+		return float64(0)
+	}
+	memoryQuota := queueSpecResources.Memory.Quota
+	if memoryQuota == unlimitedQuota {
+		return unlimitedQuota
+	}
+	return memoryQuota * megabytesToBytesMultiplier
+}
+
+func getAdditionalMetricLabelValues(queueLabels map[string]string) []string {
+	labelValues := make([]string, len(additionalQueueLabelKeys))
+
+	// we already added the additional metric labels to each metric using the original order,
+	// so we can just iterate over the additionalQueueLabelKeys - they should have the same order.
+
+	for i, queueLabelKey := range additionalQueueLabelKeys {
+		if value, exists := queueLabels[queueLabelKey]; exists {
+			labelValues[i] = value
+		} else if defaultValue, defaultExists := queueLabelToDefaultMetricValue[queueLabelKey]; defaultExists {
+			labelValues[i] = defaultValue
+		} else {
+			labelValues[i] = "" // Default to empty string if no value exists
+		}
+	}
+	return labelValues
+
+}

--- a/pkg/queuecontroller/metrics/metrics_test.go
+++ b/pkg/queuecontroller/metrics/metrics_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestQueueMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "queuecontroller metrics tests")
+}
+
+var _ = Describe("Queue Metrics", Ordered, func() {
+	var queue *v2.Queue
+
+	BeforeAll(func() {
+		InitMetrics("testns",
+			map[string]string{"priority": "queue_priority", "some-other-label": "some_other_label"},
+			map[string]string{"priority": "normal"},
+		)
+	})
+
+	AfterEach(func() {
+		ResetQueueMetrics("test-queue")
+	})
+
+	It("should create metrics with correct labels for a queue with the label", func() {
+		queue = &v2.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "test-queue",
+				Labels: map[string]string{"priority": "high", "some-other-label": "value"},
+			},
+			Spec: v2.QueueSpec{
+				Resources: &v2.QueueResources{
+					GPU:    v2.QueueResource{Quota: 2},
+					CPU:    v2.QueueResource{Quota: 500},
+					Memory: v2.QueueResource{Quota: 4},
+				},
+			},
+		}
+		SetQueueMetrics(queue)
+
+		labels := []string{"test-queue", "high", "value"}
+
+		// Use the helper for all metrics
+		expectMetricValue(queueInfo, append([]string{"test-queue", "2", "0.5", "4000000"}, labels[1:]...), 1)
+		expectMetricValue(queueDeservedGPUs, labels, 2)
+		expectMetricValue(queueQuotaCPU, labels, 0.5)
+		expectMetricValue(queueQuotaMemory, labels, 4000000)
+	})
+
+	It("should use default label value if label is missing", func() {
+		queue = &v2.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue",
+			},
+			Spec: v2.QueueSpec{
+				Resources: &v2.QueueResources{
+					GPU:    v2.QueueResource{Quota: 0.7},
+					CPU:    v2.QueueResource{Quota: 1000},
+					Memory: v2.QueueResource{Quota: 2},
+				},
+			},
+		}
+		SetQueueMetrics(queue)
+
+		labels := []string{"test-queue", "normal", ""}
+
+		expectMetricValue(queueInfo, append([]string{"test-queue", "0.7", "1", "2000000"}, labels[1:]...), 1)
+		expectMetricValue(queueDeservedGPUs, labels, 0.7)
+		expectMetricValue(queueQuotaCPU, labels, 1)
+		expectMetricValue(queueQuotaMemory, labels, 2000000)
+	})
+
+	It("should use empty string if label and default are missing", func() {
+		queue = &v2.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue",
+			},
+			Spec: v2.QueueSpec{
+				Resources: &v2.QueueResources{
+					GPU:    v2.QueueResource{Quota: 1},
+					CPU:    v2.QueueResource{Quota: 1000},
+					Memory: v2.QueueResource{Quota: 2},
+				},
+			},
+		}
+		SetQueueMetrics(queue)
+
+		labels := []string{"test-queue", "normal", ""}
+
+		expectMetricValue(queueInfo, append([]string{"test-queue", "1", "1", "2000000"}, labels[1:]...), 1)
+		expectMetricValue(queueDeservedGPUs, labels, 1)
+		expectMetricValue(queueQuotaCPU, labels, 1)
+		expectMetricValue(queueQuotaMemory, labels, 2000000)
+	})
+
+	It("should delete metrics when queue is deleted", func() {
+		queue = &v2.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "test-queue",
+				Labels: map[string]string{"priority": "high"},
+			},
+			Spec: v2.QueueSpec{
+				Resources: &v2.QueueResources{
+					GPU:    v2.QueueResource{Quota: 2},
+					CPU:    v2.QueueResource{Quota: 2000},
+					Memory: v2.QueueResource{Quota: 4},
+				},
+			},
+		}
+		SetQueueMetrics(queue)
+		ResetQueueMetrics("test-queue")
+
+		// After deletion, all metrics should not exist (should return 0)
+		gathered := testutil.CollectAndCount(queueInfo)
+		Expect(gathered).To(Equal(0))
+		gathered = testutil.CollectAndCount(queueDeservedGPUs)
+		Expect(gathered).To(Equal(0))
+		gathered = testutil.CollectAndCount(queueQuotaCPU)
+		Expect(gathered).To(Equal(0))
+		gathered = testutil.CollectAndCount(queueQuotaMemory)
+		Expect(gathered).To(Equal(0))
+	})
+})
+
+func expectMetricValue(gauge *prometheus.GaugeVec, labels []string, expected float64) {
+	metricGauge, err := gauge.GetMetricWithLabelValues(labels...)
+	Expect(err).To(BeNil())
+	Expect(metricGauge).ToNot(BeNil())
+	Expect(testutil.ToFloat64(metricGauge)).To(BeEquivalentTo(expected))
+}


### PR DESCRIPTION
* added some metrics to queuecontroller: queue_info, queue_deserved_gpus, queue_quota_cpu_cores, queue_quota_memory_bytes.
* having a configuration for queue labels converted to metric labels