### PR TITLE
Natasha/validate priority exists for podgroup

### DIFF
--- a/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -277,6 +277,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - scheduling.run.ai
   resources:
   - podgroups

--- a/pkg/podgrouper/pod_controller.go
+++ b/pkg/podgrouper/pod_controller.go
@@ -61,6 +61,7 @@ type Configs struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update;get;list;watch
+// +kubebuilder:rbac:groups="scheduling.k8s.io",resources=priorityclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="scheduling.run.ai",resources=podgroups,verbs=create;update;patch;get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -76,8 +76,8 @@ func (ph *PluginsHub) GetPodGrouperPlugin(gvk metav1.GroupVersionKind) grouper.G
 func NewPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 	gangScheduleKnative bool, queueLabelKey, nodePoolLabelKey string,
 	defaultPrioritiesConfigMapName, defaultPrioritiesConfigMapNamespace string) *PluginsHub {
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(defaultPrioritiesConfigMapName, defaultPrioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(defaultPrioritiesConfigMapName, defaultPrioritiesConfigMapNamespace)
 
 	kubeFlowDistributedGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	mpiGrouper := mpi.NewMpiGrouper(kubeClient, kubeFlowDistributedGrouper)

--- a/pkg/podgrouper/podgrouper/plugins/aml/aml_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/aml/aml_grouper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 )
@@ -47,7 +48,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	amlGrouper := NewAmlGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	amlGrouper := NewAmlGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()))
 	podGroupMetadata, err := amlGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -89,7 +90,7 @@ func TestGetPodGroupMetadataWithoutReplicas(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	amlGrouper := NewAmlGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	amlGrouper := NewAmlGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()))
 	_, err := amlGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.NotNil(t, err)

--- a/pkg/podgrouper/podgrouper/plugins/cronjobs/cronjob_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/cronjobs/cronjob_grouper_test.go
@@ -67,7 +67,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 	assert.Nil(t, err)
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(job).Build()
-	grouper := NewCronJobGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewCronJobGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(cronjob, pod)
 
 	assert.Nil(t, err)
@@ -105,7 +105,7 @@ func TestGetPodGroupMetadataJobOwnerNotFound(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(cronjob).Build()
-	grouper := NewCronJobGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewCronJobGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(cronjob, pod)
 
 	assert.NotNil(t, err)
@@ -144,7 +144,7 @@ func TestGetPodGroupMetadataJobNotExists(t *testing.T) {
 	assert.Nil(t, err)
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(cronjob).Build()
-	grouper := NewCronJobGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewCronJobGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(cronjob, pod)
 	assert.NotNil(t, err)
 	assert.Equal(t, fmt.Sprintf("jobs.batch \"%s\" not found", jobName), err.Error())

--- a/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
@@ -37,19 +37,17 @@ type DefaultGrouper struct {
 	kubeReader                          client.Reader
 }
 
-func NewDefaultGrouper(queueLabelKey, nodePoolLabelKey string) *DefaultGrouper {
+func NewDefaultGrouper(queueLabelKey, nodePoolLabelKey string, kubeReader client.Reader) *DefaultGrouper {
 	return &DefaultGrouper{
 		queueLabelKey:    queueLabelKey,
 		nodePoolLabelKey: nodePoolLabelKey,
+		kubeReader:       kubeReader,
 	}
 }
 
-func (dg *DefaultGrouper) SetDefaultPrioritiesConfigMapParams(
-	defaultPrioritiesConfigMapName, defaultPrioritiesConfigMapNamespace string, kubeReader client.Reader,
-) {
+func (dg *DefaultGrouper) SetDefaultPrioritiesConfigMapParams(defaultPrioritiesConfigMapName, defaultPrioritiesConfigMapNamespace string) {
 	dg.defaultPrioritiesConfigMapName = defaultPrioritiesConfigMapName
 	dg.defaultPrioritiesConfigMapNamespace = defaultPrioritiesConfigMapNamespace
-	dg.kubeReader = kubeReader
 }
 
 func (dg *DefaultGrouper) Name() string {
@@ -185,7 +183,7 @@ func (dg *DefaultGrouper) calcPodGroupPriorityClass(topOwner *unstructured.Unstr
 }
 
 func (dg *DefaultGrouper) validatePriorityClassExists(priorityClassName string) bool {
-	if priorityClassName == "" {
+	if priorityClassName == "" || dg.kubeReader == nil {
 		return false
 	}
 

--- a/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
@@ -160,13 +160,18 @@ func (dg *DefaultGrouper) CalcPodGroupPriorityClass(topOwner *unstructured.Unstr
 		return priorityClassName
 	}
 
+	if priorityClassName != "" {
+		logger.V(2).Info("priorityClassName from pod or owner labels is not valid, falling back to default",
+			"priorityClassName", priorityClassName, "topOwner", topOwner.GetName(), "pod", pod.GetName())
+	}
+
 	groupKind := topOwner.GroupVersionKind().GroupKind()
 	priorityClassName = dg.getDefaultPriorityClassNameForKind(&groupKind)
 	if dg.validatePriorityClassExists(priorityClassName) {
 		return priorityClassName
 	}
 
-	logger.V(4).Info("No default priority class found for group kind, using default fallback",
+	logger.V(2).Info("No default priority class found for group kind, using default fallback",
 		"groupKind", groupKind.String(), "defaultFallback", defaultPriorityClassForJob)
 	return defaultPriorityClassForJob
 }

--- a/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper_owners_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper_owners_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -57,7 +58,7 @@ func TestGetPodGroupMetadata_KubeflowPipelineScheduledWorkflow(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -129,7 +130,7 @@ func TestGetPodGroupMetadata_ArgoWorkflow(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -198,7 +199,7 @@ func TestGetPodGroupMetadata_Tekton_TaskRun(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -296,7 +297,7 @@ func TestGetPodGroupMetadata_Tekton_PipelineRun(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)

--- a/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper_test.go
@@ -44,8 +44,8 @@ func TestGetPodGroupMetadata(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "", kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "")
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -83,7 +83,7 @@ func TestGetPodGroupMetadataOnQueueFromOwnerDefaultNP(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -117,7 +117,7 @@ func TestGetPodGroupMetadataInferQueueFromProjectNodepool(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -146,7 +146,7 @@ func TestGetPodGroupMetadataOnQueueFromOwner(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -179,7 +179,7 @@ func TestGetPodGroupMetadataOnQueueFromPod(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -210,8 +210,8 @@ func TestGetPodGroupMetadataOnPriorityClassFromOwner(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "", kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "")
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -247,8 +247,8 @@ func TestGetPodGroupMetadataOnPriorityClassFromPod(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "", kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "")
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -282,8 +282,8 @@ func TestGetPodGroupMetadataOnPriorityClassFromPodSpec(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "", kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams("", "")
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -317,8 +317,8 @@ func TestGetPodGroupMetadataOnPriorityClassFromDefaultsGroupKindConfigMap(t *tes
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -351,8 +351,8 @@ func TestGetPodGroupMetadataOnPriorityClassFromDefaultsKindConfigMap(t *testing.
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -392,8 +392,8 @@ func TestGetPodGroupMetadataOnPriorityClassDefaultsConfigMapOverrideFromPodSpec(
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -434,8 +434,8 @@ func TestGetPodGroupMetadataOnPriorityClassDefaultsConfigMapOverrideFromLabel(t 
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -457,6 +457,7 @@ func TestGetPodGroupMetadataOnPriorityClassFromDefaultsConfigMapTestNils(t *test
 	pod := &v1.Pod{}
 
 	highPriorityClass := priorityClassObj("high-priority", 1000)
+	trainClass := priorityClassObj(constants.TrainPriorityClass, 1000)
 	defaultsConfigmap := &v1.ConfigMap{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      prioritiesConfigMapName,
@@ -466,25 +467,18 @@ func TestGetPodGroupMetadataOnPriorityClassFromDefaultsConfigMapTestNils(t *test
 			constants.DefaultPrioritiesConfigMapTypesKey: `[{"typeName":"TestKind.apps","priorityName":"high-priority"},{"typeName":"TestKind","priorityName":"low-priority"}]`,
 		},
 	}
-	kubeClient := fake.NewFakeClient(highPriorityClass, defaultsConfigmap)
+	kubeClient := fake.NewFakeClient(highPriorityClass, trainClass, defaultsConfigmap)
 
 	// sanity
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, "high-priority", podGroupMetadata.PriorityClassName)
 
-	// nil kubeclient
-	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, nil)
-	podGroupMetadata, err = defaultGrouper.GetPodGroupMetadata(owner, pod)
-	assert.Nil(t, err)
-	assert.Equal(t, constants.TrainPriorityClass, podGroupMetadata.PriorityClassName)
-
 	// unexisting configmap
-	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams("unexisting-cm", prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams("unexisting-cm", prioritiesConfigMapNamespace)
 	podGroupMetadata, err = defaultGrouper.GetPodGroupMetadata(owner, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, constants.TrainPriorityClass, podGroupMetadata.PriorityClassName)
@@ -501,8 +495,8 @@ func TestGetPodGroupMetadataOnPriorityClassFromDefaultsConfigMapTestNils(t *test
 			},
 		},
 	}
-	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err = defaultGrouper.GetPodGroupMetadata(owner, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, constants.TrainPriorityClass, podGroupMetadata.PriorityClassName)
@@ -536,16 +530,16 @@ func TestGetPodGroupMetadataOnPriorityClassFromDefaultsConfigMapBadConfigmapData
 	}
 	kubeClient := fake.NewFakeClient(trainPriorityClass, defaultsConfigmap)
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, constants.TrainPriorityClass, podGroupMetadata.PriorityClassName)
 
 	defaultsConfigmap.Data = map[string]string{"different-key!!!!": `[{"typeName":"TestKind.apps","priorityName":"high-priority"},{"typeName":"TestKind","priorityName":"low-priority"}]`}
 	kubeClient = fake.NewFakeClient(trainPriorityClass, defaultsConfigmap)
-	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
-	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace, kubeClient)
+	defaultGrouper = NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
+	defaultGrouper.SetDefaultPrioritiesConfigMapParams(prioritiesConfigMapName, prioritiesConfigMapNamespace)
 	podGroupMetadata, err = defaultGrouper.GetPodGroupMetadata(owner, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, constants.TrainPriorityClass, podGroupMetadata.PriorityClassName)
@@ -578,7 +572,7 @@ func TestGetPodGroupMetadata_OwnerUserOverridePodUser(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -608,7 +602,7 @@ func TestGetPodGroupMetadataWithTopology(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	podGroupMetadata, err := defaultGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)

--- a/pkg/podgrouper/podgrouper/plugins/deployment/deployment_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/deployment/deployment_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
@@ -82,7 +83,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	grouper := NewDeploymentGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewDeploymentGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()))
 	metadata, err := grouper.GetPodGroupMetadata(deployment, pod1)
 	assert.Nil(t, err)
 	assert.Equal(t, "pg-pod-1-3", metadata.Name)

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -125,7 +125,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(podgang).Build()
-	grouper := NewGroveGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewGroveGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	metadata, err := grouper.GetPodGroupMetadata(podgang, pod)
 	assert.Nil(t, err)
 	assert.Equal(t, int32(12), metadata.MinAvailable)

--- a/pkg/podgrouper/podgrouper/plugins/job/job_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/job/job_grouper_test.go
@@ -71,7 +71,7 @@ func TestGetPodGroupMetadata_Hpo(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, false)
 
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
@@ -148,7 +148,7 @@ func TestGetPodGroupMetadata_LegacyPodGroup(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, true)
 
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
@@ -221,7 +221,7 @@ func TestGetPodGroupMetadata_LegacyDisabledPodGroup(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, false)
 
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
@@ -278,7 +278,7 @@ func TestGetPodGroupMetadata_LegacyNotFound(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, true)
 
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
@@ -333,7 +333,7 @@ func TestGetPodGroupMetadata_RegularPodGroup(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, false)
 
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/distributed_common_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/distributed_common_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 )
@@ -50,7 +51,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	grouper := NewKubeflowDistributedGrouper(defaultGrouper)
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(owner, pod,
 		"xReplicaSpecs", []string{"Master"})
@@ -98,7 +99,7 @@ func TestGetPodGroupMetadataOnQueueFromOwner(t *testing.T) {
 	}
 	pod := &v1.Pod{}
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	grouper := NewKubeflowDistributedGrouper(defaultGrouper)
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(owner, pod,
 		"xReplicaSpecs", []string{"Master"})
@@ -147,7 +148,7 @@ func TestGetPodGroupMetadataRunPolicy(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	grouper := NewKubeflowDistributedGrouper(defaultGrouper)
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(owner, pod, "xReplicaSpecs", []string{"Master"})
 
@@ -189,7 +190,7 @@ func TestGetPodGroupMetadata_NoPods(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	grouper := NewKubeflowDistributedGrouper(defaultGrouper)
 	_, err := grouper.GetPodGroupMetadata(owner, pod, "xReplicaSpecs", []string{"Master"})
 
@@ -230,7 +231,7 @@ func TestGetPodGroupMetadata_NoMastersAllowed(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	grouper := NewKubeflowDistributedGrouper(defaultGrouper)
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(owner, pod,
 		"xReplicaSpecs", []string{})
@@ -273,7 +274,7 @@ func TestGetPodGroupMetadata_NoMastersForbiden(t *testing.T) {
 		},
 	}
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	grouper := NewKubeflowDistributedGrouper(defaultGrouper)
 	_, err := grouper.GetPodGroupMetadata(owner, pod,
 		"xReplicaSpecs", []string{"Master"})

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/mpi/mpi-grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/mpi/mpi-grouper_test.go
@@ -92,7 +92,7 @@ func TestLauncherPodExists(t *testing.T) {
 			_ = v1.AddToScheme(scheme)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingPods...).Build()
 
-			defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+			defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fakeClient)
 			kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 			mg := NewMpiGrouper(fakeClient, kubeFlowGrouper)
 			topOwner := &unstructured.Unstructured{
@@ -213,7 +213,7 @@ func TestHandleDelayedLauncherPolicy(t *testing.T) {
 			_ = v1.AddToScheme(scheme)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingPods...).Build()
 
-			defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+			defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fakeClient)
 			kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 			mg := NewMpiGrouper(fakeClient, kubeFlowGrouper)
 			gp := &podgroup.Metadata{
@@ -395,7 +395,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 			_ = v1.AddToScheme(scheme)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingPods...).Build()
 
-			defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+			defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fakeClient)
 			kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 			mg := NewMpiGrouper(fakeClient, kubeFlowGrouper)
 			metadata, err := mg.GetPodGroupMetadata(tt.topOwner, tt.pod)

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/kubeflow"
@@ -26,7 +27,7 @@ const (
 func TestGetPodGroupMetadata_OnlyReplicas(t *testing.T) {
 	pytorchJob := getBasicPytorchJob()
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -40,7 +41,7 @@ func TestGetPodGroupMetadata_OnlyMinReplicas(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minReplicas for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -55,7 +56,7 @@ func TestGetPodGroupMetadata_OnlyMinAvailable(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minAvailable for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -76,7 +77,7 @@ func TestGetPodGroupMetadata_MinAvailableAndMinReplicas(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minAvailable for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -88,7 +89,7 @@ func TestGetPodGroupMetadata_MinAvailableAndMinReplicas(t *testing.T) {
 func TestGetPodGroupMetadata_OnlyMasterReplicas(t *testing.T) {
 	pytorchJob := getPytorchJobWithOnlyMaster()
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -100,7 +101,7 @@ func TestGetPodGroupMetadata_OnlyMasterReplicas(t *testing.T) {
 func TestGetPodGroupMetadata_OnlyWorkerReplicas(t *testing.T) {
 	pytorchJob := getPytorchJobWithOnlyWorker()
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -116,7 +117,7 @@ func TestGetPodGroupMetadata_OnlyMasterWithMinReplicas(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minReplicas for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -132,7 +133,7 @@ func TestGetPodGroupMetadata_OnlyWorkerWithMinReplicas(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minReplicas for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -148,7 +149,7 @@ func TestGetPodGroupMetadata_OnlyMasterWithMinAvailable(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minAvailable for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)
@@ -164,7 +165,7 @@ func TestGetPodGroupMetadata_OnlyWorkerWithMinAvailable(t *testing.T) {
 	assert.Nil(t, err, "Got error when setting minAvailable for pytorch job")
 
 	pod := &v1.Pod{}
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient())
 	kubeFlowGrouper := kubeflow.NewKubeflowDistributedGrouper(defaultGrouper)
 	grouper := NewPyTorchGrouper(kubeFlowGrouper)
 	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, pod)

--- a/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func baseOwner(name string, startupPolicy string, replicas int64) *unstructured.Unstructured {
@@ -42,7 +43,7 @@ func TestGetPodGroupMetadata_LeaderCreated(t *testing.T) {
 		},
 	}
 
-	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", ""))
+	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", "", fake.NewFakeClient()))
 	podGroupMetadata, err := lwsGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -66,7 +67,7 @@ func TestGetPodGroupMetadata_LeaderReady_LeaderPod(t *testing.T) {
 		},
 	}
 
-	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", ""))
+	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", "", fake.NewFakeClient()))
 	podGroupMetadata, err := lwsGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -90,7 +91,7 @@ func TestGetPodGroupMetadata_LeaderReady_WorkerPod(t *testing.T) {
 		},
 	}
 
-	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", ""))
+	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", "", fake.NewFakeClient()))
 	podGroupMetadata, err := lwsGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
@@ -108,7 +109,7 @@ func TestGetPodGroupMetadata_GroupIndex_Label(t *testing.T) {
 		},
 	}
 
-	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", ""))
+	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", "", fake.NewFakeClient()))
 	podGroupMetadata, err := lwsGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)

--- a/pkg/podgrouper/podgrouper/plugins/ray/ray_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/ray/ray_grouper_test.go
@@ -61,7 +61,7 @@ func TestGetPodGroupMetadata_RayCluster(t *testing.T) {
 	pod := &v1.Pod{}
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(rayCluster).Build()
-	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	grouper := NewRayClusterGrouper(rayGrouper)
 
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(rayCluster, pod)
@@ -103,7 +103,7 @@ func TestGetPodGroupMetadata_RayJob(t *testing.T) {
 	pod := &v1.Pod{}
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(rayCluster).Build()
-	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	grouper := NewRayJobGrouper(rayGrouper)
 
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(owner, pod)
@@ -148,7 +148,7 @@ func TestGetPodGroupMetadata_RayJob_v1(t *testing.T) {
 	rayClusterCopy.SetAPIVersion("ray.io/v1")
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(rayClusterCopy).Build()
-	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	grouper := NewRayJobGrouper(rayGrouper)
 
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(owner, pod)
@@ -210,7 +210,7 @@ func TestGetPodGroupMetadata_RayService(t *testing.T) {
 	})
 
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(rayClusterCopy).Build()
-	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	rayGrouper := NewRayGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	grouper := NewRayServiceGrouper(rayGrouper)
 
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(rayService, pod)

--- a/pkg/podgrouper/podgrouper/plugins/runaijob/runaijob_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/runaijob/runaijob_grouper_test.go
@@ -69,7 +69,7 @@ func TestGetPodGroupMetadata_Hpo(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	runaiJobGrouper := NewRunaiJobGrouper(client, defaultGrouper, false)
 
 	podGroupMetadata, err := runaiJobGrouper.GetPodGroupMetadata(owner, pod)
@@ -146,7 +146,7 @@ func TestGetPodGroupMetadata_LegacyPodGroup(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	runaiJobGrouper := NewRunaiJobGrouper(client, defaultGrouper, true)
 
 	podGroupMetadata, err := runaiJobGrouper.GetPodGroupMetadata(owner, pod)
@@ -219,7 +219,7 @@ func TestGetPodGroupMetadata_LegacyDisabledPodGroup(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	runaiJobGrouper := NewRunaiJobGrouper(client, defaultGrouper, false)
 
 	podGroupMetadata, err := runaiJobGrouper.GetPodGroupMetadata(owner, pod)
@@ -276,7 +276,7 @@ func TestGetPodGroupMetadata_LegacyNotFound(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	runaiJobGrouper := NewRunaiJobGrouper(client, defaultGrouper, true)
 
 	podGroupMetadata, err := runaiJobGrouper.GetPodGroupMetadata(owner, pod)
@@ -331,7 +331,7 @@ func TestGetPodGroupMetadata_RegularPodGroup(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 
-	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 	runaiJobGrouper := NewRunaiJobGrouper(client, defaultGrouper, false)
 
 	podGroupMetadata, err := runaiJobGrouper.GetPodGroupMetadata(owner, pod)

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
@@ -57,7 +57,7 @@ var _ = Describe("SkipTopOwnerGrouper", func() {
 
 		BeforeEach(func() {
 			client = fake.NewFakeClient()
-			defaultGrouper = defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey)
+			defaultGrouper = defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
 			supportedTypes = map[metav1.GroupVersionKind]grouper.Grouper{
 				{Group: "", Version: "v1", Kind: "Pod"}: defaultGrouper,
 			}

--- a/pkg/podgrouper/podgrouper/plugins/spark/spark_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/spark/spark_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 )
@@ -71,7 +72,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 		Object: rawObjectMap,
 	}
 
-	grouper := NewSparkGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewSparkGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()))
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(unstructuredPod, pod)
 	assert.NoError(t, err)
 	assert.Equal(t, "spark-selector", podGroupMetadata.Name)

--- a/pkg/podgrouper/podgrouper/plugins/spotrequest/spotrequest_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/spotrequest/spotrequest_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
@@ -40,7 +41,7 @@ func TestGetPodGroupMetadata(t *testing.T) {
 		Object: rawObjectMap,
 	}
 
-	grouper := NewSpotRequestGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey))
+	grouper := NewSpotRequestGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()))
 	podGroupMetadata, err := grouper.GetPodGroupMetadata(unstructuredPod, pod)
 	assert.NoError(t, err)
 	assert.Equal(t, constants.InferencePriorityClass, podGroupMetadata.PriorityClassName)


### PR DESCRIPTION
* in podgrouper's "CalcPodGroupPriorityClass", validate the calculated PriorityClass object exists in the k8s cluster. If not - fallback to default from configmap, or the default priorityClass for type.
* had to move "kubeClient" param to the "NewDefaultGrouper" constructor - it is now required always to validate the priorityClass exists.
* fixed and added tests.