### PR TITLE
Explicitly set runtimeClassName to `nvidia` for GPU reservation pods

### DIFF
--- a/docs/gpu-sharing/README.md
+++ b/docs/gpu-sharing/README.md
@@ -18,6 +18,11 @@ GPU sharing is disabled by default. To enable it, add the following flag to the 
 --set "global.gpuSharing=true"
 ```
 
+### RuntimeClass Requirement
+KAI Scheduler requires the use of a specific RuntimeClass for GPU sharing. The recommended RuntimeClass is `nvidia`.
+
+KAI explicitly sets `runtimeClassName: "nvidia"` in the resource reservation pod spec. Ensure that your cluster has the `nvidia` RuntimeClass configured — this is typically provided by the NVIDIA device plugin.
+
 ### GPU Sharing Pod
 To submit a pod that can share a GPU device, run this command:
 ```

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -42,6 +42,8 @@ const (
 	unknownGpuIndicator            = "-1"
 )
 
+var runtimeClassName = "nvidia"
+
 type service struct {
 	fakeGPuNodes        bool
 	kubeClient          client.WithWatch
@@ -449,6 +451,7 @@ func (rsc *service) createResourceReservationPod(
 		},
 		Spec: v1.PodSpec{
 			NodeName:           nodeName,
+			RuntimeClassName:   &runtimeClassName,
 			ServiceAccountName: rsc.serviceAccountName,
 			Containers: []v1.Container{
 				{


### PR DESCRIPTION
Fixes - #340 

Reservation pods use the NVML library for GPU discovery, which requires the NVIDIA runtime.
Without explicitly setting RuntimeClassName, pods may fail if the cluster default is not nvidia.

This PR ensures reliable GPU sharing behavior by:

- [x] Explicitly setting runtimeClassName: "nvidia" in the resource reservation pod spec.
- [x] Updating GPU sharing documentation to include the requirement for the nvidia RuntimeClass.