### PR TITLE
Allow reclaiming with lower utilization ratio

### DIFF
--- a/docs/fairness/README.md
+++ b/docs/fairness/README.md
@@ -27,3 +27,16 @@ There are two main reclaim strategies:
 
 In both strategies, the scheduler ensures that the relative ordering is preserved: a queue that had the lowest utilisation ratio in its level before reclamation will still have the lowest ratio afterwards. Likewise, a queue that was below its quota will remain below its quota.
 The scheduler will prioritize the first strategy.
+
+### Reclaim Ratio Adjustment
+The utilization ratio comparison can be adjusted using the `reclaimerUtilizationMultiplier` plugin argument. This multiplier is applied to the reclaimer's utilization ratio before comparison:
+- Values > 1.0 make it harder for jobs to reclaim resources (more conservative)
+- Minimum value is 1.0 (standard comparison, default)
+- Values < 1.0 are not allowed and will be set to 1.0 - These values could cause infinite reclaim cycles that we want to avoid.
+
+Example configuration:
+```yaml
+pluginArguments:
+  proportion:
+    reclaimerUtilizationMultiplier: "1.2"  # Makes reclamation 20% more conservative
+```

--- a/docs/fairness/README.md
+++ b/docs/fairness/README.md
@@ -18,7 +18,7 @@ These two steps are repeated across all hierarchy levels until every leaf queue 
 ## Fair Share
 Once the fair share for each queue is calculated, it serves two primary purposes:
 1. Queue Order - Queues with a fair share further below their allocation will be prioritized for scheduling.
-2. Reclaim action – When reclamation is required, the scheduler compares the **utilisation ratio** (`Allocated / FairShare`) of queues that share the same parent. A queue can only reclaim resources if, **after** the transfer, its utilisation ratio remains lower than that of every sibling queue. For more details see the reclaim strategies.
+2. Reclaim action – When reclamation is required, the scheduler compares the **Saturation Ratio** (`Allocated / FairShare`) of queues that share the same parent. A queue can only reclaim resources if, **after** the transfer, its utilisation ratio remains lower than that of every sibling queue. For more details see the reclaim strategies.
 
 ## Reclaim Strategies
 There are two main reclaim strategies:
@@ -29,7 +29,7 @@ In both strategies, the scheduler ensures that the relative ordering is preserve
 The scheduler will prioritize the first strategy.
 
 ### Reclaim Ratio Adjustment
-The utilization ratio comparison can be adjusted using the `reclaimerUtilizationMultiplier` plugin argument. This multiplier is applied to the reclaimer's utilization ratio before comparison:
+The Saturation Ratio comparison can be adjusted using the `reclaimerUtilizationMultiplier` plugin argument. This multiplier is applied to the reclaimer's Saturation Ratio before comparison:
 - Values > 1.0 make it harder for jobs to reclaim resources (more conservative)
 - Minimum value is 1.0 (standard comparison, default)
 - Values < 1.0 are not allowed and will be set to 1.0 - These values could cause infinite reclaim cycles that we want to avoid.

--- a/docs/fairness/README.md
+++ b/docs/fairness/README.md
@@ -18,12 +18,12 @@ These two steps are repeated across all hierarchy levels until every leaf queue 
 ## Fair Share
 Once the fair share for each queue is calculated, it serves two primary purposes:
 1. Queue Order - Queues with a fair share further below their allocation will be prioritized for scheduling.
-2. Reclaim action - If scheduling cannot be performed due to limited resources in the cluster, the scheduler will evict workloads from queues that have exceeded their fair share, giving priority to queues that are below their fair share. For more details, refer to the reclaim strategies.
+2. Reclaim action – When reclamation is required, the scheduler compares the **utilisation ratio** (`Allocated / FairShare`) of queues that share the same parent. A queue can only reclaim resources if, **after** the transfer, its utilisation ratio remains lower than that of every sibling queue. For more details see the reclaim strategies.
 
 ## Reclaim Strategies
 There are two main reclaim strategies:
 1. Workloads from queues with resources below their fair share can evict workloads from queues that have exceeded their fair share.
 2. Workloads from queues under their quota can evict workloads from queues that have exceeded their quota.
 
-In both strategies, the scheduler ensures that the initial state remains unchanged after resource reclamation. Specifically, a queue below its fair share will not exceed that share after reclamation, and a queue below its quota will not exceed the quota.
+In both strategies, the scheduler ensures that the relative ordering is preserved: a queue that had the lowest utilisation ratio in its level before reclamation will still have the lowest ratio afterwards. Likewise, a queue that was below its quota will remain below its quota.
 The scheduler will prioritize the first strategy.

--- a/pkg/scheduler/actions/reclaim/reclaimDepartments_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaimDepartments_test.go
@@ -765,5 +765,301 @@ func getTestsDepartmentsMetadata() []integration_tests_utils.TestTopologyMetadat
 				},
 			},
 		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Reclaim from overquota department with multiple departments",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "d1_p1_pending_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityInferenceNumber,
+						QueueName:           "d1_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+					{
+						Name:                "d1_p2_job1",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d1_project2",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d1_p2_job2",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d1_project2",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d1_p2_job3",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d1_project2",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d1_p2_job4",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d1_project2",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job1",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job2",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job3",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job4",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job5",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job6",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job7",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d2_job8",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d2_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d3_job1",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d3_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d3_job2",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d3_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d3_job3",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d3_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d3_job4",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d3_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "d4_job1",
+						RequiredGPUsPerTask: 5,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "d4_project1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Pending,
+								NodeName: "node0",
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 16,
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "d1_project1",
+						DeservedGPUs:       3,
+						GPUOverQuotaWeight: 3,
+						ParentQueue:        "d1",
+					},
+					{
+						Name:               "d1_project2",
+						DeservedGPUs:       1,
+						GPUOverQuotaWeight: 1,
+						ParentQueue:        "d1",
+					},
+					{
+						Name:               "d2_project1",
+						DeservedGPUs:       4,
+						GPUOverQuotaWeight: 4,
+						ParentQueue:        "d2",
+					},
+					{
+						Name:               "d3_project1",
+						DeservedGPUs:       4,
+						GPUOverQuotaWeight: 4,
+						ParentQueue:        "d3",
+					},
+					{
+						Name:               "d4_project1",
+						DeservedGPUs:       4,
+						GPUOverQuotaWeight: 4,
+						ParentQueue:        "d4",
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "d1",
+						DeservedGPUs: 4,
+					},
+					{
+						Name:         "d2",
+						DeservedGPUs: 4,
+					},
+					{
+						Name:         "d3",
+						DeservedGPUs: 4,
+					},
+					{
+						Name:         "d4",
+						DeservedGPUs: 4,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"d1_p1_pending_job": {
+						NodeName:     "node0",
+						GPUsRequired: 1,
+						Status:       pod_status.Pipelined,
+					},
+					"d2_job8": {
+						NodeName:     "node0",
+						GPUsRequired: 1,
+						Status:       pod_status.Releasing,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds:      1,
+						NumberOfCacheEvictions:  1,
+						NumberOfPipelineActions: 1,
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -55,32 +55,34 @@ type proportionPlugin struct {
 	queues              map[common_info.QueueID]*rs.QueueAttributes
 	jobSimulationQueues map[common_info.QueueID]*rs.QueueAttributes
 	// Arguments given for the plugin
-	pluginArguments                map[string]string
-	subGroupOrderFn                common_info.LessFn
-	taskOrderFunc                  common_info.LessFn
-	reclaimablePlugin              *rec.Reclaimable
-	isInferencePreemptible         bool
-	allowConsolidatingReclaim      bool
-	reclaimerUtilizationMultiplier float64
+	pluginArguments               map[string]string
+	subGroupOrderFn               common_info.LessFn
+	taskOrderFunc                 common_info.LessFn
+	reclaimablePlugin             *rec.Reclaimable
+	isInferencePreemptible        bool
+	allowConsolidatingReclaim     bool
+	relcaimerSaturationMultiplier float64
 }
 
 func New(arguments map[string]string) framework.Plugin {
 	multiplier := 1.0
-	if val, exists := arguments["reclaimerUtilizationMultiplier"]; exists {
+	if val, exists := arguments["relcaimerSaturationMultiplier"]; exists {
 		if m, err := strconv.ParseFloat(val, 64); err == nil {
 			if m < 1.0 {
-				log.InfraLogger.Warningf("reclaimerUtilizationMultiplier must be >= 1.0, got %v. Using default value of 1.0", m)
+				log.InfraLogger.Warningf("relcaimerSaturationMultiplier must be >= 1.0, got %v. Using default value of 1.0", m)
 			} else {
 				multiplier = m
 			}
+		} else {
+			log.InfraLogger.V(1).Errorf("Failed to parse relcaimerSaturationMultiplier: %s. Using default 1.", val)
 		}
 	}
 
 	return &proportionPlugin{
-		totalResource:                  rs.EmptyResourceQuantities(),
-		queues:                         map[common_info.QueueID]*rs.QueueAttributes{},
-		pluginArguments:                arguments,
-		reclaimerUtilizationMultiplier: multiplier,
+		totalResource:                 rs.EmptyResourceQuantities(),
+		queues:                        map[common_info.QueueID]*rs.QueueAttributes{},
+		pluginArguments:               arguments,
+		relcaimerSaturationMultiplier: multiplier,
 	}
 }
 
@@ -92,7 +94,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	pp.calculateResourcesProportion(ssn)
 	pp.subGroupOrderFn = ssn.SubGroupOrderFn
 	pp.taskOrderFunc = ssn.TaskOrderFn
-	pp.reclaimablePlugin = rec.New(pp.reclaimerUtilizationMultiplier)
+	pp.reclaimablePlugin = rec.New(pp.relcaimerSaturationMultiplier)
 	pp.isInferencePreemptible = ssn.IsInferencePreemptible()
 	capacityPolicy := cp.New(pp.queues, ssn.IsInferencePreemptible())
 	ssn.AddQueueOrderFn(pp.queueOrder)

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -78,7 +78,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	pp.calculateResourcesProportion(ssn)
 	pp.subGroupOrderFn = ssn.SubGroupOrderFn
 	pp.taskOrderFunc = ssn.TaskOrderFn
-	pp.reclaimablePlugin = rec.New(ssn.IsInferencePreemptible())
+	pp.reclaimablePlugin = rec.New()
 	pp.isInferencePreemptible = ssn.IsInferencePreemptible()
 	capacityPolicy := cp.New(pp.queues, ssn.IsInferencePreemptible())
 	ssn.AddQueueOrderFn(pp.queueOrder)

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -774,3 +774,42 @@ var _ = Describe("Set Fair Share in Proportion", func() {
 
 	})
 })
+
+var _ = Describe("New", func() {
+	Context("Initializing proportion plugin", func() {
+		var args map[string]string
+
+		BeforeEach(func() {
+			args = make(map[string]string)
+		})
+
+		It("should create plugin with empty state and default multiplier", func() {
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin).NotTo(BeNil())
+			Expect(plugin.totalResource).To(Equal(rs.EmptyResourceQuantities()))
+			Expect(plugin.queues).To(HaveLen(0))
+			Expect(plugin.pluginArguments).To(Equal(args))
+		})
+
+		It("should handle malformed Saturation Multiplier arg", func() {
+			args := map[string]string{"relcaimerSaturationMultiplier": "wrong"}
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin.pluginArguments).To(Equal(args))
+			Expect(plugin.relcaimerSaturationMultiplier).To(Equal(1.0))
+		})
+
+		It("should handle Saturation Multiplier arg", func() {
+			args := map[string]string{"relcaimerSaturationMultiplier": "1.5"}
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin.pluginArguments).To(Equal(args))
+			Expect(plugin.relcaimerSaturationMultiplier).To(Equal(1.5))
+		})
+
+		It("should prevent Saturation Multiplier lower than 1", func() {
+			args := map[string]string{"relcaimerSaturationMultiplier": "0.5"}
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin.pluginArguments).To(Equal(args))
+			Expect(plugin.relcaimerSaturationMultiplier).To(Equal(1.0))
+		})
+	})
+})

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable.go
@@ -15,11 +15,10 @@ import (
 )
 
 type Reclaimable struct {
-	isInferencePreemptible bool
 }
 
-func New(isInferencePreemptible bool) *Reclaimable {
-	return &Reclaimable{isInferencePreemptible}
+func New() *Reclaimable {
+	return &Reclaimable{}
 }
 
 func (r *Reclaimable) CanReclaimResources(

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
@@ -1029,6 +1029,61 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(true))
 	})
+	It("Reclaimer has lower utilization ratio than reclaimee but over 1", func() {
+		queuesData = map[common_info.QueueID]queuesTestData{
+			"d1": {
+				"",
+				4,
+				4,
+				4,
+			},
+			"d1-project-1": {
+				"d1",
+				3,
+				1,
+				0,
+			},
+			"d1-project-2": {
+				"d1",
+				1,
+				3,
+				4,
+			},
+			"d2": {
+				"",
+				3,
+				3,
+				7,
+			},
+			"d2-project-1": {
+				"d2",
+				3,
+				3,
+				7,
+			},
+		}
+		queues := buildQueues(queuesData)
+		reclaimable = New()
+
+		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1)
+		reclaimerInfo.Queue = "d1-project-1"
+		reclaimee2 := &podgroup_info.PodGroupInfo{
+			Name:  "reclaimee2",
+			Queue: "d2-project-1",
+			PodInfos: pod_info.PodsMap{
+				"1": &pod_info.PodInfo{
+					ResReq: &resource_info.ResourceRequirements{
+						GpuResourceRequirement: *resource_info.NewGpuResourceRequirementWithGpus(1, 0),
+					},
+					Status: pod_status.Running,
+				},
+			},
+		}
+
+		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee2}
+		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
+		Expect(result).To(Equal(true))
+	})
 })
 
 func buildQueues(queuesData map[common_info.QueueID]queuesTestData) map[common_info.QueueID]*rs.QueueAttributes {

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Can Reclaim Resources", func() {
 		for _, data := range tests {
 			testData := data
 			It(testData.name, func() {
-				reclaimable := New(true)
+				reclaimable := New()
 				queues := map[common_info.QueueID]*rs.QueueAttributes{
 					testData.queue.UID: testData.queue,
 				}
@@ -518,7 +518,7 @@ var _ = Describe("Can Reclaim Resources", func() {
 		for _, data := range tests {
 			testData := data
 			It(testData.name, func() {
-				reclaimable := New(true)
+				reclaimable := New()
 				queues := map[common_info.QueueID]*rs.QueueAttributes{
 					testData.queue.UID: testData.queue,
 				}
@@ -607,7 +607,7 @@ var _ = Describe("Reclaimable - Single department", func() {
 				},
 			},
 		}
-		reclaimable = New(true)
+		reclaimable = New()
 	})
 	It("Reclaimer is below fair share, reclaimee above fair share", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
@@ -767,7 +767,7 @@ var _ = Describe("Reclaimable - Multiple departments", func() {
 				},
 			},
 		}
-		reclaimable = New(true)
+		reclaimable = New()
 	})
 	It("Reclaimer is below fair share, reclaimee above fair share - sanity", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
@@ -858,7 +858,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(true)
+		reclaimable = New()
 		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee}
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(true))
@@ -910,7 +910,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(true)
+		reclaimable = New()
 		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee}
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(false))
@@ -955,7 +955,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(true)
+		reclaimable = New()
 
 		reclaimee.PodInfos["1"].ResReq.GpuResourceRequirement =
 			*resource_info.NewGpuResourceRequirementWithGpus(1.5, 0)
@@ -1006,7 +1006,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(true)
+		reclaimable = New()
 
 		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1)
 		reclaimerInfo.Queue = "left-leaf1"

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Can Reclaim Resources", func() {
 		for _, data := range tests {
 			testData := data
 			It(testData.name, func() {
-				reclaimable := New()
+				reclaimable := New(1.0)
 				queues := map[common_info.QueueID]*rs.QueueAttributes{
 					testData.queue.UID: testData.queue,
 				}
@@ -518,7 +518,7 @@ var _ = Describe("Can Reclaim Resources", func() {
 		for _, data := range tests {
 			testData := data
 			It(testData.name, func() {
-				reclaimable := New()
+				reclaimable := New(1.0)
 				queues := map[common_info.QueueID]*rs.QueueAttributes{
 					testData.queue.UID: testData.queue,
 				}
@@ -607,7 +607,7 @@ var _ = Describe("Reclaimable - Single department", func() {
 				},
 			},
 		}
-		reclaimable = New()
+		reclaimable = New(1.0)
 	})
 	It("Reclaimer is below fair share, reclaimee above fair share", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
@@ -767,7 +767,7 @@ var _ = Describe("Reclaimable - Multiple departments", func() {
 				},
 			},
 		}
-		reclaimable = New()
+		reclaimable = New(1.0)
 	})
 	It("Reclaimer is below fair share, reclaimee above fair share - sanity", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
@@ -858,7 +858,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New()
+		reclaimable = New(1.0)
 		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee}
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(true))
@@ -910,7 +910,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New()
+		reclaimable = New(1.0)
 		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee}
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(false))
@@ -955,7 +955,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New()
+		reclaimable = New(1.0)
 
 		reclaimee.PodInfos["1"].ResReq.GpuResourceRequirement =
 			*resource_info.NewGpuResourceRequirementWithGpus(1.5, 0)
@@ -1006,7 +1006,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New()
+		reclaimable = New(1.0)
 
 		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1)
 		reclaimerInfo.Queue = "left-leaf1"
@@ -1063,7 +1063,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New()
+		reclaimable = New(1.0)
 
 		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1)
 		reclaimerInfo.Queue = "d1-project-1"


### PR DESCRIPTION
Currently it is possible for a reclaim to fail between two departments due to a third department requesting quota that it can't receive. To help remediate this issue this PR will allow queues to reclaim from other queues if their utilization ratio (allocation / fair share) is better for all resources.
The original intention for checking that the fair share is not over 1 was to prevent reclaim cycles where the reclaimed project will be able to reclaim the resources back and to create an infinite loop of reclaims and this test is a more relaxed version of this which will also achieve the same goal by always lowering the utilization ratio.

There is an action test for reclaim that show this issue and also unit test in reclaimable_test.go 

This change will allow the scheduler to find more reclaim scenarios at minimal performance cost.