### PR TITLE
fix: use global.securityContext in crd-upgrader

### DIFF
--- a/deployments/kai-scheduler/templates/crd-upgrader.yaml
+++ b/deployments/kai-scheduler/templates/crd-upgrader.yaml
@@ -18,6 +18,10 @@ spec:
       - name: upgrader
         image: "{{ .Values.global.registry }}/{{ .Values.crdupgrader.image.name }}:{{ .Chart.Version }}"
         imagePullPolicy: {{ .Values.crdupgrader.image.pullPolicy }}
+        {{- if .Values.global.securityContext }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
       {{- if .Values.global.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
This MR makes the `crd-upgrader` `Job` use the `global.securityContext`, like the other pre-sync hook `Job`s do. This allows deploying the Helm chart in environments where pods not setting certain security contexts fields are rejected.