### PR TITLE
Fix: incorrect scheduling decision and calculation when using MIG

### DIFF
--- a/pkg/scheduler/api/pod_info/pod_info.go
+++ b/pkg/scheduler/api/pod_info/pod_info.go
@@ -371,10 +371,6 @@ func getTaskStatus(pod *v1.Pod, bindRequest *bindrequest_info.BindRequestInfo) p
 }
 
 func (pi *PodInfo) updatePodAdditionalFields(bindRequest *bindrequest_info.BindRequestInfo) {
-	if len(pi.Job) == 0 {
-		return
-	}
-
 	if bindRequest != nil && len(bindRequest.BindRequest.Spec.SelectedGPUGroups) > 0 {
 		pi.GPUGroups = bindRequest.BindRequest.Spec.SelectedGPUGroups
 	} else {

--- a/pkg/scheduler/cache/cluster_info/cluster_info_test.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info_test.go
@@ -278,51 +278,15 @@ func TestSnapshotNodes(t *testing.T) {
 			Phase: v1core.PodRunning,
 		},
 	}
-	exampleMIGPod := &v1core.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "mig-pod-1",
-		},
-		Spec: v1core.PodSpec{
-			NodeName: "node-1",
-			Containers: []v1core.Container{
-				{
-					Resources: v1core.ResourceRequirements{
-						Requests: v1core.ResourceList{
-							"cpu":                   resource.MustParse("2"),
-							"nvidia.com/mig-1g.5gb": resource.MustParse("2"),
-						},
-					},
-				},
-			},
-		},
-		Status: v1core.PodStatus{
-			Phase: v1core.PodRunning,
-		},
+	exampleMIGPod := examplePod.DeepCopy()
+	exampleMIGPod.Name = "mig-pod"
+	exampleMIGPod.Spec.Containers[0].Resources.Requests["nvidia.com/mig-1g.5gb"] = resource.MustParse("2")
+	exampleMIGPodWithPG := examplePod.DeepCopy()
+	exampleMIGPodWithPG.Name = "mig-pod-with-pg"
+	exampleMIGPodWithPG.Annotations = map[string]string{
+		commonconstants.PodGroupAnnotationForPod: "pg-1",
 	}
-	exampleMIGPodWithPG := &v1core.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "mig-pod-2",
-			Annotations: map[string]string{
-				commonconstants.PodGroupAnnotationForPod: "pg-1",
-			},
-		},
-		Spec: v1core.PodSpec{
-			NodeName: "node-1",
-			Containers: []v1core.Container{
-				{
-					Resources: v1core.ResourceRequirements{
-						Requests: v1core.ResourceList{
-							"cpu":                   resource.MustParse("2"),
-							"nvidia.com/mig-1g.5gb": resource.MustParse("2"),
-						},
-					},
-				},
-			},
-		},
-		Status: v1core.PodStatus{
-			Phase: v1core.PodRunning,
-		},
-	}
+	exampleMIGPodWithPG.Spec.Containers[0].Resources.Requests["nvidia.com/mig-1g.5gb"] = resource.MustParse("2")
 	tests := map[string]struct {
 		objs          []runtime.Object
 		resultNodes   []*node_info.NodeInfo

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -26,7 +26,6 @@ import (
 	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info/resources"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
@@ -245,19 +244,7 @@ func getNodeResources(ssn *framework.Session, node *node_info.NodeInfo) rs.Resou
 	if shouldIgnoreGPUs {
 		nodeResource.Add(rs.NewResourceQuantities(node.Allocatable.Cpu(), node.Allocatable.Memory(), 0))
 	} else {
-		nodeResource.Add(rs.NewResourceQuantities(node.Allocatable.Cpu(), node.Allocatable.Memory(), node.Allocatable.GPUs()))
-		migEnabledGpus := 0
-		for resource, qty := range node.Node.Status.Allocatable {
-			if resource_info.IsMigResource(resource) {
-				gpu, _, err := resources.ExtractGpuAndMemoryFromMigResourceName(string(resource))
-				if err != nil {
-					log.InfraLogger.Errorf("Failed to extract gpu and memory from mig resource %v: %v", resource, err)
-					continue
-				}
-				migEnabledGpus += int(qty.Value()) * gpu
-			}
-		}
-		nodeResource[rs.GpuResource] += float64(migEnabledGpus)
+		nodeResource.Add(utils.QuantifyResource(node.Allocatable))
 	}
 
 	// Subtract resources of non-related pods

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -245,7 +245,7 @@ func getNodeResources(ssn *framework.Session, node *node_info.NodeInfo) rs.Resou
 	if shouldIgnoreGPUs {
 		nodeResource.Add(rs.NewResourceQuantities(node.Allocatable.Cpu(), node.Allocatable.Memory(), 0))
 	} else {
-		nodeResource.Add(utils.QuantifyResource(node.Allocatable))
+		nodeResource.Add(rs.NewResourceQuantities(node.Allocatable.Cpu(), node.Allocatable.Memory(), node.Allocatable.GPUs()))
 		migEnabledGpus := 0
 		for resource, qty := range node.Node.Status.Allocatable {
 			if resource_info.IsMigResource(resource) {

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -576,9 +576,6 @@ var _ = Describe("Set Fair Share in Proportion", func() {
 								"node-role.kubernetes.io/gpu-worker": "true",
 							},
 						},
-						Status: v1.NodeStatus{
-							Allocatable: common_info.BuildResourceListWithMig("8000m", "10G", "nvidia.com/mig-1g.5gb"),
-						},
 					},
 					Allocatable: resource_info.ResourceFromResourceList(
 						common_info.BuildResourceListWithMig("8000m", "10G", "nvidia.com/mig-1g.5gb"),

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -566,6 +566,31 @@ var _ = Describe("Set Fair Share in Proportion", func() {
 				},
 			},
 			{
+				name:           "mig gpu node",
+				isRestrictNode: true,
+				node: &node_info.NodeInfo{
+					Name: "n1",
+					Node: &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"node-role.kubernetes.io/gpu-worker": "true",
+							},
+						},
+						Status: v1.NodeStatus{
+							Allocatable: common_info.BuildResourceListWithMig("8000m", "10G", "nvidia.com/mig-1g.5gb"),
+						},
+					},
+					Allocatable: resource_info.ResourceFromResourceList(
+						common_info.BuildResourceListWithMig("8000m", "10G", "nvidia.com/mig-1g.5gb"),
+					),
+				},
+				want: rs.ResourceQuantities{
+					rs.CpuResource:    8000,
+					rs.MemoryResource: 10000000000,
+					rs.GpuResource:    1,
+				},
+			},
+			{
 				name:           "ignore extra resources",
 				isRestrictNode: true,
 				node: &node_info.NodeInfo{


### PR DESCRIPTION
This PR tries to fix two problems we found:

1. If a MIG pod is not scheduled by Kai, its `ResourceRequestType` is not set to `MigInstance`. This results in incorrect idle resource calculation for the node, which in turn leads to inaccurate scheduling decisions.
2. When calculating resource proportions, the MIG resource of a node is counted twice.
