### PR TITLE
Consider historical usage data in fair share calculations

### DIFF
--- a/pkg/scheduler/plugins/proportion/resource_division/resource_division.go
+++ b/pkg/scheduler/plugins/proportion/resource_division/resource_division.go
@@ -183,9 +183,11 @@ func divideUpToFairShare(totalResourceAmount, kValue float64, queues map[common_
 				continue
 			}
 
-			// normalize values
+			// Normalize queue over quota weight
 			nWeight := share.OverQuotaWeight / totalWeights
-			nUsage := share.GetUsage() / totalUsages
+
+			// We assume that usage is normalized to usage/clusterCapacity
+			nUsage := share.GetUsage()
 
 			portion := nWeight + kValue*(nWeight-nUsage)
 			portions[queue.UID] = portion

--- a/pkg/scheduler/plugins/proportion/resource_division/resource_division.go
+++ b/pkg/scheduler/plugins/proportion/resource_division/resource_division.go
@@ -189,9 +189,15 @@ func divideUpToFairShare(totalResourceAmount, kValue float64, queues map[common_
 			// We assume that usage is normalized to usage/clusterCapacity
 			nUsage := share.GetUsage()
 
-			portion := nWeight + kValue*(nWeight-nUsage)
+			// Floor portion to 0 if it's negative
+			portion := math.Max(0, nWeight+kValue*(nWeight-nUsage))
+
 			portions[queue.UID] = portion
 			totalPortions += portion
+		}
+
+		if totalPortions == 0 {
+			break
 		}
 
 		for _, queue := range queues {


### PR DESCRIPTION
Take historical queue usage into account when calculating the fair share for each queue. The calculation is based on https://github.com/NVIDIA/KAI-Scheduler/blob/95910267b4a0b3c2f7bb156250767e3bd505130c/docs/developer/designs/time-aware-fairness/time-aware-fairness.md#design-details