### PR TITLE
Topology scheduling tests

### DIFF
--- a/pkg/scheduler/actions/integration_tests/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/integration_tests/allocate/allocate_test.go
@@ -6,11 +6,8 @@ package allocate_test
 import (
 	"testing"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	kueuev1alpha1 "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 
-	enginev2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/constants"
@@ -1073,124 +1070,6 @@ func getAllocateTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
 					"pending_job1": {
 						GPUsRequired: 1,
 						Status:       pod_status.Pending,
-					},
-				},
-				Mocks: &test_utils.TestMock{
-					CacheRequirements: &test_utils.CacheMocking{
-						NumberOfCacheBinds: 2,
-					},
-				},
-			},
-			RoundsUntilMatch: 1,
-		},
-		{
-			TestTopologyBasic: test_utils.TestTopologyBasic{
-				Name: "Topology basic test",
-				Topologies: []*kueuev1alpha1.Topology{
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name: "cluster-topology",
-						},
-						Spec: kueuev1alpha1.TopologySpec{
-							Levels: []kueuev1alpha1.TopologyLevel{
-								{
-									NodeLabel: "k8s.io/rack",
-								},
-							},
-						},
-					},
-				},
-				Jobs: []*jobs_fake.TestJobBasic{
-					{
-						Name:                "running_job0",
-						RequiredGPUsPerTask: 1,
-						Priority:            constants.PriorityTrainNumber,
-						QueueName:           "queue0",
-						Tasks: []*tasks_fake.TestTaskBasic{
-							{
-								State:    pod_status.Running,
-								NodeName: "node0",
-							},
-						},
-					},
-					{
-						Name:                "pending_job0",
-						RequiredGPUsPerTask: 1,
-						Priority:            constants.PriorityTrainNumber,
-						QueueName:           "queue0",
-						Topology: &enginev2alpha2.TopologyConstraint{
-							Topology:              "cluster-topology",
-							RequiredTopologyLevel: "k8s.io/rack",
-						},
-						Tasks: []*tasks_fake.TestTaskBasic{
-							{
-								State: pod_status.Pending,
-							},
-							{
-								State: pod_status.Pending,
-							},
-						},
-					},
-				},
-				Nodes: map[string]nodes_fake.TestNodeBasic{
-					"node0": {
-						GPUs: 1,
-						Labels: map[string]string{
-							"k8s.io/rack": "rack1",
-						},
-					},
-					"node1": {
-						GPUs: 1,
-						Labels: map[string]string{
-							"k8s.io/rack": "rack1",
-						},
-					},
-					"node2": {
-						GPUs: 1,
-						Labels: map[string]string{
-							"k8s.io/rack": "rack2",
-						},
-					},
-					"node3": {
-						GPUs: 1,
-						Labels: map[string]string{
-							"k8s.io/rack": "rack2",
-						},
-					},
-				},
-				Queues: []test_utils.TestQueueBasic{
-					{
-						Name:               "queue0",
-						ParentQueue:        "department-a",
-						DeservedGPUs:       4,
-						GPUOverQuotaWeight: 1,
-						MaxAllowedGPUs:     4,
-					},
-				},
-				Departments: []test_utils.TestDepartmentBasic{
-					{
-						Name:         "department-a",
-						DeservedGPUs: 4,
-					},
-				},
-				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
-					"running_job0-0": {
-						NodeName:             "node0",
-						GPUsRequired:         1,
-						Status:               pod_status.Running,
-						DontValidateGPUGroup: true,
-					},
-					"pending_job0-0": {
-						NodeName:             "node2",
-						GPUsRequired:         1,
-						Status:               pod_status.Running,
-						DontValidateGPUGroup: true,
-					},
-					"pending_job0-1": {
-						NodeName:             "node3",
-						GPUsRequired:         1,
-						Status:               pod_status.Running,
-						DontValidateGPUGroup: true,
 					},
 				},
 				Mocks: &test_utils.TestMock{

--- a/pkg/scheduler/actions/integration_tests/allocate/allocate_topology_test.go
+++ b/pkg/scheduler/actions/integration_tests/allocate/allocate_topology_test.go
@@ -1,0 +1,1067 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package allocate_test
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kueuev1alpha1 "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+
+	enginev2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions/integration_tests/integration_tests_utils"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+func TestHandleTopologyAllocation(t *testing.T) {
+	integration_tests_utils.RunTests(t, getTopologyTestsMetadata())
+}
+
+func getTopologyTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
+	return []integration_tests_utils.TestTopologyMetadata{
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Required topology level - schedule all tasks on the same rack",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:              "cluster-topology",
+							RequiredTopologyLevel: "k8s.io/rack",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 1,
+						Labels: map[string]string{
+							"k8s.io/rack": "rack1",
+						},
+					},
+					"node1": {
+						GPUs: 1,
+						Labels: map[string]string{
+							"k8s.io/rack": "rack1",
+						},
+					},
+					"node2": {
+						GPUs: 1,
+						Labels: map[string]string{
+							"k8s.io/rack": "rack2",
+						},
+					},
+					"node3": {
+						GPUs: 1,
+						Labels: map[string]string{
+							"k8s.io/rack": "rack2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       4,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     4,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 4,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						NodeName:             "node2",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						NodeName:             "node3",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 2,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Required topology with multiple levels - schedule all tasks on the same spine",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+								{
+									NodeLabel: "k8s.io/spine",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:              "cluster-topology",
+							RequiredTopologyLevel: "k8s.io/spine",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node1": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       4,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     4,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 4,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 2,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Required topology with multiple levels - schedule all tasks on the same rack",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+								{
+									NodeLabel: "k8s.io/spine",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:              "cluster-topology",
+							RequiredTopologyLevel: "k8s.io/rack",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node1": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine2",
+						},
+					},
+					"node2": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack2",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node3": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack2",
+							"k8s.io/spine": "spine2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       8,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     8,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 8,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						NodeName:             "node2",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						NodeName:             "node2",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-2": {
+						NodeName:             "node3",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-3": {
+						NodeName:             "node3",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 4,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Required topology with multiple levels - schedule all tasks on the same partially occupied rack",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+								{
+									NodeLabel: "k8s.io/spine",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:              "cluster-topology",
+							RequiredTopologyLevel: "k8s.io/rack",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node1": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       8,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     8,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 8,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 2,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Required topology with multiple levels - job remains pending as no available rack can be found",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+								{
+									NodeLabel: "k8s.io/spine",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "running_job1",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node2",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:              "cluster-topology",
+							RequiredTopologyLevel: "k8s.io/rack",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node1": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine2",
+						},
+					},
+					"node2": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack2",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node3": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack2",
+							"k8s.io/spine": "spine2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       8,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     8,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 8,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"running_job1-0": {
+						NodeName:             "node2",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						GPUsRequired:         1,
+						Status:               pod_status.Pending,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						GPUsRequired:         1,
+						Status:               pod_status.Pending,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-2": {
+						GPUsRequired:         1,
+						Status:               pod_status.Pending,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-3": {
+						GPUsRequired:         1,
+						Status:               pod_status.Pending,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 0,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Preferred topology - schedule job on the same rack",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:               "cluster-topology",
+							PreferredTopologyLevel: "k8s.io/rack",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack": "rack1",
+						},
+					},
+					"node1": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack": "rack2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       4,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     4,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 4,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 2,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+		/*
+			{
+				TestTopologyBasic: test_utils.TestTopologyBasic{
+					Name: "Preferred topology - schedule job even if preferred constraint can't be met",
+					Topologies: []*kueuev1alpha1.Topology{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name: "cluster-topology",
+							},
+							Spec: kueuev1alpha1.TopologySpec{
+								Levels: []kueuev1alpha1.TopologyLevel{
+									{
+										NodeLabel: "k8s.io/rack",
+									},
+								},
+							},
+						},
+					},
+					Jobs: []*jobs_fake.TestJobBasic{
+						{
+							Name:                "running_job0",
+							RequiredGPUsPerTask: 1,
+							Priority:            constants.PriorityTrainNumber,
+							QueueName:           "queue0",
+							Tasks: []*tasks_fake.TestTaskBasic{
+								{
+									State:    pod_status.Running,
+									NodeName: "node0",
+								},
+							},
+						},
+						{
+							Name:                "running_job1",
+							RequiredGPUsPerTask: 1,
+							Priority:            constants.PriorityTrainNumber,
+							QueueName:           "queue0",
+							Tasks: []*tasks_fake.TestTaskBasic{
+								{
+									State:    pod_status.Running,
+									NodeName: "node1",
+								},
+							},
+						},
+						{
+							Name:                "pending_job0",
+							RequiredGPUsPerTask: 1,
+							Priority:            constants.PriorityTrainNumber,
+							QueueName:           "queue0",
+							Topology: &enginev2alpha2.TopologyConstraint{
+								Topology:               "cluster-topology",
+								PreferredTopologyLevel: "k8s.io/rack",
+							},
+							Tasks: []*tasks_fake.TestTaskBasic{
+								{
+									State: pod_status.Pending,
+								},
+								{
+									State: pod_status.Pending,
+								},
+							},
+						},
+					},
+					Nodes: map[string]nodes_fake.TestNodeBasic{
+						"node0": {
+							GPUs: 2,
+							Labels: map[string]string{
+								"k8s.io/rack": "rack1",
+							},
+						},
+						"node1": {
+							GPUs: 2,
+							Labels: map[string]string{
+								"k8s.io/rack": "rack2",
+							},
+						},
+					},
+					Queues: []test_utils.TestQueueBasic{
+						{
+							Name:               "queue0",
+							ParentQueue:        "department-a",
+							DeservedGPUs:       4,
+							GPUOverQuotaWeight: 1,
+							MaxAllowedGPUs:     4,
+						},
+					},
+					Departments: []test_utils.TestDepartmentBasic{
+						{
+							Name:         "department-a",
+							DeservedGPUs: 4,
+						},
+					},
+					TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+						"running_job0-0": {
+							NodeName:             "node0",
+							GPUsRequired:         1,
+							Status:               pod_status.Running,
+							DontValidateGPUGroup: true,
+						},
+						"running_job1-0": {
+							NodeName:             "node1",
+							GPUsRequired:         1,
+							Status:               pod_status.Running,
+							DontValidateGPUGroup: true,
+						},
+						"pending_job0-0": {
+							NodeName:             "node0",
+							GPUsRequired:         1,
+							Status:               pod_status.Running,
+							DontValidateGPUGroup: true,
+						},
+						"pending_job0-1": {
+							NodeName:             "node1",
+							GPUsRequired:         1,
+							Status:               pod_status.Running,
+							DontValidateGPUGroup: true,
+						},
+					},
+					Mocks: &test_utils.TestMock{
+						CacheRequirements: &test_utils.CacheMocking{
+							NumberOfCacheBinds: 2,
+						},
+					},
+				},
+				RoundsUntilMatch: 1,
+			},
+		*/
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Combined preferred and required topology constraints - schedule job although preferred constraint cannot be satisfied",
+				Topologies: []*kueuev1alpha1.Topology{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "cluster-topology",
+						},
+						Spec: kueuev1alpha1.TopologySpec{
+							Levels: []kueuev1alpha1.TopologyLevel{
+								{
+									NodeLabel: "k8s.io/rack",
+								},
+								{
+									NodeLabel: "k8s.io/spine",
+								},
+							},
+						},
+					},
+				},
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "running_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+							{
+								State:    pod_status.Running,
+								NodeName: "node0",
+							},
+							{
+								State:    pod_status.Running,
+								NodeName: "node1",
+							},
+							{
+								State:    pod_status.Running,
+								NodeName: "node2",
+							},
+							{
+								State:    pod_status.Running,
+								NodeName: "node3",
+							},
+						},
+					},
+					{
+						Name:                "pending_job0",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Topology: &enginev2alpha2.TopologyConstraint{
+							Topology:               "cluster-topology",
+							RequiredTopologyLevel:  "k8s.io/rack",
+							PreferredTopologyLevel: "k8s.io/spine",
+						},
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node1": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack1",
+							"k8s.io/spine": "spine2",
+						},
+					},
+					"node2": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack2",
+							"k8s.io/spine": "spine1",
+						},
+					},
+					"node3": {
+						GPUs: 2,
+						Labels: map[string]string{
+							"k8s.io/rack":  "rack2",
+							"k8s.io/spine": "spine2",
+						},
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						ParentQueue:        "department-a",
+						DeservedGPUs:       8,
+						GPUOverQuotaWeight: 1,
+						MaxAllowedGPUs:     8,
+					},
+				},
+				Departments: []test_utils.TestDepartmentBasic{
+					{
+						Name:         "department-a",
+						DeservedGPUs: 8,
+					},
+				},
+				TaskExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"running_job0-0": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"running_job0-1": {
+						NodeName:             "node0",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"running_job0-2": {
+						NodeName:             "node1",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"running_job0-3": {
+						NodeName:             "node2",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"running_job0-4": {
+						NodeName:             "node3",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-0": {
+						NodeName:             "node2",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job0-1": {
+						NodeName:             "node3",
+						GPUsRequired:         1,
+						Status:               pod_status.Running,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 2,
+					},
+				},
+			},
+			RoundsUntilMatch: 1,
+		},
+	}
+}


### PR DESCRIPTION
Those are the tests I have implemented:

- Require Only
  - Require topology level - schedule all tasks on capable domain (even though first domain can have part of the tasks)
  - Require topology level on multi hierarchy topology (Rack, Spine) - schedule all tasks on capable domain (even though first domain can have part of the tasks)
  - Multi hierarchy topology (Rack, Spine) cluster, require higher level (Rack) - schedule all tasks on capable domain (even though first domain can have part of the tasks)
  - Multi hierarchy topology (Rack, Spine) cluster, require higher level (Rack) - schedule all tasks on capable domain (even though its not empty domain)
  - Require topology level - dont schedule as no domain is capable to have all tasks
- Prefer Only
  - Prefer topology level - schedule all tasks on capable domain (even though first domain can have part of tasks)
  - Prefer topology level - schedule all tasks even though no domain can have all tasks
- Require + Prefer
  - Prefer + Require topology level - schedule all tasks on capable require domain (even though first require domain capable to have part of the tasks), spread on multiple prefer domain

`Prefer topology level - schedule all tasks even though no domain can have all tasks` found a bug in topology implementation - so its comment out.