### PR TITLE
Time fairshare - support tumbling window config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require (
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/NVIDIA/gpu-operator v1.8.3-0.20250724212111-616690d88d86
+	github.com/aptible/supercronic v0.2.33
 	github.com/argoproj/argo-workflows/v3 v3.6.4
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gin-contrib/pprof v1.5.2
@@ -75,7 +76,6 @@ require (
 	github.com/NVIDIA/k8s-operator-libs v0.0.0-20250311214045-7d667fbaa7ac // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/aptible/supercronic v0.2.33 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/awslabs/operatorpkg v0.0.0-20241205163410-0fff9f28d115 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/NVIDIA/k8s-operator-libs v0.0.0-20250311214045-7d667fbaa7ac // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/aptible/supercronic v0.2.33 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/awslabs/operatorpkg v0.0.0-20241205163410-0fff9f28d115 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqC
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
+github.com/aptible/supercronic v0.2.33 h1:tA/fda6BOBlPSxjAnnD4DqgLdIkasmmEdzgNpZbZ4bU=
+github.com/aptible/supercronic v0.2.33/go.mod h1:cLHAF1blBT8rPL9b4TDc0uOv4T1mdxisGTapLHgULUU=
 github.com/argoproj/argo-workflows/v3 v3.6.4 h1:5+Cc1UwaQE5ka3w7R3hxZ1TK3M6VjDEXA5WSQ/IXrxY=
 github.com/argoproj/argo-workflows/v3 v3.6.4/go.mod h1:2f5zB8CkbNCCO1od+kd1dWkVokqcuyvu+tc+Jwx1MZg=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/pkg/scheduler/cache/usagedb/api/interface.go
+++ b/pkg/scheduler/cache/usagedb/api/interface.go
@@ -37,6 +37,9 @@ type UsageParams struct {
 	WindowSize *time.Duration `yaml:"windowSize" json:"windowSize"`
 	// Window type for time-series aggregation. If not set, defaults to sliding.
 	WindowType *WindowType `yaml:"windowType" json:"windowType"`
+	// Cron string for the usage. If not set, the usage will not be aggregated.
+	CronString string `yaml:"cronString" json:"cronString"`
+
 	// ExtraParams are extra parameters for the usage db client, which are client specific.
 	ExtraParams map[string]string `yaml:"extraParams" json:"extraParams"`
 }

--- a/pkg/scheduler/cache/usagedb/api/interface.go
+++ b/pkg/scheduler/cache/usagedb/api/interface.go
@@ -37,8 +37,8 @@ type UsageParams struct {
 	WindowSize *time.Duration `yaml:"windowSize" json:"windowSize"`
 	// Window type for time-series aggregation. If not set, defaults to sliding.
 	WindowType *WindowType `yaml:"windowType" json:"windowType"`
-	// Cron string for the usage. If not set, the usage will not be aggregated.
-	CronString string `yaml:"cronString" json:"cronString"`
+	// A cron string used to determine when to reset resource usage for all queues.
+	TumblingWindowCronString string `yaml:"tumblingWindowCronString" json:"tumblingWindowCronString"`
 
 	// ExtraParams are extra parameters for the usage db client, which are client specific.
 	ExtraParams map[string]string `yaml:"extraParams" json:"extraParams"`

--- a/pkg/scheduler/cache/usagedb/prometheus/prometheus.go
+++ b/pkg/scheduler/cache/usagedb/prometheus/prometheus.go
@@ -13,11 +13,18 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache/usagedb/api"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
+	"github.com/aptible/supercronic/cronexpr"
 	promapi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	v1 "k8s.io/api/core/v1"
 )
+
+const (
+	queueNameLabel = "queue_name"
+)
+
+type queryUsageFunction func(ctx context.Context, allocationMetric string) (map[common_info.QueueID]float64, error)
 
 var _ api.Interface = &PrometheusClient{}
 
@@ -27,9 +34,11 @@ type PrometheusClient struct {
 	usageParams *api.UsageParams
 
 	// Extra params
-	usageQueryTimeout    time.Duration
-	queryResolution      time.Duration
-	allocationMetricsMap map[string]string
+	usageQueryTimeout            time.Duration
+	queryResolution              time.Duration
+	allocationMetricsMap         map[string]string
+	queryUsageFunction           queryUsageFunction
+	tumblingWindowCronExpression *cronexpr.Expression
 }
 
 func NewPrometheusClient(address string, params *api.UsageParams) (api.Interface, error) {
@@ -44,12 +53,6 @@ func NewPrometheusClient(address string, params *api.UsageParams) (api.Interface
 
 	v1api := promv1.NewAPI(client)
 
-	if params.WindowType != nil && *params.WindowType == api.TumblingWindow {
-		log.InfraLogger.V(3).Warnf("Tumbling window is not supported for prometheus client, using sliding window instead")
-		windowType := api.SlidingWindow
-		params.WindowType = &windowType
-	}
-
 	usageQueryTimeout := params.GetExtraDurationParamOrDefault("usageQueryTimeout", 10*time.Second)
 	queryResolution := params.GetExtraDurationParamOrDefault("queryResolution", 1*time.Minute)
 
@@ -59,7 +62,7 @@ func NewPrometheusClient(address string, params *api.UsageParams) (api.Interface
 		"memory":         params.GetExtraStringParamOrDefault("memoryAllocationMetric", "kai_queue_allocated_memory_bytes"),
 	}
 
-	return &PrometheusClient{
+	clientObj := &PrometheusClient{
 		client:      v1api,
 		promClient:  client,
 		usageParams: params,
@@ -67,7 +70,25 @@ func NewPrometheusClient(address string, params *api.UsageParams) (api.Interface
 		usageQueryTimeout:    usageQueryTimeout,
 		queryResolution:      queryResolution,
 		allocationMetricsMap: allocationMetricsMap,
-	}, nil
+	}
+
+	if params.WindowType == nil {
+		return nil, fmt.Errorf("window type is not set in usage params")
+	}
+	switch *params.WindowType {
+	case api.TumblingWindow:
+		clientObj.queryUsageFunction = clientObj.queryTumblingWindowUsage
+
+		cronExpression, err := cronexpr.Parse(params.CronString)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing cron string '%s' for usage tumbling window: %v", params.CronString, err)
+		}
+		clientObj.tumblingWindowCronExpression = cronExpression
+	case api.SlidingWindow:
+		clientObj.queryUsageFunction = clientObj.querySlidingWindowUsage
+	}
+
+	return clientObj, nil
 }
 
 func (p *PrometheusClient) GetResourceUsage() (*queue_info.ClusterUsage, error) {
@@ -77,7 +98,7 @@ func (p *PrometheusClient) GetResourceUsage() (*queue_info.ClusterUsage, error) 
 	usage := queue_info.NewClusterUsage()
 
 	for _, resource := range []v1.ResourceName{commonconstants.GpuResource, v1.ResourceCPU, v1.ResourceMemory} {
-		resourceUsage, err := p.queryResourceUsage(ctx, p.allocationMetricsMap[string(resource)])
+		resourceUsage, err := p.queryUsageFunction(ctx, p.allocationMetricsMap[string(resource)])
 		if err != nil {
 			return nil, fmt.Errorf("error querying %s and usage: %v", resource, err)
 		}
@@ -92,7 +113,7 @@ func (p *PrometheusClient) GetResourceUsage() (*queue_info.ClusterUsage, error) 
 	return usage, nil
 }
 
-func (p *PrometheusClient) queryResourceUsage(ctx context.Context, allocationMetric string) (map[common_info.QueueID]float64, error) {
+func (p *PrometheusClient) querySlidingWindowUsage(ctx context.Context, allocationMetric string) (map[common_info.QueueID]float64, error) {
 	queueUsage := make(map[common_info.QueueID]float64)
 
 	decayedAllocationMetric := allocationMetric
@@ -126,7 +147,7 @@ func (p *PrometheusClient) queryResourceUsage(ctx context.Context, allocationMet
 	}
 
 	for _, usageSample := range usageVector {
-		queueName := string(usageSample.Metric["queue_name"])
+		queueName := string(usageSample.Metric[queueNameLabel])
 		value := float64(usageSample.Value)
 
 		queueUsage[common_info.QueueID(queueName)] = value
@@ -144,4 +165,60 @@ func getExponentialDecayQuery(halfLifePeriod *time.Duration) string {
 	now := time.Now().Unix()
 
 	return fmt.Sprintf("0.5^((%d - time()) / %f)", now, halfLifeSeconds)
+}
+
+func (p *PrometheusClient) queryTumblingWindowUsage(ctx context.Context, allocationMetric string) (map[common_info.QueueID]float64, error) {
+	queuesUsage := make(map[common_info.QueueID]float64)
+
+	usageQuery := fmt.Sprintf("(%s)[%s:%s]",
+		allocationMetric,
+		p.usageParams.WindowSize.String(),
+		p.queryResolution.String(),
+	)
+
+	usageResult, warnings, err := p.client.Query(ctx, usageQuery, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("error running query %s: %v", usageQuery, err)
+	}
+
+	// Log warnings if exist
+	for _, w := range warnings {
+		log.InfraLogger.V(3).Warnf("Warning querying cluster usage metric %s: %s", allocationMetric, w)
+	}
+
+	if usageResult.Type() != model.ValMatrix {
+		return nil, fmt.Errorf("unexpected query result: got %s, expected matrix", usageResult.Type())
+	}
+
+	usageMatrix := usageResult.(model.Matrix)
+	if len(usageMatrix) == 0 {
+		return nil, fmt.Errorf("no data returned for cluster usage metric %s", allocationMetric)
+	}
+
+	lastUsageReset := p.getLatestUsageResetTime()
+
+	for _, usageSample := range usageMatrix {
+		queueID := common_info.QueueID(usageSample.Metric[queueNameLabel])
+
+		for _, usagePoint := range usageSample.Values {
+			if usagePoint.Timestamp.Time().Before(lastUsageReset) {
+				continue // Skip data before the last tumbling reset
+			}
+			queuesUsage[queueID] += float64(usagePoint.Value)
+		}
+	}
+
+	return queuesUsage, nil
+}
+
+func (p *PrometheusClient) getLatestUsageResetTime() time.Time {
+	maxWindowStartingPoint := time.Now().Add(-*p.usageParams.WindowSize)
+	lastUsageReset := maxWindowStartingPoint
+	nextInWindowReset := maxWindowStartingPoint
+
+	for nextInWindowReset.Before(time.Now()) {
+		lastUsageReset = nextInWindowReset
+		nextInWindowReset = p.tumblingWindowCronExpression.Next(nextInWindowReset)
+	}
+	return lastUsageReset
 }

--- a/pkg/scheduler/cache/usagedb/prometheus/prometheus_test.go
+++ b/pkg/scheduler/cache/usagedb/prometheus/prometheus_test.go
@@ -15,28 +15,53 @@ func TestNewPrometheusClient(t *testing.T) {
 	tests := []struct {
 		name          string
 		address       string
+		params        *api.UsageParams
 		expectError   bool
 		errorContains string
 	}{
 		{
 			name:          "valid address",
 			address:       "http://localhost:9090",
+			params:        nil,
 			expectError:   false,
 			errorContains: "",
 		},
 		{
 			name:          "invalid address",
 			address:       "://invalid:9090",
+			params:        nil,
 			expectError:   true,
 			errorContains: "error creating prometheus client",
+		},
+		{
+			name:    "invalid cron string - for tumbling window",
+			address: "http://localhost:9090",
+			params: &api.UsageParams{
+				WindowType: &[]api.WindowType{api.TumblingWindow}[0],
+				CronString: "invalid",
+			},
+			expectError:   true,
+			errorContains: "error parsing cron string 'invalid' for usage tumbling window",
+		},
+		{
+			name:    "invalid cron string - for sliding window",
+			address: "http://localhost:9090",
+			params: &api.UsageParams{
+				WindowType: &[]api.WindowType{api.SlidingWindow}[0],
+				CronString: "invalid",
+			},
+			expectError:   false,
+			errorContains: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			params := &api.UsageParams{}
-			params.SetDefaults()
-			client, err := NewPrometheusClient(tt.address, params)
+			if tt.params == nil {
+				tt.params = &api.UsageParams{}
+				tt.params.SetDefaults()
+			}
+			client, err := NewPrometheusClient(tt.address, tt.params)
 			if tt.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorContains)

--- a/pkg/scheduler/cache/usagedb/prometheus/prometheus_test.go
+++ b/pkg/scheduler/cache/usagedb/prometheus/prometheus_test.go
@@ -37,8 +37,8 @@ func TestNewPrometheusClient(t *testing.T) {
 			name:    "invalid cron string - for tumbling window",
 			address: "http://localhost:9090",
 			params: &api.UsageParams{
-				WindowType: &[]api.WindowType{api.TumblingWindow}[0],
-				CronString: "invalid",
+				WindowType:               &[]api.WindowType{api.TumblingWindow}[0],
+				TumblingWindowCronString: "invalid",
 			},
 			expectError:   true,
 			errorContains: "error parsing cron string 'invalid' for usage tumbling window",
@@ -47,8 +47,8 @@ func TestNewPrometheusClient(t *testing.T) {
 			name:    "invalid cron string - for sliding window",
 			address: "http://localhost:9090",
 			params: &api.UsageParams{
-				WindowType: &[]api.WindowType{api.SlidingWindow}[0],
-				CronString: "invalid",
+				WindowType:               &[]api.WindowType{api.SlidingWindow}[0],
+				TumblingWindowCronString: "invalid",
 			},
 			expectError:   false,
 			errorContains: "",


### PR DESCRIPTION
Add support for Prometheus client tumbling window configuration - allow the usage data used for fairshare calculations to be reset each X time instead of a sliding window