### PR TITLE
Grove: Add support for PodGangSet to PodCliqueSet API name change

### DIFF
--- a/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -150,6 +150,7 @@ rules:
   resources:
   - podcliques
   - podcliquescalinggroups
+  - podcliquesets
   - podgangsets
   verbs:
   - get
@@ -160,6 +161,7 @@ rules:
   resources:
   - podcliques/finalizers
   - podcliquescalinggroups/finalizers
+  - podcliquesets/finalizers
   - podgangsets/finalizers
   verbs:
   - create

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -257,6 +257,11 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 			Version: "v1alpha1",
 			Kind:    "PodGangSet",
 		}: groveGrouper,
+		{
+			Group:   "grove.io",
+			Version: "v1alpha1",
+			Kind:    "PodCliqueSet",
+		}: groveGrouper,
 	}
 
 	skipTopOwnerGrouper := skiptopowner.NewSkipTopOwnerGrouper(kubeClient, defaultGrouper, table)

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -40,6 +40,8 @@ func (gg *GroveGrouper) Name() string {
 
 // +kubebuilder:rbac:groups=grove.io,resources=podgangsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podgangsets/finalizers,verbs=patch;update;create
+// +kubebuilder:rbac:groups=grove.io,resources=podcliquesets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=grove.io,resources=podcliquesets/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=grove.io,resources=podcliquescalinggroups,verbs=get;list;watch

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -38,6 +38,9 @@ func (gg *GroveGrouper) Name() string {
 	return "Grove Grouper"
 }
 
+// PodCliqueSet is the top-level CR in Grove. PodGangSet is the older name and got renamed to PodCLiqueSet.
+// PodGangSet support and rbac will be eventually deprecated.
+
 // +kubebuilder:rbac:groups=grove.io,resources=podgangsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podgangsets/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=grove.io,resources=podcliquesets,verbs=get;list;watch


### PR DESCRIPTION
Gove top-level CR `PodGangSet` has been renamed to `PodCliqueSet` ([Grove Issue](https://github.com/NVIDIA/grove/issues/182)). This PR adds support for new name in KAI.