### PR TITLE
Topology plugin - Filter out worse case domains

### DIFF
--- a/pkg/scheduler/plugins/topology/job_filtering.go
+++ b/pkg/scheduler/plugins/topology/job_filtering.go
@@ -148,7 +148,7 @@ func (t *topologyPlugin) calcSubTreeAllocatable(
 func calcNodeAccommodation(jobAllocationMetaData *jobAllocationMetaData, node *node_info.NodeInfo) int {
 	allocatablePodsCount := 0
 	for _, resourceRepresentorPod := range jobAllocationMetaData.allocationTestPods {
-		if node.IsTaskAllocatable(resourceRepresentorPod) {
+		if node.IsTaskAllocatableOnReleasingOrIdle(resourceRepresentorPod) {
 			allocatablePodsCount++
 		} else {
 			break
@@ -164,7 +164,7 @@ func calcNodeAccommodation(jobAllocationMetaData *jobAllocationMetaData, node *n
 				ResReq: calcNextAllocationTestPodResources(latestTestPod.ResReq, jobAllocationMetaData.maxPodResources),
 			}
 			jobAllocationMetaData.allocationTestPods = append(jobAllocationMetaData.allocationTestPods, iAllocationsTestPod)
-			if node.IsTaskAllocatable(iAllocationsTestPod) {
+			if node.IsTaskAllocatableOnReleasingOrIdle(iAllocationsTestPod) {
 				allocatablePodsCount++
 			} else {
 				break


### PR DESCRIPTION
In this PR we change the mechanism that calculates allocatable pods.

Instead of using `IsTaskAllocatable` we use `IsTaskAllocatableOnReleasingOrIdle`.

This mechanism goal is to filter out domains that can have the job in terms of resources.
If `IsTaskAllocatableOnReleasingOrIdle` is false, it means for sure that `IsTaskAllocatable` is false.
But not the other way arround.

That means we filter out less domains with that function.
Which is good, as this mechanism is only optimization, but it filters out domains, so we prefer false-positive then false-negative