### PR TITLE
Prepare infra for time aware env tests

### DIFF
--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -47,9 +47,12 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/cmd/scheduler/app/options"
 	"github.com/NVIDIA/KAI-scheduler/cmd/scheduler/profiling"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf_util"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/metrics"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/version"
 )
 
@@ -160,8 +163,17 @@ func Run(opt *options.ServerOption, config *restclient.Config, mux *http.ServeMu
 	}
 	metrics.InitMetrics(opt.MetricsNamespace)
 
+	actions.InitDefaultActions()
+	plugins.InitDefaultPlugins()
+
+	// Load configuration of scheduler
+	schedConfig, err := conf_util.ResolveConfigurationFromFile(opt.SchedulerConf)
+	if err != nil {
+		return fmt.Errorf("error resolving configuration from file: %v", err)
+	}
+
 	scheduler, err := scheduler.NewScheduler(config,
-		opt.SchedulerConf,
+		schedConfig,
 		BuildSchedulerParams(opt),
 		mux,
 	)

--- a/pkg/env-tests/binder/binder.go
+++ b/pkg/env-tests/binder/binder.go
@@ -20,7 +20,7 @@ import (
 func RunBinder(cfg *rest.Config, ctx context.Context) error {
 	options := app.InitOptions(pflag.NewFlagSet("binder-test", pflag.ContinueOnError))
 
-	options.MetricsAddr = ":8084"
+	options.MetricsAddr = ":8085"
 	options.EnableLeaderElection = false
 
 	app, err := app.New(options, cfg)

--- a/pkg/env-tests/env_tests_suite_test.go
+++ b/pkg/env-tests/env_tests_suite_test.go
@@ -15,6 +15,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 	featuregate "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,6 +64,9 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
+
+	// Effectively disable rate limiting
+	cfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
 
 	// Add any scheme registration here if needed for your custom CRDs
 	kaiv2.AddToScheme(scheme.Scheme)

--- a/pkg/env-tests/scheduler_test.go
+++ b/pkg/env-tests/scheduler_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 		Expect(ctrlClient.Create(ctx, testNode)).To(Succeed(), "Failed to create test node")
 
 		stopCh = make(chan struct{})
-		err := scheduler.RunScheduler(cfg, stopCh)
+		err := scheduler.RunScheduler(cfg, nil, stopCh)
 		Expect(err).NotTo(HaveOccurred(), "Failed to run scheduler")
 	})
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -85,6 +85,7 @@ type SchedulerCacheParams struct {
 	KubeClient                  kubernetes.Interface
 	KAISchedulerClient          kubeaischedulerver.Interface
 	KueueClient                 kueueclient.Interface
+	UsageDBParams               *usageapi.UsageParams
 	UsageDBClient               usageapi.Interface
 	DetailedFitErrors           bool
 	ScheduleCSIStorage          bool
@@ -161,7 +162,10 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCac
 	sc.podGroupLister = sc.kubeAiSchedulerInformerFactory.Scheduling().V2alpha2().PodGroups().Lister()
 
 	if schedulerCacheParams.UsageDBClient != nil {
-		sc.usageLister = usagedb.NewUsageLister(schedulerCacheParams.UsageDBClient, nil, nil, nil)
+		sc.usageLister = usagedb.NewUsageLister(schedulerCacheParams.UsageDBClient,
+			schedulerCacheParams.UsageDBParams.FetchInterval,
+			schedulerCacheParams.UsageDBParams.StalenessPeriod,
+			schedulerCacheParams.UsageDBParams.WaitTimeout)
 	}
 
 	clusterInfo, err := cluster_info.New(sc.informerFactory, sc.kubeAiSchedulerInformerFactory, sc.kueueInformerFactory, sc.usageLister, sc.schedulingNodePoolParams,

--- a/pkg/scheduler/cache/usagedb/api/defaults.go
+++ b/pkg/scheduler/cache/usagedb/api/defaults.go
@@ -17,6 +17,18 @@ func (up *UsageParams) SetDefaults() {
 		windowType := SlidingWindow
 		up.WindowType = &windowType
 	}
+	if up.FetchInterval == nil {
+		fetchInterval := 1 * time.Minute
+		up.FetchInterval = &fetchInterval
+	}
+	if up.StalenessPeriod == nil {
+		stalenessPeriod := 5 * time.Minute
+		up.StalenessPeriod = &stalenessPeriod
+	}
+	if up.WaitTimeout == nil {
+		waitTimeout := 1 * time.Minute
+		up.WaitTimeout = &waitTimeout
+	}
 }
 
 // WindowType defines the type of time window for aggregating usage data

--- a/pkg/scheduler/cache/usagedb/api/interface.go
+++ b/pkg/scheduler/cache/usagedb/api/interface.go
@@ -39,6 +39,12 @@ type UsageParams struct {
 	WindowType *WindowType `yaml:"windowType" json:"windowType"`
 	// A cron string used to determine when to reset resource usage for all queues.
 	TumblingWindowCronString string `yaml:"tumblingWindowCronString" json:"tumblingWindowCronString"`
+	// Fetch interval of the usage. Default is 1 minute.
+	FetchInterval *time.Duration `yaml:"fetchInterval" json:"fetchInterval"`
+	// Staleness period of the usage. Default is 5 minutes.
+	StalenessPeriod *time.Duration `yaml:"stalenessPeriod" json:"stalenessPeriod"`
+	// Wait timeout of the usage. Default is 1 minute.
+	WaitTimeout *time.Duration `yaml:"waitTimeout" json:"waitTimeout"`
 
 	// ExtraParams are extra parameters for the usage db client, which are client specific.
 	ExtraParams map[string]string `yaml:"extraParams" json:"extraParams"`

--- a/pkg/scheduler/conf_util/scheduler_conf_util.go
+++ b/pkg/scheduler/conf_util/scheduler_conf_util.go
@@ -65,7 +65,7 @@ func ResolveConfigurationFromFile(confPath string) (*conf.SchedulerConfiguration
 		return nil, err
 	}
 
-	defaultConfig, err := loadSchedulerConf(defaultSchedulerConf)
+	defaultConfig, err := GetDefaultSchedulerConf()
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +103,10 @@ func GetActionsFromConfig(conf *conf.SchedulerConfiguration) ([]framework.Action
 		}
 	}
 	return actions, nil
+}
+
+func GetDefaultSchedulerConf() (*conf.SchedulerConfiguration, error) {
+	return loadSchedulerConf(defaultSchedulerConf)
 }
 
 func loadSchedulerConf(confStr string) (*conf.SchedulerConfiguration, error) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -32,6 +32,7 @@ import (
 	kubeaischedulerver "github.com/NVIDIA/KAI-scheduler/pkg/apis/client/clientset/versioned"
 	schedcache "github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache/usagedb"
+	api "github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache/usagedb/api"
 	usagedbapi "github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache/usagedb/api"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf_util"
@@ -63,11 +64,16 @@ func NewScheduler(
 		return nil, fmt.Errorf("error getting usage db client: %v", err)
 	}
 
+	var usageDBParams *api.UsageParams
+	if schedulerConf.UsageDBConfig != nil {
+		usageDBParams = schedulerConf.UsageDBConfig.GetUsageParams()
+	}
+
 	schedulerCacheParams := &schedcache.SchedulerCacheParams{
 		KubeClient:                  kubeClient,
 		KAISchedulerClient:          kubeAiSchedulerClient,
 		KueueClient:                 kueueClient,
-		UsageDBParams:               schedulerConf.UsageDBConfig.GetUsageParams(),
+		UsageDBParams:               usageDBParams,
 		UsageDBClient:               usageDBClient,
 		SchedulerName:               schedulerParams.SchedulerName,
 		NodePoolParams:              schedulerParams.PartitionParams,


### PR DESCRIPTION
* Init default actions & plugins outside the scheduler, to allow injecting scheduler config externally
* Changed binder metrics port in env tests
* Allow configuration of informer params from UsageDB params (fetch interval, staleness period, timeout)