### PR TITLE
Changed SubSetNodes signature to use SubGroupInfo instead of SubGroupSet

### DIFF
--- a/pkg/scheduler/actions/common/allocate.go
+++ b/pkg/scheduler/actions/common/allocate.go
@@ -27,7 +27,8 @@ func AllocateJob(ssn *framework.Session, stmt *framework.Statement, nodes []*nod
 		return false
 	}
 
-	nodeSets, err := ssn.SubsetNodesFn(job, job.RootSubGroupSet, tasksToAllocate, nodes)
+	podSets := job.RootSubGroupSet.GetAllPodSets()
+	nodeSets, err := ssn.SubsetNodesFn(job, &job.RootSubGroupSet.SubGroupInfo, podSets, tasksToAllocate, nodes)
 	if err != nil {
 		log.InfraLogger.Errorf(
 			"Failed to run SubsetNodes on job <%s/%s>: %v", job.Namespace, job.Namespace, err)

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -116,7 +116,7 @@ func NewPodGroupInfo(uid common_info.PodGroupID, tasks ...*pod_info.PodInfo) *Po
 			Stale:     false,
 		},
 		RootSubGroupSet: defaultSubGroupSet,
-		PodSets:         defaultSubGroupSet.GetPodSets(),
+		PodSets:         defaultSubGroupSet.GetAllPodSets(),
 
 		LastStartTimestamp:   nil,
 		activeAllocatedCount: ptr.To(0),
@@ -199,7 +199,7 @@ func (pgi *PodGroupInfo) setSubGroups(podGroup *enginev2alpha2.PodGroup) error {
 		return err
 	}
 	pgi.RootSubGroupSet = rootSubGroupSet
-	podSets := rootSubGroupSet.GetPodSets()
+	podSets := rootSubGroupSet.GetAllPodSets()
 	if len(podSets) > 0 {
 		pgi.PodSets = podSets
 	} else {
@@ -480,7 +480,7 @@ func (pgi *PodGroupInfo) CloneWithTasks(tasks []*pod_info.PodInfo) *PodGroupInfo
 	pgi.CreationTimestamp.DeepCopyInto(&info.CreationTimestamp)
 
 	info.RootSubGroupSet = pgi.RootSubGroupSet.Clone()
-	info.PodSets = info.RootSubGroupSet.GetPodSets()
+	info.PodSets = info.RootSubGroupSet.GetAllPodSets()
 
 	for _, task := range tasks {
 		info.AddTaskInfo(task.Clone())

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset.go
@@ -63,13 +63,13 @@ func (sgs *SubGroupSet) Clone() *SubGroupSet {
 	return root
 }
 
-func (sgs *SubGroupSet) GetPodSets() map[string]*PodSet {
+func (sgs *SubGroupSet) GetAllPodSets() map[string]*PodSet {
 	result := make(map[string]*PodSet)
 	for _, podSet := range sgs.podSets {
 		result[podSet.GetName()] = podSet
 	}
 	for _, subGroup := range sgs.groups {
-		podSets := subGroup.GetPodSets()
+		podSets := subGroup.GetAllPodSets()
 		for name, podSet := range podSets {
 			result[name] = podSet
 		}

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
@@ -175,7 +175,7 @@ func TestGetPodSets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sg, want := tt.build()
-			got := sg.GetPodSets()
+			got := sg.GetAllPodSets()
 			if len(got) != len(want) {
 				t.Errorf("expected %d podsets, got %d", len(want), len(got))
 			}

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -30,7 +30,8 @@ import (
 )
 
 // SubsetNodesFn is used to divide the nodes into sets
-type SubsetNodesFn func(podGroup *podgroup_info.PodGroupInfo, subGroupSet *subgroup_info.SubGroupSet, tasks []*pod_info.PodInfo, nodeSet node_info.NodeSet) ([]node_info.NodeSet, error)
+type SubsetNodesFn func(podGroup *podgroup_info.PodGroupInfo, subGroup *subgroup_info.SubGroupInfo,
+	podSets map[string]*subgroup_info.PodSet, tasks []*pod_info.PodInfo, nodeSet node_info.NodeSet) ([]node_info.NodeSet, error)
 
 // PredicateFn is used to predicate node for task.
 type PredicateFn func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo, *node_info.NodeInfo) error

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -264,7 +264,9 @@ func (ssn *Session) SubGroupOrderFn(l, r interface{}) bool {
 	return lSubGroup.GetName() < rSubGroup.GetName()
 }
 
-func (ssn *Session) QueueOrderFn(lQ, rQ *queue_info.QueueInfo, lJob, rJob *podgroup_info.PodGroupInfo, lVictims, rVictims []*podgroup_info.PodGroupInfo) bool {
+func (ssn *Session) QueueOrderFn(lQ, rQ *queue_info.QueueInfo, lJob, rJob *podgroup_info.PodGroupInfo,
+	lVictims, rVictims []*podgroup_info.PodGroupInfo,
+) bool {
 	for _, qof := range ssn.QueueOrderFns {
 		if j := qof(lQ, rQ, lJob, rJob, lVictims, rVictims); j != 0 {
 			return j < 0
@@ -322,14 +324,17 @@ func (ssn *Session) IsTaskAllocationOnNodeOverCapacityFn(task *pod_info.PodInfo,
 	}
 }
 
-func (ssn *Session) SubsetNodesFn(podGroup *podgroup_info.PodGroupInfo, subGroupSet *subgroup_info.SubGroupSet, tasks []*pod_info.PodInfo, initNodeSet node_info.NodeSet) ([]node_info.NodeSet, error) {
+func (ssn *Session) SubsetNodesFn(
+	podGroup *podgroup_info.PodGroupInfo, subGroupInfo *subgroup_info.SubGroupInfo,
+	podSets map[string]*subgroup_info.PodSet, tasks []*pod_info.PodInfo, initNodeSet node_info.NodeSet,
+) ([]node_info.NodeSet, error) {
 	nodeSets := []node_info.NodeSet{initNodeSet}
 	for _, subsetNodesFn := range ssn.SubsetNodesFns {
 		log.InfraLogger.V(7).Infof(
 			"Running plugin func <%v> on podGroup <%s/%s>", subsetNodesFn, podGroup.Namespace, podGroup.Namespace)
 		var newNodeSets []node_info.NodeSet
 		for _, nodeSet := range nodeSets {
-			nodeSubsets, err := subsetNodesFn(podGroup, subGroupSet, tasks, nodeSet)
+			nodeSubsets, err := subsetNodesFn(podGroup, subGroupInfo, podSets, tasks, nodeSet)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -113,7 +113,7 @@ func TestPartitionMultiImplementation(t *testing.T) {
 		},
 	}
 
-	shardClusterSubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet) ([]node_info.NodeSet, error) {
+	shardClusterSubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupInfo, _ map[string]*subgroup_info.PodSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet) ([]node_info.NodeSet, error) {
 		var subset1 []*node_info.NodeInfo
 		var subset2 []*node_info.NodeInfo
 		for _, node := range nodeset {
@@ -126,7 +126,7 @@ func TestPartitionMultiImplementation(t *testing.T) {
 		return []node_info.NodeSet{subset1, subset2}, nil
 	}
 
-	topologySubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet) ([]node_info.NodeSet, error) {
+	topologySubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupInfo, _ map[string]*subgroup_info.PodSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet) ([]node_info.NodeSet, error) {
 		var subset1 []*node_info.NodeInfo
 		var subset2 []*node_info.NodeInfo
 		for _, node := range nodeset {
@@ -144,7 +144,7 @@ func TestPartitionMultiImplementation(t *testing.T) {
 	ssn.AddSubsetNodesFn(shardClusterSubseting)
 	ssn.AddSubsetNodesFn(topologySubseting)
 
-	partitions, _ := ssn.SubsetNodesFn(podgroup_info.NewPodGroupInfo("a"), nil, nil, nodes)
+	partitions, _ := ssn.SubsetNodesFn(podgroup_info.NewPodGroupInfo("a"), nil, nil, nil, nodes)
 
 	assert.Equal(t, 4, len(partitions))
 

--- a/pkg/scheduler/plugins/topology/job_filtering_test.go
+++ b/pkg/scheduler/plugins/topology/job_filtering_test.go
@@ -390,7 +390,9 @@ func TestTopologyPlugin_subsetNodesFn(t *testing.T) {
 			}
 
 			// Call the function under test
-			subsets, err := plugin.subSetNodesFn(job, job.RootSubGroupSet, podgroup_info.GetTasksToAllocate(job, nil, nil, true), maps.Values(nodesInfoMap))
+			subsets, err := plugin.subSetNodesFn(job, &job.RootSubGroupSet.SubGroupInfo,
+				job.RootSubGroupSet.GetAllPodSets(), podgroup_info.GetTasksToAllocate(job, nil, nil, true),
+				maps.Values(nodesInfoMap))
 
 			// Check error
 			if tt.expectedError != "" {
@@ -723,7 +725,7 @@ func TestTopologyPlugin_calculateRelevantDomainLevels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := &topologyPlugin{}
 
-			result, err := plugin.calculateRelevantDomainLevels(tt.subGroupSet, tt.topologyTree)
+			result, err := plugin.calculateRelevantDomainLevels(&tt.subGroupSet.SubGroupInfo, tt.topologyTree)
 
 			// Check error
 			if tt.expectedError != "" {
@@ -1081,7 +1083,7 @@ func TestTopologyPlugin_calcTreeAllocatable(t *testing.T) {
 			},
 		},
 		{
-			name: "no leaf domains - no allocateable domains",
+			name: "no leaf domains - no allocatable domains",
 			job: &jobs_fake.TestJobBasic{
 				Name:                "test-job",
 				RequiredCPUsPerTask: 2000, // Too much for any node
@@ -1840,7 +1842,9 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 			for _, podSet := range tt.job.PodSets {
 				tt.job.RootSubGroupSet.AddPodSet(podSet)
 			}
-			result, err := plugin.getJobAllocatableDomains(tt.job, tt.job.RootSubGroupSet, len(podgroup_info.GetTasksToAllocate(tt.job, nil, nil, true)), tt.topologyTree)
+			result, err := plugin.getJobAllocatableDomains(tt.job, &tt.job.RootSubGroupSet.SubGroupInfo,
+				tt.job.RootSubGroupSet.GetAllPodSets(), len(podgroup_info.GetTasksToAllocate(tt.job, nil, nil, true)),
+				tt.topologyTree)
 
 			// Check error
 			if tt.expectedError != "" {

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
+	kueuev1alpha1 "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
@@ -31,7 +33,6 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/dra_fake"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
-	kueuev1alpha1 "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 )
 
 var SchedulerVerbosity = flag.String("vv", "", "Scheduler's verbosity")


### PR DESCRIPTION
This PR is a preparation for a future change in allocate algorithm to support multi leveled topology constraint in subgroup hierarchical structure. The main change here is in SubSetNodes signature that now receives SubGroupInfo parameter instead of SubGroupSet.