### PR TITLE
test: Time aware fairness tracker

### DIFF
--- a/pkg/env-tests/schedulerplugins/plugins.go
+++ b/pkg/env-tests/schedulerplugins/plugins.go
@@ -1,0 +1,72 @@
+package schedulerplugins
+
+import (
+	"sync"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
+)
+
+var plugin *FairnessTrackerPlugin
+
+func GetFairnessTrackerPlugin() *FairnessTrackerPlugin {
+	return plugin
+}
+
+// QueueFairShareSnapshot stores the fair share for a queue at a point in time
+type QueueFairShareSnapshot struct {
+	QueueID   common_info.QueueID
+	FairShare *resource_info.ResourceRequirements
+}
+
+type FairnessTrackerPlugin struct {
+	// snapshots stores the fair share for each queue when the session opens
+	snapshots map[common_info.QueueID]resource_info.ResourceRequirements
+	mu        sync.RWMutex
+}
+
+func New(arguments framework.PluginArguments) framework.Plugin {
+	if plugin != nil {
+		return plugin
+	}
+	plugin = &FairnessTrackerPlugin{
+		snapshots: map[common_info.QueueID]resource_info.ResourceRequirements{},
+		mu:        sync.RWMutex{},
+	}
+	return plugin
+}
+
+func (pp *FairnessTrackerPlugin) Name() string {
+	return "fairnessTracker"
+}
+
+func (pp *FairnessTrackerPlugin) OnSessionOpen(ssn *framework.Session) {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	// Clear previous snapshots
+	pp.snapshots = map[common_info.QueueID]resource_info.ResourceRequirements{}
+
+	// Copy fair shares for all queues
+	for queueID, queueInfo := range ssn.Queues {
+		fairShare := ssn.QueueFairShare(queueInfo)
+		if fairShare != nil {
+			pp.snapshots[queueID] = *fairShare.Clone()
+		}
+	}
+}
+
+func (pp *FairnessTrackerPlugin) OnSessionClose(_ *framework.Session) {}
+
+// GetSnapshots returns a copy of the current snapshots (thread-safe)
+func (pp *FairnessTrackerPlugin) GetSnapshots() map[common_info.QueueID]resource_info.ResourceRequirements {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+
+	snapshots := make(map[common_info.QueueID]resource_info.ResourceRequirements)
+	for queueID, fairShare := range pp.snapshots {
+		snapshots[queueID] = *fairShare.Clone()
+	}
+	return snapshots
+}

--- a/pkg/env-tests/timeaware/data.go
+++ b/pkg/env-tests/timeaware/data.go
@@ -1,0 +1,38 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package timeaware
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+)
+
+type SimulationDataPoint struct {
+	Allocation float64
+	FairShare  float64
+}
+
+type SimulationHistory []map[common_info.QueueID]SimulationDataPoint
+
+func (a SimulationHistory) ToCSV() string {
+	var builder strings.Builder
+
+	// Pre-allocate based on estimated size
+	// Header + estimated 50 bytes per entry
+	estimatedSize := 32
+	for _, dataPoints := range a {
+		estimatedSize += len(dataPoints) * 50
+	}
+	builder.Grow(estimatedSize)
+
+	builder.WriteString("Time,QueueID,Allocation,FairShare\n")
+	for timeIndex, allocationDataPoint := range a {
+		for queueID, allocationDataPoint := range allocationDataPoint {
+			builder.WriteString(fmt.Sprintf("%d,%s,%f,%f\n", timeIndex, queueID, allocationDataPoint.Allocation, allocationDataPoint.FairShare))
+		}
+	}
+	return builder.String()
+}

--- a/pkg/scheduler/cache/usagedb/fake/fake_with_history.go
+++ b/pkg/scheduler/cache/usagedb/fake/fake_with_history.go
@@ -11,8 +11,6 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache/usagedb/api"
-	"github.com/go-gota/gota/dataframe"
-	"github.com/go-gota/gota/series"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -107,39 +105,8 @@ func (f *FakeUsageDBClient) AppendQueueAllocation(queueAllocations map[common_in
 	f.clusterCapacityHistory = append(f.clusterCapacityHistory, totalInCluster)
 }
 
-func (f *FakeUsageDBClient) GetAllocationHistory() AllocationHistory {
-	return f.allocationHistory
-}
-
 type AllocationHistory []map[common_info.QueueID]queue_info.QueueUsage
 type ClusterCapacityHistory []map[v1.ResourceName]float64
-
-func (a AllocationHistory) ToDataFrame() dataframe.DataFrame {
-	var times []int
-	var queueIDs []string
-	var resources []string
-	var allocations []float64
-
-	for timeIndex, queueAllocations := range a {
-		for queueID, queueUsage := range queueAllocations {
-			for resourceName, allocation := range queueUsage {
-				times = append(times, timeIndex)
-				queueIDs = append(queueIDs, string(queueID))
-				resources = append(resources, string(resourceName))
-				allocations = append(allocations, allocation)
-			}
-		}
-	}
-
-	df := dataframe.New(
-		series.New(times, series.Int, "Time"),
-		series.New(queueIDs, series.String, "QueueID"),
-		series.New(resources, series.String, "Resource"),
-		series.New(allocations, series.Float, "Allocation"),
-	)
-
-	return df
-}
 
 func getDecaySlice(length int, period *time.Duration) []float64 {
 	if period == nil || period.Seconds() == 0 {


### PR DESCRIPTION
This PR improves the time-aware simulations by adding more data (fairness) and exporting the results to a csv, to allow them to be analyzed and visualized by external tools. In particular, this PR:

1. Fixes half life calculations in simulations
2. Allows half life to be configured per test
3. Adds a test-only scheduler plugin to export fairness data
4. Tracks fairness and allocation independently