### PR TITLE
Topology plugin goes into infinite loop on empty tasks list

### DIFF
--- a/pkg/scheduler/plugins/topology/job_filtering.go
+++ b/pkg/scheduler/plugins/topology/job_filtering.go
@@ -40,7 +40,7 @@ func (t *topologyPlugin) subSetNodesFn(
 			nil)
 		return []node_info.NodeSet{}, nil
 	}
-	if topologyTree == nil {
+	if topologyTree == nil || len(tasks) == 0 {
 		return []node_info.NodeSet{nodeSet}, nil
 	}
 


### PR DESCRIPTION
Topology plugin goes into infinite loop when the received tasks list is empty.
It is a possible usecase when scheduling a workload with multiple subgroups with topology constraints and one of the subgroups already reached minAvailable or has no more pending tasks to schedule.