### PR TITLE
test: Remove explicit queue v2 storage in env tests

### DIFF
--- a/pkg/env-tests/env_tests_suite_test.go
+++ b/pkg/env-tests/env_tests_suite_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	resourceapi "k8s.io/api/resource/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"


### PR DESCRIPTION
Remove a leftover from where queue crd v2 wasn't the stored version. No behavior changes.