### PR TITLE
fix: queue version in docs to v2

### DIFF
--- a/docs/queues/README.md
+++ b/docs/queues/README.md
@@ -21,7 +21,7 @@ Scheduling queues are the core resource management primitive in KAI Scheduler, p
 
 ### Queue Specification
 ```yaml
-apiVersion: scheduling.run.ai/v2alpha2
+apiVersion: scheduling.run.ai/v2
 kind: Queue
 metadata:
   name: example-queue
@@ -71,7 +71,7 @@ resources:
 
 ### Basic Queue
 ```yaml
-apiVersion: scheduling.run.ai/v2alpha2
+apiVersion: scheduling.run.ai/v2
 kind: Queue
 metadata:
   name: research-team
@@ -88,7 +88,7 @@ spec:
 
 ### Hierarchical Queue 
 ```yaml
-apiVersion: scheduling.run.ai/v2alpha2
+apiVersion: scheduling.run.ai/v2
 kind: Queue
 metadata:
   name: ml-team
@@ -107,7 +107,7 @@ spec:
 
 ### Unlimited Queue - default value is -1
 ```yaml
-apiVersion: scheduling.run.ai/v2alpha2
+apiVersion: scheduling.run.ai/v2
 kind: Queue
 metadata:
   name: burst-queue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

fix: queue version in docs to v2

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) NO NEED
- [ ] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed) NO NEED
- [x] Updated documentation (if needed)

## Breaking Changes

None

## Additional Notes

None
