### PR TITLE
ci: Extend the amount of ci nodes of the kind cluster used in the "Validate & test" step

### DIFF
--- a/hack/e2e-kind-config.yaml
+++ b/hack/e2e-kind-config.yaml
@@ -11,3 +11,9 @@ nodes:
 - role: worker
   labels:
     run.ai/simulated-gpu-node-pool: default
+- role: worker
+  labels:
+    run.ai/simulated-gpu-node-pool: default
+- role: worker
+  labels:
+    run.ai/simulated-gpu-node-pool: default


### PR DESCRIPTION
## Description

Extend the amount of ci nodes of the kind cluster used in the "Validate & test" step. This allows the topology test to run in the "Validate & test" step of the CI.
