### PR TITLE
fix(chart): scope CRD manager permissions to specific resource names

### DIFF
--- a/deployments/kai-scheduler/templates/rbac/crd-manager.yaml
+++ b/deployments/kai-scheduler/templates/rbac/crd-manager.yaml
@@ -12,6 +12,13 @@ metadata:
 rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
+  resourceNames:
+    - configs.kai.scheduler
+    - schedulingshards.kai.scheduler
+    - bindrequests.scheduling.run.ai
+    - podgroups.scheduling.run.ai
+    - queues.scheduling.run.ai
+    - topologies.kueue.x-k8s.io
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description

This PR restricts the RBAC permissions for the CRD manager by adding specific `resourceNames` to the ClusterRole, following the principle of least privilege. Instead of granting blanket permissions to all CustomResourceDefinitions, the CRD manager now only has permissions to manage the specific CRDs used by KAI Scheduler:

- `configs.kai.scheduler`
- `schedulingshards.kai.scheduler`
- `bindrequests.scheduling.run.ai`
- `podgroups.scheduling.run.ai`
- `queues.scheduling.run.ai`
- `topologies.kueue.x-k8s.io`

This change improves security by limiting the scope of permissions and reducing the potential attack surface.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. This change only restricts existing permissions to specific CRD resources, which should not affect normal operation since the CRD manager only needs to manage these specific CRDs.

## Additional Notes

**Security Consideration:** This change follows Kubernetes RBAC best practices by scoping permissions to only the specific resources needed. The `resourceNames` field ensures that the CRD manager service account can only interact with the explicitly listed CRDs, preventing potential unauthorized access to other CRDs in the cluster.

