### PR TITLE
feat(podgrouper): Publish the pod-grouper DefaultPluginsHub 

### DIFF
--- a/cmd/podgrouper/app/app.go
+++ b/cmd/podgrouper/app/app.go
@@ -24,7 +24,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
+	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
 	kubeAiSchedulerV2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	controllers "github.com/NVIDIA/KAI-scheduler/pkg/podgrouper"
 	pluginshub "github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/hub"
@@ -51,7 +51,7 @@ func init() {
 
 type App struct {
 	Mgr               manager.Manager
-	DefaultPluginsHub pluginshub.PluginsHub
+	DefaultPluginsHub *pluginshub.DefaultPluginsHub
 
 	configs    controllers.Configs
 	pluginsHub pluginshub.PluginsHub

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -77,6 +77,19 @@ func (ph *DefaultPluginsHub) GetPodGrouperPlugin(gvk metav1.GroupVersionKind) gr
 	return ph.defaultPlugin
 }
 
+func (ph *DefaultPluginsHub) GetDefaultPlugin() grouper.Grouper {
+	return ph.defaultPlugin
+}
+
+func (ph *DefaultPluginsHub) HasMatchingPlugin(gvk metav1.GroupVersionKind) bool {
+	// search using wildcard version - this hub will return a plugin even if the version is not exact match
+	gvk.Version = "*"
+	if _, found := ph.customPlugins[gvk]; found {
+		return true
+	}
+	return false
+}
+
 func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 	gangScheduleKnative bool, queueLabelKey, nodePoolLabelKey string,
 	defaultPrioritiesConfigMapName, defaultPrioritiesConfigMapNamespace string) *DefaultPluginsHub {


### PR DESCRIPTION
## Description

1- Publish the pod-grouper DefaultPluginsHub as a DefaultPluginsHub object instead of a PluginsHub  interface

2- Allow the DefaultPluginsHub to publish it's default plugin and a HasMatchingPlugin function

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [V] Self-reviewed
- [V] Added/updated tests (if needed)
- [V] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed)
- [ V] Updated documentation (if needed)
