### PR TITLE
fix(podgrouper): HasMatchingPlugin for the default hub should return true for exact matches

### DIFF
--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -82,7 +82,11 @@ func (ph *DefaultPluginsHub) GetDefaultPlugin() grouper.Grouper {
 }
 
 func (ph *DefaultPluginsHub) HasMatchingPlugin(gvk metav1.GroupVersionKind) bool {
-	// search using wildcard version - this hub will return a plugin even if the version is not exact match
+	if _, found := ph.customPlugins[gvk]; found {
+		return true
+	}
+
+	// search using wildcard version
 	gvk.Version = "*"
 	if _, found := ph.customPlugins[gvk]; found {
 		return true

--- a/pkg/podgrouper/podgrouper/hub/hub_test.go
+++ b/pkg/podgrouper/podgrouper/hub/hub_test.go
@@ -49,6 +49,16 @@ var _ = Describe("SupportedTypes", func() {
 			Expect(plugin.Name()).To(BeEquivalentTo("TensorFlow Grouper"))
 		})
 
+		It("should return plugin for exact GVK match - HasMatchingPlugin function", func() {
+			gvk := metav1.GroupVersionKind{
+				Group:   "kubeflow.org",
+				Version: "v1",
+				Kind:    "TFJob",
+			}
+			hasPlugin := hub.HasMatchingPlugin(gvk)
+			Expect(hasPlugin).To(BeTrue())
+		})
+
 		It("should return default plugin for non-existent GVK", func() {
 			gvk := metav1.GroupVersionKind{
 				Group:   "non-existent-group",
@@ -58,6 +68,16 @@ var _ = Describe("SupportedTypes", func() {
 			plugin := hub.GetPodGrouperPlugin(gvk)
 			Expect(plugin).NotTo(BeNil())
 			Expect(plugin.Name()).To(BeEquivalentTo("Default Grouper"))
+		})
+
+		It("non-existent GVK - HasMatchingPlugin returns false", func() {
+			gvk := metav1.GroupVersionKind{
+				Group:   "non-existent-group",
+				Version: "v1",
+				Kind:    "NonExistentKind",
+			}
+			hasPlugin := hub.HasMatchingPlugin(gvk)
+			Expect(hasPlugin).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
## Description

Bug fix - HasMatchingPlugin should return true for cases without wildcard.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [V] Self-reviewed
- [V] Added/updated tests (if needed)
- [ ] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed)
- [ ] Updated documentation (if needed)

