### PR TITLE
docs: Fix fairshare formula in time aware docs

### DIFF
--- a/docs/developer/designs/time-aware-fairness/time-aware-fairness.md
+++ b/docs/developer/designs/time-aware-fairness/time-aware-fairness.md
@@ -116,7 +116,7 @@ Where:
 - **$C$** is the remaining capacity (max amount to give in current round)
 - **$P'_i$** is the normalized portion for queue i, defined as:
 
-$$P_i = \max{\{W'_i - k \cdot (W'_i - U'_i), 0\}}$$
+$$P_i = \max{\{W'_i + k \cdot (W'_i - U'_i), 0\}}$$
 
 $$P'_i = \frac{P_i}{\sum{P}}$$
 


### PR DESCRIPTION
## Description

Fix a small mistake in time aware docs

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed)
- [x] Updated documentation (if needed)