### PR TITLE
docs: Drop unnecessary namespace in command

### DIFF
--- a/docs/timeaware/README.md
+++ b/docs/timeaware/README.md
@@ -69,7 +69,7 @@ watch kubectl get pod -n kai-scheduler prometheus-prometheus-0
 And configure the scheduler to connect to it by patching the scheduling shard:
 
 ```sh
-kubectl patch schedulingshard -nkai-scheudler default --type merge -p '{"spec":{"usageDBConfig":{"clientType":"prometheus"}}}'
+kubectl patch schedulingshard default --type merge -p '{"spec":{"usageDBConfig":{"clientType":"prometheus"}}}'
 ```
 
 The scheduler should now restart and attempt to connect to prometheus.


### PR DESCRIPTION
## Description

Drop a redundant namespace filtering in kubectl command

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed)
- [x] Updated documentation (if needed)
