### PR TITLE
style: If the pod is deleting, do not log owner not found as error

### DIFF
--- a/pkg/podgrouper/pod_controller.go
+++ b/pkg/podgrouper/pod_controller.go
@@ -102,6 +102,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	topOwner, allOwners, err := r.podGrouper.GetPodOwners(ctx, &pod)
 	if err != nil {
+		if pod.DeletionTimestamp != nil {
+			logger.V(1).Info(fmt.Sprintf("Pod %s/%s is being deleted, it's ok if the owner is not available", pod.Namespace, pod.Name))
+			return ctrl.Result{}, nil
+		}
 		logger.V(1).Error(err, "Failed to find pod top owner", req.Namespace, req.Name)
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

If a pod is deleting, it's ok if we cannot access its top owner - it might have been deleted as well.

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated [CHANGELOG.md](/CHANGELOG.md) (if needed)
- [ ] Updated documentation (if needed)
