### PR TITLE
style: Improve topology wrong level error message

### DIFF
--- a/pkg/scheduler/plugins/topology/job_filtering.go
+++ b/pkg/scheduler/plugins/topology/job_filtering.go
@@ -395,9 +395,9 @@ func newTopologyConstraintConfigError(subGroup *subgroup_info.SubGroupInfo, topo
 	} else {
 		topologyConstraintPodGroupSet = fmt.Sprintf("sub-group %s", subGroup.GetName())
 	}
-	return fmt.Errorf("topology constraint error: the %s set a %s topology constraint %s, "+
-		"but no level for the topology tree %s matches this level",
-		topologyConstraintPodGroupSet, placementType, placementName, topologyTree.Name)
+	return fmt.Errorf("topology constraint error: %s specified '%s' as the %s topology constraint level, "+
+		"but the topology tree '%s' does not contain a level with this name",
+		topologyConstraintPodGroupSet, placementName, placementType, topologyTree.Name)
 }
 
 func (*topologyPlugin) treeAllocatableCleanup(topologyTree *Info) {

--- a/pkg/scheduler/plugins/topology/job_filtering_test.go
+++ b/pkg/scheduler/plugins/topology/job_filtering_test.go
@@ -433,7 +433,7 @@ func TestTopologyPlugin_subsetNodesFn(t *testing.T) {
 			domainLevel: map[DomainID]DomainLevel{
 				"zone1": "zone",
 			},
-			expectedError: "topology constraint config error: the sub-group  set a topology required constraint nonexistent-level, but no level for the topology tree test-topology matches this level",
+			expectedError: "topology constraint error: sub-group  specified 'nonexistent-level' as the required topology constraint level, but the topology tree 'test-topology' does not contain a level with this name",
 		},
 	}
 
@@ -661,7 +661,7 @@ func TestTopologyPlugin_calculateRelevantDomainLevels(t *testing.T) {
 				},
 			},
 			expectedLevels: nil,
-			expectedError:  "topology constraint config error: the sub-group test-subgroup set a topology required constraint nonexistent, but no level for the topology tree test-topology matches this level",
+			expectedError:  "topology constraint error: sub-group test-subgroup specified 'nonexistent' as the required topology constraint level, but the topology tree 'test-topology' does not contain a level with this name",
 		},
 		{
 			name: "preferred placement not found in topology",
@@ -683,7 +683,7 @@ func TestTopologyPlugin_calculateRelevantDomainLevels(t *testing.T) {
 				},
 			},
 			expectedLevels: nil,
-			expectedError:  "topology constraint config error: the sub-group test-subgroup set a topology preferred constraint nonexistent, but no level for the topology tree test-topology matches this level",
+			expectedError:  "topology constraint error: sub-group test-subgroup specified 'nonexistent' as the preferred topology constraint level, but the topology tree 'test-topology' does not contain a level with this name",
 		},
 		{
 			name: "required placement at first level",
@@ -1500,7 +1500,7 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 				return l.(*pod_info.PodInfo).Name < r.(*pod_info.PodInfo).Name
 			},
 			expectedDomains: nil,
-			expectedError:   "topology constraint config error: the sub-group test set a topology required constraint zone, but no level for the topology tree test-topology matches this level",
+			expectedError:   "topology constraint error: sub-group test specified 'zone' as the required topology constraint level, but the topology tree 'test-topology' does not contain a level with this name",
 		},
 		{
 			name: "complex topology with multiple levels",


### PR DESCRIPTION
## Description

Improve error messages if the podgroup has a topology constraint that doesn't match the topology tree defined labels.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

## Additional Notes
