### PR TITLE
test(scheduler): add unit tests for getNodeSetID function consistency and uniqueness

### DIFF
--- a/pkg/scheduler/plugins/topology/common_test.go
+++ b/pkg/scheduler/plugins/topology/common_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package topology
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
+)
+
+func TestGetNodeSetID_ConsistencyWithLargeNodeSet(t *testing.T) {
+	const numNodes = 10000
+
+	nodeNames := make([]string, numNodes)
+	for i := 0; i < numNodes; i++ {
+		nodeNames[i] = "node-" + strconv.Itoa(i)
+	}
+
+	createNodeSet := func(names []string) node_info.NodeSet {
+		nodeSet := make(node_info.NodeSet, len(names))
+		for i, name := range names {
+			nodeSet[i] = &node_info.NodeInfo{Name: name}
+		}
+		return nodeSet
+	}
+
+	expectedID := getNodeSetID(createNodeSet(nodeNames))
+
+	// Verify consistency on repeated calls
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, expectedID, getNodeSetID(createNodeSet(nodeNames)))
+	}
+
+	// Verify order independence with shuffled node sets
+	for i := 0; i < 10; i++ {
+		shuffled := make([]string, len(nodeNames))
+		copy(shuffled, nodeNames)
+		rand.New(rand.NewSource(int64(i))).Shuffle(len(shuffled), func(i, j int) {
+			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		})
+		assert.Equal(t, expectedID, getNodeSetID(createNodeSet(shuffled)))
+	}
+
+	// Verify different node sets produce different IDs
+	assert.NotEqual(t, expectedID, getNodeSetID(createNodeSet(nodeNames[:numNodes-1])))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

Add unit test for getNodeSetID function consistency and uniqueness

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
