### PR TITLE
chore(ci): move Docker data and image cache to /mnt for more disk space

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -127,11 +127,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
-      - name: Open non-blocking debug session with tmate
-        uses: mxschmitt/action-tmate@v3
-        with:
-          detached: true
 
       - name: Move Docker Data to /mnt
         run: |
@@ -165,8 +160,6 @@ jobs:
           kubectl wait --for=condition=available --timeout=60s deployment/registry -n kube-registry
 
       - name: Load docker images to registry
-        # GuyTodo: Remove
-        # working-directory: /mnt/images
         env:
           PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
         run: |
@@ -177,27 +170,6 @@ jobs:
             docker tag $image $new_image
             docker push $new_image
           done
-
-      - name: 🔍 Debug Disk Usage
-        if: always() # Runs even if previous steps fail
-        run: |
-          echo "=============================================================================="
-          echo "1. GLOBAL DISK USAGE (df -h)"
-          echo "=============================================================================="
-          df -h
-
-          echo ""
-          echo "=============================================================================="
-          echo "2. DOCKER USAGE (docker system df)"
-          echo "=============================================================================="
-          docker system df -v
-
-          echo ""
-          echo "=============================================================================="
-          echo "3. TOP 20 LARGEST DIRECTORIES (du)"
-          echo "=============================================================================="
-          # Find largest directories in root, excluding mount points that might hang
-          sudo du -h / --max-depth=4 --exclude=/proc --exclude=/sys --exclude=/dev 2>/dev/null | sort -hr | head -n 20
 
       - name: Deploy fake gpu operator
         run: |
@@ -210,6 +182,7 @@ jobs:
         run: |
           helm upgrade -i kai-scheduler /mnt/images/kai-scheduler-$PACKAGE_VERSION.tgz -n kai-scheduler --create-namespace \
             --set "global.gpuSharing=true" --set "global.registry=localhost:30100" --debug --wait
+      
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -225,27 +198,6 @@ jobs:
         run: |
           docker images --format '{{.Repository}}:{{.Tag}}' | grep $PACKAGE_VERSION | xargs docker rmi -f
           sudo rm -rf /mnt/images
-
-      - name: 🔍 Debug Disk Usage
-        if: always() # Runs even if previous steps fail
-        run: |
-          echo "=============================================================================="
-          echo "1. GLOBAL DISK USAGE (df -h)"
-          echo "=============================================================================="
-          df -h
-
-          echo ""
-          echo "=============================================================================="
-          echo "2. DOCKER USAGE (docker system df)"
-          echo "=============================================================================="
-          docker system df -v
-
-          echo ""
-          echo "=============================================================================="
-          echo "3. TOP 20 LARGEST DIRECTORIES (du)"
-          echo "=============================================================================="
-          # Find largest directories in root, excluding mount points that might hang
-          sudo du -h / --max-depth=4 --exclude=/proc --exclude=/sys --exclude=/dev 2>/dev/null | sort -hr | head -n 20
 
       - name: Run e2e tests
         run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

This pull request updates the GitHub Actions workflow to move Docker and build artifact storage to the `/mnt` directory. This change is aimed at improving disk management and ensuring consistent storage locations for Docker data and cached build artifacts during CI runs. The most important changes are grouped below:

**Docker and Artifact Storage Refactor:**

* Changed all references from the local `images` directory to `/mnt/images` for caching, saving, and loading Docker images and Helm charts, ensuring artifacts are stored in a consistent and potentially larger disk location. [[1]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79L103-R121) [[2]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79L148-R167) [[3]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79L169-R185) [[4]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79L185-R200)
* Added steps to stop Docker, move its data root to `/mnt/docker-data`, and restart Docker, so that all Docker data is stored on `/mnt` rather than the default location.

**Workflow Enhancements:**

* Updated permissions and directory creation logic to use `sudo` for operations in `/mnt`, ensuring proper access rights for subsequent workflow steps. [[1]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79L103-R121) [[2]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79R131-R147)
* Updated cache restore and save steps to use `/mnt/images` instead of the previous `images` directory, aligning cache paths with the new storage location. [[1]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79L103-R121) [[2]](diffhunk://#diff-cf471f78f249e26c7248a05b6ce021eb81cfcb53e3aeaaa6e2fa95efc4415d79R131-R147)

These changes improve workflow reliability and help prevent disk space issues by leveraging the `/mnt` mount point for heavy build and Docker operations.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
