### PR TITLE
fix(ci): enable changelog validation for PRs to all branches

### DIFF
--- a/.github/workflows/validate-changelog.yaml
+++ b/.github/workflows/validate-changelog.yaml
@@ -6,9 +6,6 @@ name: Validate Changelog
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - main
-      - 'v*.*'
 
 jobs:
   validate-changelog:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

This fixes a bug where the changelog validation isn't triggered on PRs to version branches and make its trigger match the `on-pr.yaml` workflow.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
