### PR TITLE
fix(chart): Add missing permission for kai-scheduler operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed confusing resource division log message [#733](https://github.com/NVIDIA/KAI-Scheduler/pull/733) [itsomri](https://github.com/itsomri)
 - Made post-delete-cleanup resources configurable [#737](https://github.com/NVIDIA/KAI-Scheduler/pull/737) [dttung2905](https://github.com/dttung2905)
 - GPU Memory pods are not reclaimed or consolidated correctly
+- Added missing leases permission for the operator [#753](https://github.com/NVIDIA/KAI-Scheduler/pull/753) [dttung2905](https://github.com/dttung2905)
 
 ## [v0.10.2] - 2025-11-24
 

--- a/cmd/operator/app/app.go
+++ b/cmd/operator/app/app.go
@@ -110,6 +110,8 @@ func (app *App) InitOperands(configOperands []operands.Operand, shardOperandsFor
 	app.shardReconciler.SetOperands(shardOperandsForShard)
 }
 
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
+
 func (app *App) Run() error {
 
 	var err error

--- a/deployments/kai-scheduler/templates/rbac/operator.yaml
+++ b/deployments/kai-scheduler/templates/rbac/operator.yaml
@@ -37,18 +37,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
@@ -96,6 +84,18 @@ rules:
   resources:
   - daemonsets
   - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
   verbs:
   - create
   - delete


### PR DESCRIPTION

Hi team,
I'm adding missing lease permission for kai-scheduler operator. Please let me know if the permissions are too broad. Adding these permissions our cluster help the operator to move past that error

## Description

<!-- What does this PR do and why? -->

## Related Issues

Fixes https://github.com/NVIDIA/KAI-Scheduler/issues/752

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

nil

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
