### PR TITLE
feat(scheduler): Add a tumbling window usage type option - cherrypick v0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [v0.10.4]
+
+## Added 
+- Add a "tumbling window" usage configuration - calculate a tumbling window size based on a start timne configuration and a duration config field.
+
+
+## [v0.10.3]
+
 ## Fixed
 - Fixed reclaim/preempt/consolidate actions for topology workloads [#748](https://github.com/NVIDIA/KAI-Scheduler/pull/748)  [itsomri](https://github.com/itsomri)
 
@@ -17,6 +25,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fixed confusing resource division log message [#734](https://github.com/NVIDIA/KAI-Scheduler/pull/734) [itsomri](https://github.com/itsomri)
 - Fixed a bug where the snapshot tool would not load topology objects [#731](https://github.com/NVIDIA/KAI-Scheduler/pull/731) [itsomri](https://github.com/itsomri)
+
+### Changed
+- Renamed the previous "tumbling" option for the scheduler usage window type to "cron".
 
 ## [v0.10.2] - 2025-11-24
 

--- a/deployments/kai-scheduler/crds/kai.scheduler_schedulingshards.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_schedulingshards.yaml
@@ -109,6 +109,10 @@ spec:
                     description: UsageParams defines common params for all usage db
                       clients. Some clients may not support all the params.
                     properties:
+                      cronString:
+                        description: The cron string defining the behavior of the
+                          cron window.
+                        type: string
                       extraParams:
                         additionalProperties:
                           type: string
@@ -125,9 +129,10 @@ spec:
                       stalenessPeriod:
                         description: Staleness period of the usage. Default is 5 minutes.
                         type: string
-                      tumblingWindowCronString:
-                        description: A cron string used to determine when to reset
-                          resource usage for all queues.
+                      tumblingWindowStartTime:
+                        description: The start timestamp of the tumbling window. If
+                          not set, defaults to the current time.
+                        format: date-time
                         type: string
                       waitTimeout:
                         description: Wait timeout of the usage. Default is 1 minute.

--- a/pkg/scheduler/cache/usagedb/api/defaults.go
+++ b/pkg/scheduler/cache/usagedb/api/defaults.go
@@ -39,6 +39,11 @@ const (
 	// Example: 1-hour windows at 0-1h, 1-2h, 2-3h
 	TumblingWindow WindowType = "tumbling"
 
+	// CronWindow represents a tumbling window that is defined by a cron string.
+	// In this configuration, the window size is not used, and the window is defined by the cron string.
+	// Example: every 1 hour at 00:00:00, every 1 hour at 01:00:00, etc.
+	CronWindow WindowType = "cron"
+
 	// SlidingWindow represents overlapping time windows that slide forward
 	// Example: a 1-hour sliding window will consider the usage of the last 1 hour prior to the current time.
 	SlidingWindow WindowType = "sliding"
@@ -47,7 +52,7 @@ const (
 // IsValid returns true if the WindowType is a valid value
 func (wt WindowType) IsValid() bool {
 	switch wt {
-	case TumblingWindow, SlidingWindow:
+	case TumblingWindow, SlidingWindow, CronWindow:
 		return true
 	default:
 		return false

--- a/pkg/scheduler/cache/usagedb/api/interface.go
+++ b/pkg/scheduler/cache/usagedb/api/interface.go
@@ -47,8 +47,10 @@ type UsageParams struct {
 	WindowSize *metav1.Duration `yaml:"windowSize,omitempty" json:"windowSize,omitempty"`
 	// Window type for time-series aggregation. If not set, defaults to sliding.
 	WindowType *WindowType `yaml:"windowType,omitempty" json:"windowType,omitempty"`
-	// A cron string used to determine when to reset resource usage for all queues.
-	TumblingWindowCronString string `yaml:"tumblingWindowCronString,omitempty" json:"tumblingWindowCronString,omitempty"`
+	// The start timestamp of the tumbling window. If not set, defaults to the current time.
+	TumblingWindowStartTime *metav1.Time `yaml:"tumblingWindowStartTime,omitempty" json:"tumblingWindowStartTime,omitempty"`
+	// The cron string defining the behavior of the cron window.
+	CronString string `yaml:"cronString,omitempty" json:"cronString,omitempty"`
 	// Fetch interval of the usage. Default is 1 minute.
 	FetchInterval *metav1.Duration `yaml:"fetchInterval,omitempty" json:"fetchInterval,omitempty"`
 	// Staleness period of the usage. Default is 5 minutes.
@@ -74,7 +76,11 @@ func (p *UsageParams) DeepCopy() *UsageParams {
 		windowType := *p.WindowType
 		out.WindowType = &windowType
 	}
-	out.TumblingWindowCronString = p.TumblingWindowCronString
+	if p.TumblingWindowStartTime != nil {
+		startTime := *p.TumblingWindowStartTime
+		out.TumblingWindowStartTime = &startTime
+	}
+	out.CronString = p.CronString
 	if p.FetchInterval != nil {
 		duration := *p.FetchInterval
 		out.FetchInterval = &duration


### PR DESCRIPTION
* Convert the current "tumbling window" scheduler usage window type to "cron window".
* For the cron window, do not use the duration as part of the window calculation - use only the cron string to calculate the window size.
* Add a "tumbling window" usage configuration - calculate a tumbling window size based on a start timne configuration and a duration config field

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
