### PR TITLE
chore: Add dependabot gomod updates for supported version branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
   # Enable version updates for Go modules on supported version branches
   - package-ecosystem: "gomod"
     directory: "/"
-    target-branch: "v0.10"
+    target-branch: "v0.12"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

Add Dependabot Go module updates for all currently supported version branches
as defined in SUPPORT.md:
- v0.12 (current)
- v0.9 (LTS)
- v0.6 (LTS)
- v0.4 (LTS)

This ensures dependency updates and security patches are also proposed for
maintenance branches, not just the default branch.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
