### PR TITLE
feat: Added the option to disable service monitor creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Added the option to disable prometheus service monitor creation [#810](https://github.com/NVIDIA/KAI-Scheduler/pull/810) [itsomri](https://github.com/itsomri)
+
 ## [v0.12.0] - 2025-12-24
 
 ### Added

--- a/pkg/operator/operands/prometheus/resources.go
+++ b/pkg/operator/operands/prometheus/resources.go
@@ -200,6 +200,12 @@ func serviceMonitorsForKAIConfig(
 	logger := log.FromContext(ctx)
 	config := kaiConfig.Spec.Prometheus
 
+	// Check if ServiceMonitors are enabled
+	if config.ServiceMonitor != nil && config.ServiceMonitor.Enabled != nil && !*config.ServiceMonitor.Enabled {
+		logger.Info("ServiceMonitors are disabled, skipping ServiceMonitor creation")
+		return []client.Object{}, nil
+	}
+
 	// Check if ServiceMonitor CRD is available
 	hasServiceMonitorCRD, err := common.CheckPrometheusCRDsAvailable(ctx, runtimeClient, "serviceMonitor")
 	if err != nil {


### PR DESCRIPTION
## Description

Let admins opt out of service monitor creation in prometheus operand

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
