### PR TITLE
fix: Error messages are persisted to Kubernetes resource status

### DIFF
--- a/pkg/binder/controllers/bindrequest_controller.go
+++ b/pkg/binder/controllers/bindrequest_controller.go
@@ -113,7 +113,7 @@ func (r *BindRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		var finalError error
 		if r := recover(); r != nil {
 			finalError = fmt.Errorf("Internal Error: %v\n%s", r, string(debug.Stack()))
-			err = fmt.Errorf("Internal Error: %vs", r)
+			err = fmt.Errorf("Internal Error: %v", r)
 		}
 
 		result, err = r.UpdateStatus(ctx, bindRequest, result, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

<!-- What does this PR do and why? -->
we got redundant "s" char here.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
