### PR TITLE
fix: ToDo consider handling gracefully in storage.go

### DIFF
--- a/pkg/scheduler/cache/cluster_info/storage.go
+++ b/pkg/scheduler/cache/cluster_info/storage.go
@@ -106,8 +106,11 @@ func (c *ClusterInfo) snapshotStorageCapacities() (map[common_info.StorageCapaci
 	for _, capacity := range capacities {
 		capacityInfo, err := storagecapacity_info.NewStorageCapacityInfo(capacity)
 		if err != nil {
-			// ToDo: consider handling gracefully
-			return nil, err
+			// Skip invalid capacity and continue processing others
+			log.InfraLogger.V(2).Warnf(
+				"Failed to process CSIStorageCapacity %s/%s, skipping: %v",
+				capacity.Namespace, capacity.Name, err)
+			continue
 		}
 		result[capacityInfo.UID] = capacityInfo
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description
This PR changed error handling in snapshotStorageCapacities() to gracefully skip invalid CSIStorageCapacity objects with a warning log instead of failing the entire snapshot, allowing the scheduler to continue with valid capacities.
If i'm wrong plz correct me.
<!-- What does this PR do and why? -->


## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

