### PR TITLE
Allow the e2e tests to run in parallel on different scheduling shards.

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -261,6 +261,10 @@ jobs:
       - name: Install ginkgo
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
+      
+      - name: Set shorter scheduler cycle period
+        run: |
+          kubectl patch schedulingshard default -p '{"spec":{"args":{"defaultSchedulerPeriod":"100ms"}}}' --type merge
 
       - name: Delete images from disk
         env:

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -268,10 +268,14 @@ jobs:
         run: |
           docker images --format '{{.Repository}}:{{.Tag}}' | grep $PACKAGE_VERSION | xargs docker rmi -f
           sudo rm -rf /mnt/images
-
-      - name: Run e2e tests
+      
+      - name: Set second shard for parallel testing
         run: |
-          ginkgo -r --keep-going --randomize-all --randomize-suites --trace -vv --label-filter '!autoscale && !scale' ./test/e2e/suites
+          ./hack/parallel_e2e_config/set_parallel_testing_shards.sh
+
+      - name: Run parallel e2e tests
+        run: |
+          ginkgo -r --keep-going --randomize-all --randomize-suites --procs=2 --trace -vv --label-filter '!autoscale && !scale' ./test/e2e/suites
 
       - name: Uninstall KAI-scheduler
         run: |

--- a/hack/parallel_e2e_config/set_parallel_testing_shards.sh
+++ b/hack/parallel_e2e_config/set_parallel_testing_shards.sh
@@ -4,5 +4,31 @@
 
 REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../..
 
+# Get all nodes containing "worker" in their name
+ALL_WORKER_NODES=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep 'worker')
+if [ -z "$ALL_WORKER_NODES" ]; then
+  echo "Error: No 'worker' nodes found"
+  exit 1
+fi
+
+# Count total worker nodes
+TOTAL_WORKERS=$(echo "$ALL_WORKER_NODES" | wc -l | tr -d ' ')
+echo "Found $TOTAL_WORKERS worker node(s)"
+
+# Calculate half (rounded up)
+HALF_WORKERS=$(( ($TOTAL_WORKERS + 1) / 2 ))
+echo "Selecting $HALF_WORKERS node(s) to label (half of $TOTAL_WORKERS)"
+
+# Select half of the worker nodes
+NODES_TO_LABEL=$(echo "$ALL_WORKER_NODES" | head -n $HALF_WORKERS | tr '\n' ' ')
+
+if [ -z "$NODES_TO_LABEL" ]; then
+  echo "Error: Failed to select nodes to label"
+  exit 1
+fi
+
+echo "Labeling nodes: $NODES_TO_LABEL for scheduling shard test-pool-2"
+kubectl label nodes $NODES_TO_LABEL kai.scheduler/node-pool=test-pool-2 --overwrite
+
+echo "Create the scheduling shard test-shard-2.yaml"
 kubectl apply -f ${REPO_ROOT}/hack/parallel_e2e_config/test-shard-2.yaml
-kubectl label nodes e2e-kai-scheduler-worker3 e2e-kai-scheduler-worker4 kai.scheduler/node-pool=test-pool-2 --overwrite

--- a/hack/parallel_e2e_config/set_parallel_testing_shards.sh
+++ b/hack/parallel_e2e_config/set_parallel_testing_shards.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../..
+
+kubectl apply -f ${REPO_ROOT}/hack/parallel_e2e_config/test-shard-2.yaml
+kubectl label nodes e2e-kai-scheduler-worker3 e2e-kai-scheduler-worker4 kai.scheduler/node-pool=test-pool-2 --overwrite

--- a/hack/parallel_e2e_config/test-shard-2.yaml
+++ b/hack/parallel_e2e_config/test-shard-2.yaml
@@ -1,0 +1,14 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kai.scheduler/v1
+kind: SchedulingShard
+metadata:
+  name: test-shard-2
+spec:
+  args:
+    restrict-node-scheduling: "false"
+  partitionLabelValue: test-pool-2
+  placementStrategy:
+    cpu: binpack
+    gpu: binpack

--- a/hack/parallel_e2e_config/test-shard-2.yaml
+++ b/hack/parallel_e2e_config/test-shard-2.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   args:
     restrict-node-scheduling: "false"
+    defaultSchedulerPeriod: "100ms"
   partitionLabelValue: test-pool-2
   placementStrategy:
     cpu: binpack

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -83,6 +83,8 @@ fi
 # Allow all the pods in the fake-gpu-operator and kai-scheduler to start
 sleep 10
 
+kubectl patch schedulingshard default -p '{"spec":{"args":{"defaultSchedulerPeriod":"100ms"}}}' --type merge
+
 # Install ginkgo if it's not installed
 if [ ! -f ${GOBIN}/ginkgo ]; then
     echo "Installing ginkgo"

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -77,11 +77,11 @@ if [ "$LOCAL_IMAGES_BUILD" = "true" ]; then
     cd ${REPO_ROOT}/hack
 else
     PACKAGE_VERSION=0.0.0-$(git rev-parse --short origin/main)
-    helm upgrade -i kai-scheduler oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler -n kai-scheduler --create-namespace --set "global.gpuSharing=true" --version "$PACKAGE_VERSION"
+    helm upgrade -i kai-scheduler oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler -n kai-scheduler --create-namespace --set "global.gpuSharing=true" --wait --version "$PACKAGE_VERSION"
 fi
 
 # Allow all the pods in the fake-gpu-operator and kai-scheduler to start
-sleep 30
+sleep 10
 
 # Install ginkgo if it's not installed
 if [ ! -f ${GOBIN}/ginkgo ]; then
@@ -89,7 +89,7 @@ if [ ! -f ${GOBIN}/ginkgo ]; then
     GOBIN=${GOBIN} go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
 fi
 
-#${GOBIN}/ginkgo -r --keep-going --randomize-all --randomize-suites --label-filter '!autoscale && !scale' --trace -vv ${REPO_ROOT}/test/e2e/suites
+${GOBIN}/ginkgo -r --keep-going --randomize-all --randomize-suites --label-filter '!autoscale && !scale' --trace -vv ${REPO_ROOT}/test/e2e/suites
 
 if [ "$PRESERVE_CLUSTER" != "true" ]; then
     kind delete cluster --name $CLUSTER_NAME

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -89,7 +89,7 @@ if [ ! -f ${GOBIN}/ginkgo ]; then
     GOBIN=${GOBIN} go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
 fi
 
-${GOBIN}/ginkgo -r --keep-going --randomize-all --randomize-suites --label-filter '!autoscale && !scale' --trace -vv ${REPO_ROOT}/test/e2e/suites
+#${GOBIN}/ginkgo -r --keep-going --randomize-all --randomize-suites --label-filter '!autoscale && !scale' --trace -vv ${REPO_ROOT}/test/e2e/suites
 
 if [ "$PRESERVE_CLUSTER" != "true" ]; then
     kind delete cluster --name $CLUSTER_NAME

--- a/test/e2e/modules/configurations/config.go
+++ b/test/e2e/modules/configurations/config.go
@@ -11,6 +11,7 @@ import (
 	kaiv1 "github.com/NVIDIA/KAI-scheduler/pkg/apis/kai/v1"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 )
 
 func PatchKAIConfig(ctx context.Context, testCtx *testcontext.TestContext, update func(*kaiv1.Config)) error {
@@ -26,7 +27,12 @@ func PatchKAIConfig(ctx context.Context, testCtx *testcontext.TestContext, updat
 	)
 }
 
-func PatchSchedulingShard(ctx context.Context, testCtx *testcontext.TestContext, shardName string, update func(*kaiv1.SchedulingShard)) error {
+func PatchSchedulingShard(ctx context.Context, testCtx *testcontext.TestContext, update func(*kaiv1.SchedulingShard)) error {
+	shardName := "default"
+	if config := shardconfig.GetCurrentShardConfig(); config != nil {
+		shardName = config.ShardName
+	}
+
 	originalShard := &kaiv1.SchedulingShard{}
 	err := testCtx.ControllerClient.Get(ctx, client.ObjectKey{Name: shardName}, originalShard)
 	if err != nil {
@@ -39,9 +45,9 @@ func PatchSchedulingShard(ctx context.Context, testCtx *testcontext.TestContext,
 	)
 }
 
-func SetShardArg(ctx context.Context, testCtx *testcontext.TestContext, shardName string, argName string, value *string) error {
+func SetShardArg(ctx context.Context, testCtx *testcontext.TestContext, argName string, value *string) error {
 	return PatchSchedulingShard(
-		ctx, testCtx, shardName,
+		ctx, testCtx,
 		func(shard *kaiv1.SchedulingShard) {
 			if value == nil {
 				delete(shard.Spec.Args, argName)

--- a/test/e2e/modules/configurations/feature_flags/hierarchy_fairness_type.go
+++ b/test/e2e/modules/configurations/feature_flags/hierarchy_fairness_type.go
@@ -23,7 +23,7 @@ func SetFullHierarchyFairness(
 	if value != nil {
 		targetValue = ptr.To(fmt.Sprint(*value))
 	}
-	if err := configurations.SetShardArg(ctx, testCtx, "default", "full-hierarchy-fairness", targetValue); err != nil {
+	if err := configurations.SetShardArg(ctx, testCtx, "full-hierarchy-fairness", targetValue); err != nil {
 		return err
 	}
 	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)

--- a/test/e2e/modules/configurations/feature_flags/knative_grouping.go
+++ b/test/e2e/modules/configurations/feature_flags/knative_grouping.go
@@ -25,7 +25,7 @@ func SetKnativeGangScheduling(ctx context.Context, testCtx *testcontext.TestCont
 	if value != nil {
 		targetValue = ptr.To(fmt.Sprint(*value))
 	}
-	if err := configurations.SetShardArg(ctx, testCtx, "default", "knative-gang-schedule", targetValue); err != nil {
+	if err := configurations.SetShardArg(ctx, testCtx, "knative-gang-schedule", targetValue); err != nil {
 		return err
 	}
 	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)

--- a/test/e2e/modules/configurations/feature_flags/placement_strategy.go
+++ b/test/e2e/modules/configurations/feature_flags/placement_strategy.go
@@ -28,7 +28,7 @@ func SetPlacementStrategy(
 	ctx context.Context, testCtx *testContext.TestContext, strategy string,
 ) error {
 	if err := configurations.PatchSchedulingShard(
-		ctx, testCtx, "default",
+		ctx, testCtx,
 		func(shard *kaiv1.SchedulingShard) {
 			shard.Spec.PlacementStrategy.CPU = ptr.To(strategy)
 			shard.Spec.PlacementStrategy.GPU = ptr.To(strategy)

--- a/test/e2e/modules/configurations/feature_flags/restrict_node_scheduling.go
+++ b/test/e2e/modules/configurations/feature_flags/restrict_node_scheduling.go
@@ -23,7 +23,7 @@ func SetRestrictNodeScheduling(
 	if value != nil {
 		targetValue = ptr.To(fmt.Sprint(*value))
 	}
-	if err := configurations.SetShardArg(ctx, testCtx, "default", "restrict-node-scheduling", targetValue); err != nil {
+	if err := configurations.SetShardArg(ctx, testCtx, "restrict-node-scheduling", targetValue); err != nil {
 		return err
 	}
 	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)

--- a/test/e2e/modules/context/context.go
+++ b/test/e2e/modules/context/context.go
@@ -6,6 +6,7 @@ package context
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -20,6 +21,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/pod_group"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 )
 
@@ -88,7 +90,7 @@ func (tc *TestContext) TestContextCleanup(ctx context.Context) {
 	wait.ForNoReservationPods(ctx, tc.ControllerClient)
 
 	wait.ForRunningSystemComponentEvent(ctx, tc.ControllerClient, "binder")
-	wait.ForRunningSystemComponentEvent(ctx, tc.ControllerClient, "kai-scheduler-default")
+	wait.ForRunningSystemComponentEvent(ctx, tc.ControllerClient, getSchedulerDeploymentName())
 }
 
 func (tc *TestContext) ClusterCleanup(ctx context.Context) {
@@ -133,4 +135,13 @@ func (tc *TestContext) deleteAllQueues(ctx context.Context) {
 			metav1.DeleteOptions{})
 		tc.asserter.Expect(err).To(gomega.Succeed())
 	}
+}
+
+// getSchedulerDeploymentName returns the scheduler deployment name based on current shard
+func getSchedulerDeploymentName() string {
+	config := shardconfig.GetCurrentShardConfig()
+	if config == nil {
+		return "kai-scheduler-default"
+	}
+	return fmt.Sprintf("kai-scheduler-%s", config.ShardName)
 }

--- a/test/e2e/modules/resources/fillers/filler_jobs.go
+++ b/test/e2e/modules/resources/fillers/filler_jobs.go
@@ -96,20 +96,27 @@ func createFillerJob(ctx context.Context, testCtx *testcontext.TestContext, test
 }
 
 func setTargetNodeAffinity(targetNodes []string, job *batchv1.Job) {
-	var nodeSelectorRequirements []v1.NodeSelectorRequirement
-	for _, nodeName := range targetNodes {
-		nodeSelectorRequirements = append(nodeSelectorRequirements, v1.NodeSelectorRequirement{
+	var nodeSelectorRequirement v1.NodeSelectorRequirement
+	if len(targetNodes) == 1 {
+		nodeSelectorRequirement = v1.NodeSelectorRequirement{
 			Key:      constant.NodeNamePodLabelName,
 			Operator: v1.NodeSelectorOpIn,
-			Values:   []string{nodeName},
-		})
+			Values:   []string{targetNodes[0]},
+		}
+	} else {
+		nodeSelectorRequirement = v1.NodeSelectorRequirement{
+			Key:      constant.NodeNamePodLabelName,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   targetNodes,
+		}
 	}
 	job.Spec.Template.Spec.Affinity = &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 				NodeSelectorTerms: []v1.NodeSelectorTerm{
 					{
-						MatchExpressions: nodeSelectorRequirements,
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							nodeSelectorRequirement},
 					},
 				},
 			},

--- a/test/e2e/modules/resources/rd/batch_job.go
+++ b/test/e2e/modules/resources/rd/batch_job.go
@@ -20,6 +20,7 @@ import (
 	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
 
@@ -33,6 +34,12 @@ func CreateBatchJobObject(podQueue *v2.Queue, resources v1.ResourceRequirements)
 	pod.Labels[BatchJobAppLabel] = matchLabelValue
 	pod.Spec.RestartPolicy = v1.RestartPolicyNever
 
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+		BatchJobAppLabel:       matchLabelValue,
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "batch/v1",
@@ -41,10 +48,7 @@ func CreateBatchJobObject(podQueue *v2.Queue, resources v1.ResourceRequirements)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GenerateRandomK8sName(10),
 			Namespace: namespace,
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-				BatchJobAppLabel:       matchLabelValue,
-			},
+			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
 			Template: v1.PodTemplateSpec{

--- a/test/e2e/modules/resources/rd/cronjob.go
+++ b/test/e2e/modules/resources/rd/cronjob.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
 
@@ -19,6 +20,13 @@ const CronJobAppLabel = "cron-job-app-name"
 
 func CreateCronJobObject(namespace, queueName string) *batchv1.CronJob {
 	matchLabelValue := utils.GenerateRandomK8sName(10)
+
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+		CronJobAppLabel:        matchLabelValue,
+		"kai.scheduler/queue":  queueName,
+	}
+	labels = shardconfig.AddShardLabels(labels)
 
 	return &batchv1.CronJob{
 		TypeMeta: metav1.TypeMeta{
@@ -28,10 +36,7 @@ func CreateCronJobObject(namespace, queueName string) *batchv1.CronJob {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GenerateRandomK8sName(10),
 			Namespace: namespace,
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-				CronJobAppLabel:        matchLabelValue,
-			},
+			Labels:    labels,
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: "* * * * *",
@@ -39,11 +44,7 @@ func CreateCronJobObject(namespace, queueName string) *batchv1.CronJob {
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								constants.AppLabelName: "engine-e2e",
-								CronJobAppLabel:        matchLabelValue,
-								"kai.scheduler/queue":  queueName,
-							},
+							Labels: labels,
 						},
 						Spec: v1.PodSpec{
 							RestartPolicy:                 v1.RestartPolicyNever,

--- a/test/e2e/modules/resources/rd/deployment.go
+++ b/test/e2e/modules/resources/rd/deployment.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
 
@@ -20,14 +21,18 @@ const DeploymentAppLabel = "deployment-app-name"
 func CreateDeploymentObject(namespace, queueName string) *appsv1.Deployment {
 	matchLabelValue := utils.GenerateRandomK8sName(10)
 
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+		DeploymentAppLabel:     matchLabelValue,
+		"kai.scheduler/queue":  queueName,
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GenerateRandomK8sName(10),
 			Namespace: namespace,
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-				DeploymentAppLabel:     matchLabelValue,
-			},
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.To(int32(1)),
@@ -39,11 +44,7 @@ func CreateDeploymentObject(namespace, queueName string) *appsv1.Deployment {
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.AppLabelName: "engine-e2e",
-						DeploymentAppLabel:     matchLabelValue,
-						"kai.scheduler/queue":  queueName,
-					},
+					Labels: labels,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/test/e2e/modules/resources/rd/namespace.go
+++ b/test/e2e/modules/resources/rd/namespace.go
@@ -14,24 +14,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 )
 
 func CreateNamespaceObject(name, queueName string) *corev1.Namespace {
+	labels := map[string]string{
+		"project":              queueName,
+		"kai.scheduler/queue":  queueName,
+		constants.AppLabelName: "engine-e2e",
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"project":              queueName,
-				"kai.scheduler/queue":  queueName,
-				constants.AppLabelName: "engine-e2e",
-			},
+			Name:   name,
+			Labels: labels,
 		},
 	}
 }
 
 func GetE2ENamespaces(ctx context.Context, kubeClient *kubernetes.Clientset) (*corev1.NamespaceList, error) {
 	return kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=engine-e2e", constants.AppLabelName),
+		LabelSelector: fmt.Sprintf("%s=engine-e2e,%s", constants.AppLabelName, shardconfig.GetShardLabelSelectorString()),
 	})
 }
 

--- a/test/e2e/modules/resources/rd/pod.go
+++ b/test/e2e/modules/resources/rd/pod.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
 
@@ -129,6 +130,13 @@ func CreatePod(ctx context.Context, client *kubernetes.Clientset, pod *v1.Pod) (
 
 func CreatePodObject(podQueue *v2.Queue, resources v1.ResourceRequirements) *v1.Pod {
 	namespace := queue.GetConnectedNamespaceToQueue(podQueue)
+
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+		"kai.scheduler/queue":  podQueue.Name,
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -138,10 +146,7 @@ func CreatePodObject(podQueue *v2.Queue, resources v1.ResourceRequirements) *v1.
 			Name:        utils.GenerateRandomK8sName(10),
 			Namespace:   namespace,
 			Annotations: map[string]string{},
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-				"kai.scheduler/queue":  podQueue.Name,
-			},
+			Labels:      labels,
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/test/e2e/modules/resources/rd/pod_group/pod_group.go
+++ b/test/e2e/modules/resources/rd/pod_group/pod_group.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 )
 
 const (
@@ -27,6 +28,11 @@ const (
 )
 
 func Create(namespace, name, queue string) *v2alpha2.PodGroup {
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	podGroup := &v2alpha2.PodGroup{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduling.run.ai/v2alpha2",
@@ -36,9 +42,7 @@ func Create(namespace, name, queue string) *v2alpha2.PodGroup {
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: map[string]string{},
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-			},
+			Labels:      labels,
 		},
 		Spec: v2alpha2.PodGroupSpec{
 			MinMember: 1,

--- a/test/e2e/modules/resources/rd/priority_class.go
+++ b/test/e2e/modules/resources/rd/priority_class.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	e2econstant "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
 
@@ -55,18 +56,22 @@ func DeleteAllE2EPriorityClasses(ctx context.Context, client runtimeClient.WithW
 	err := client.DeleteAllOf(
 		ctx, &schedulingv1.PriorityClass{},
 		runtimeClient.MatchingLabels{constants.AppLabelName: "engine-e2e"},
+		runtimeClient.MatchingLabelsSelector{Selector: shardconfig.GetShardLabelSelector()},
 	)
 	err = runtimeClient.IgnoreNotFound(err)
 	return err
 }
 
 func CreatePriorityClass(name string, value int) *schedulingv1.PriorityClass {
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	return &schedulingv1.PriorityClass{
 		ObjectMeta: v12.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-			},
+			Name:   name,
+			Labels: labels,
 		},
 		Value: int32(value),
 	}

--- a/test/e2e/modules/resources/rd/queue/queue.go
+++ b/test/e2e/modules/resources/rd/queue/queue.go
@@ -13,6 +13,7 @@ import (
 	kaiClient "github.com/NVIDIA/KAI-scheduler/pkg/apis/client/clientset/versioned"
 	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 )
 
 func Create(kaiClientset *kaiClient.Clientset, ctx context.Context, queue *v2.Queue,
@@ -38,21 +39,26 @@ func Delete(kaiClientset *kaiClient.Clientset, ctx context.Context, name string,
 }
 
 func GetAllQueues(kaiClientset *kaiClient.Clientset, ctx context.Context) (*v2.QueueList, error) {
-	return kaiClientset.SchedulingV2().Queues("").List(ctx, metav1.ListOptions{})
+	return kaiClientset.SchedulingV2().Queues("").List(ctx, metav1.ListOptions{
+		LabelSelector: shardconfig.GetShardLabelSelectorString(),
+	})
 }
 
 func CreateQueueObject(name string, parentQueueName string) *v2.Queue {
+	labels := map[string]string{
+		"project":              name,
+		constants.AppLabelName: "engine-e2e",
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	queue := &v2.Queue{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduling.run.ai/v2",
 			Kind:       "Queue",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"project":              name,
-				constants.AppLabelName: "engine-e2e",
-			},
+			Name:   name,
+			Labels: labels,
 		},
 		Spec: v2.QueueSpec{
 			ParentQueue: parentQueueName,
@@ -80,17 +86,20 @@ func CreateQueueObject(name string, parentQueueName string) *v2.Queue {
 
 func CreateQueueObjectWithGpuResource(name string, gpuResource v2.QueueResource,
 	parentQueueName string) *v2.Queue {
+	labels := map[string]string{
+		"project":              name,
+		constants.AppLabelName: "engine-e2e",
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	queue := &v2.Queue{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "scheduling.run.ai/v2",
 			Kind:       "Queue",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"project":              name,
-				constants.AppLabelName: "engine-e2e",
-			},
+			Name:   name,
+			Labels: labels,
 		},
 		Spec: v2.QueueSpec{
 			ParentQueue: parentQueueName,

--- a/test/e2e/modules/resources/rd/replicaset.go
+++ b/test/e2e/modules/resources/rd/replicaset.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
 
@@ -20,14 +21,18 @@ const ReplicaSetAppLabel = "replicaset-app-name"
 func CreateReplicasetObject(namespace, queueName string) *v1.ReplicaSet {
 	matchLabelValue := utils.GenerateRandomK8sName(10)
 
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+		ReplicaSetAppLabel:     matchLabelValue,
+		"kai.scheduler/queue":  queueName,
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	return &v1.ReplicaSet{
 		ObjectMeta: v13.ObjectMeta{
 			Name:      utils.GenerateRandomK8sName(10),
 			Namespace: namespace,
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-				ReplicaSetAppLabel:     matchLabelValue,
-			},
+			Labels:    labels,
 		},
 		Spec: v1.ReplicaSetSpec{
 			Replicas: pointer.Int32(1),
@@ -39,11 +44,7 @@ func CreateReplicasetObject(namespace, queueName string) *v1.ReplicaSet {
 			},
 			Template: v12.PodTemplateSpec{
 				ObjectMeta: v13.ObjectMeta{
-					Labels: map[string]string{
-						constants.AppLabelName: "engine-e2e",
-						ReplicaSetAppLabel:     matchLabelValue,
-						"kai.scheduler/queue":  queueName,
-					},
+					Labels: labels,
 				},
 				Spec: v12.PodSpec{
 					Containers: []v12.Container{

--- a/test/e2e/modules/resources/rd/statefulset.go
+++ b/test/e2e/modules/resources/rd/statefulset.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 )
@@ -22,14 +23,18 @@ const StatefulSetAppLabel = "stateful-set-app-name"
 func CreateStatefulSetObject(namespace, queueName string) *v1.StatefulSet {
 	matchLabelValue := utils.GenerateRandomK8sName(10)
 
+	labels := map[string]string{
+		constants.AppLabelName: "engine-e2e",
+		StatefulSetAppLabel:    matchLabelValue,
+		"kai.scheduler/queue":  queueName,
+	}
+	labels = shardconfig.AddShardLabels(labels)
+
 	return &v1.StatefulSet{
 		ObjectMeta: v13.ObjectMeta{
 			Name:      utils.GenerateRandomK8sName(10),
 			Namespace: namespace,
-			Labels: map[string]string{
-				constants.AppLabelName: "engine-e2e",
-				StatefulSetAppLabel:    matchLabelValue,
-			},
+			Labels:    labels,
 		},
 		Spec: v1.StatefulSetSpec{
 			Replicas: pointer.Int32(1),
@@ -41,11 +46,7 @@ func CreateStatefulSetObject(namespace, queueName string) *v1.StatefulSet {
 			},
 			Template: v12.PodTemplateSpec{
 				ObjectMeta: v13.ObjectMeta{
-					Labels: map[string]string{
-						constants.AppLabelName: "engine-e2e",
-						StatefulSetAppLabel:    matchLabelValue,
-						"kai.scheduler/queue":  queueName,
-					},
+					Labels: labels,
 				},
 				Spec: v12.PodSpec{
 					Containers: []v12.Container{

--- a/test/e2e/modules/shardconfig/shardconfig.go
+++ b/test/e2e/modules/shardconfig/shardconfig.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package shardconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// ShardConfig stores configuration for a specific schedulingShard
+type ShardConfig struct {
+	ShardName           string
+	PartitionLabelKey   string // e.g., "kai.scheduler/node-pool"
+	PartitionLabelValue string // e.g., "test-pool-2"
+
+	labelSelector       labels.Selector
+	labelSelectorString string
+}
+
+// Package-level shard configuration (nil for default/process 1)
+var currentShardConfig *ShardConfig = nil
+
+// GetCurrentShardConfig returns the current shard configuration (nil if using default shard)
+func GetCurrentShardConfig() *ShardConfig {
+	return currentShardConfig
+}
+
+// SetCurrentShardConfig sets the current shard configuration
+func SetCurrentShardConfig(config *ShardConfig) {
+	currentShardConfig = config
+}
+
+func GetShardLabelSelector() labels.Selector {
+	if currentShardConfig == nil || currentShardConfig.PartitionLabelKey == "" {
+		Fail("Failed to get shard label selector: currentShardConfig is nil or PartitionLabelKey is empty")
+		return nil
+	}
+	if currentShardConfig.labelSelector != nil {
+		return currentShardConfig.labelSelector
+	}
+
+	operator := selection.DoesNotExist
+	var vals []string
+	if len(currentShardConfig.PartitionLabelValue) > 0 {
+		operator = selection.Equals
+		vals = []string{currentShardConfig.PartitionLabelValue}
+	}
+
+	requirement, err := labels.NewRequirement(currentShardConfig.PartitionLabelKey, operator, vals)
+	if err != nil {
+		Expect(err).NotTo(HaveOccurred(), "Failed to create shard label selector")
+		return nil
+	}
+	selector := labels.NewSelector().Add(*requirement)
+	currentShardConfig.labelSelector = selector
+	return selector
+}
+
+func GetShardLabelSelectorString() string {
+	if currentShardConfig == nil || currentShardConfig.PartitionLabelKey == "" {
+		Fail("Failed to get shard label selector string: currentShardConfig is nil or PartitionLabelKey is empty")
+		return ""
+	}
+	if currentShardConfig.labelSelectorString == "" {
+		currentShardConfig.labelSelectorString = GetShardLabelSelector().String()
+	}
+	return currentShardConfig.labelSelectorString
+}
+
+func AddShardLabels(labels map[string]string) map[string]string {
+	if currentShardConfig == nil || currentShardConfig.PartitionLabelKey == "" || currentShardConfig.PartitionLabelValue == "" {
+		return labels
+	}
+	labels[currentShardConfig.PartitionLabelKey] = currentShardConfig.PartitionLabelValue
+	return labels
+}

--- a/test/e2e/modules/wait/pod.go
+++ b/test/e2e/modules/wait/pod.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait/watcher"
 )
 
@@ -145,7 +146,9 @@ func ForPodsToBeDeleted(ctx context.Context, client runtimeClient.WithWatch, lis
 }
 
 func ForNoE2EPods(ctx context.Context, client runtimeClient.WithWatch) {
-	ForPodsToBeDeleted(ctx, client, runtimeClient.MatchingLabels{constants.AppLabelName: "engine-e2e"})
+	labels := map[string]string{constants.AppLabelName: "engine-e2e"}
+	labels = shardconfig.AddShardLabels(labels)
+	ForPodsToBeDeleted(ctx, client, runtimeClient.MatchingLabels(labels))
 }
 
 func ForNoReservationPods(ctx context.Context, client runtimeClient.WithWatch) {

--- a/test/e2e/suites/allocate/predicates/restrict_node_scheduling_test.go
+++ b/test/e2e/suites/allocate/predicates/restrict_node_scheduling_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/capacity"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/shardconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 )
@@ -177,7 +178,7 @@ var _ = Describe("Restrict node scheduling", Label(labels.Operated), Ordered, fu
 
 func setupGpuNode(textCtx *testContext.TestContext, ctx context.Context) *corev1.Node {
 	nodes, err := textCtx.KubeClientset.CoreV1().Nodes().
-		List(ctx, v1.ListOptions{LabelSelector: constants.GpuCountLabel})
+		List(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("%s,%s", constants.GpuCountLabel, shardconfig.GetShardLabelSelectorString())})
 	Expect(err).NotTo(HaveOccurred(), "Failed to list nodes")
 	nodes.Items = filterTaintedNodes(nodes.Items)
 	if len(nodes.Items) == 0 {
@@ -193,7 +194,7 @@ func setupGpuNode(textCtx *testContext.TestContext, ctx context.Context) *corev1
 
 func setupCpuNode(textCtx *testContext.TestContext, ctx context.Context, availableCPU resource.Quantity) *corev1.Node {
 	nodes, err := textCtx.KubeClientset.CoreV1().Nodes().
-		List(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("!%s", gpuWorkerLabelName)})
+		List(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("!%s,%s", gpuWorkerLabelName, shardconfig.GetShardLabelSelectorString())})
 	Expect(err).NotTo(HaveOccurred(), "Failed to list nodes")
 	nodes.Items = filterTaintedNodes(nodes.Items)
 	Expect(len(nodes.Items)).Should(BeNumerically(">", 0), "No non-gpu nodes")

--- a/test/e2e/suites/allocate/priority/order_test.go
+++ b/test/e2e/suites/allocate/priority/order_test.go
@@ -30,7 +30,7 @@ const (
 	priorityClassLabelName = "priorityClassName"
 )
 
-var _ = Describe("Order jobs allocation queue", Label(labels.Operated), Ordered, func() {
+var _ = Describe("Order jobs allocation queue", Label(labels.Operated), Serial, Ordered, func() {
 	var (
 		testCtx      *testcontext.TestContext
 		lowPriority  string

--- a/test/e2e/suites/consolidation/consolidation_test.go
+++ b/test/e2e/suites/consolidation/consolidation_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -91,8 +92,14 @@ var _ = Describe("Consolidation", Ordered, func() {
 			},
 		}
 
+		targetNodes := rd.ListAllShardNodes(ctx, testCtx.ControllerClient)
+		targetNodesNames := lo.Map(targetNodes.Items, func(item v1.Node, _ int) string {
+			return item.Name
+		})
+
 		fillerJobs, _, err := fillers.FillAllNodesWithJobs(
 			ctx, testCtx, testQueue, requirements, nil, nil, priorityClass,
+			targetNodesNames...,
 		)
 		Expect(err).To(Succeed())
 		Expect(len(fillerJobs)).Should(BeNumerically(">", 0))

--- a/test/e2e/suites/preempt/preempt_distributed_test.go
+++ b/test/e2e/suites/preempt/preempt_distributed_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,8 +81,14 @@ var _ = Describe("preempt Distributed Jobs", Ordered, func() {
 				},
 			}
 
+			targetNodes := rd.ListAllShardNodes(ctx, testCtx.ControllerClient)
+			targetNodesNames := lo.Map(targetNodes.Items, func(item v1.Node, _ int) string {
+				return item.Name
+			})
+
 			_, fillerPods, err := fillers.FillAllNodesWithJobs(
 				ctx, testCtx, testQueue, resources, nil, nil, lowPriority,
+				targetNodesNames...,
 			)
 			Expect(err).To(Succeed())
 			nodesNamesMap := map[string]bool{}

--- a/test/e2e/suites/reclaim/hierarchy_level_fairness_test.go
+++ b/test/e2e/suites/reclaim/hierarchy_level_fairness_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,8 +111,14 @@ var _ = Describe("Hierarchy level fairness", Ordered, func() {
 				},
 			}
 
+			targetNodes := rd.ListAllShardNodes(ctx, testCtx.ControllerClient)
+			targetNodesNames := lo.Map(targetNodes.Items, func(item v1.Node, _ int) string {
+				return item.Name
+			})
+
 			_, _, err := fillers.FillAllNodesWithJobs(
 				ctx, testCtx, reclaimeeQueue, resources, nil, nil, lowPriority,
+				targetNodesNames...,
 			)
 			Expect(err).To(Succeed())
 			namespace := queue.GetConnectedNamespaceToQueue(reclaimeeQueue)

--- a/test/e2e/suites/reclaim/reclaim_distributed_test.go
+++ b/test/e2e/suites/reclaim/reclaim_distributed_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,8 +80,14 @@ var _ = Describe("Reclaim Distributed Jobs", Ordered, func() {
 				},
 			}
 
+			targetNodes := rd.ListAllShardNodes(ctx, testCtx.ControllerClient)
+			targetNodesNames := lo.Map(targetNodes.Items, func(item v1.Node, _ int) string {
+				return item.Name
+			})
+
 			_, fillerPods, err := fillers.FillAllNodesWithJobs(
 				ctx, testCtx, reclaimeeQueue, resources, nil, nil, lowPriority,
+				targetNodesNames...,
 			)
 			Expect(err).To(Succeed())
 			nodesNamesMap := map[string]bool{}


### PR DESCRIPTION
## Description

Allow the e2e tests to run in parallel on different scheduling shards.
2- "On PR" CI workflow will use 2 shards to run e2e tests.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
