### PR TITLE
fix: resolve issue with topology constraints when required and prefer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fixed pod controller logging to use request namespace/name instead of empty pod object fields when pod is not found
+- Fixed a bug where topology constrains with equal required and preferred levels would cause preferred level not to be found.
 
 ## [v0.12.0] - 2025-12-24
 

--- a/pkg/scheduler/plugins/topology/job_filtering.go
+++ b/pkg/scheduler/plugins/topology/job_filtering.go
@@ -398,16 +398,17 @@ func (*topologyPlugin) calculateRelevantDomainLevels(
 
 	var relevantLevels []DomainLevel
 	for _, level := range levels {
-		if level == requiredPlacement {
-			foundRequiredLevel = true
-			relevantLevels = append(relevantLevels, level)
-			break
-		}
 		if level == preferredPlacement {
 			foundPreferredLevel = true
 		}
-		if foundPreferredLevel {
+		if level == requiredPlacement {
+			foundRequiredLevel = true
+		}
+		if foundPreferredLevel || foundRequiredLevel {
 			relevantLevels = append(relevantLevels, level)
+		}
+		if foundRequiredLevel {
+			break
 		}
 	}
 


### PR DESCRIPTION
## Description

  Fixes a bug where topology constraints with equal required and preferred levels would cause the preferred level not to be found during scheduling. When `requiredTopologyLevel` and `preferredTopologyLevel`
  were set to the same value, the scheduler's topology evaluation logic would fail to properly handle this edge case.

  ## Related Issues

  Fixes #

  ## Checklist

  - [x] Self-reviewed
  - [x] Added/updated tests (if needed)
  - [ ] Updated documentation (if needed)

  ## Breaking Changes

  None

  ## Additional Notes

  This ensures workloads can successfully schedule when topology constraints specify the same level for both required and preferred topology placement.