### PR TITLE
fix (scheduler): Removed direct nesting constraint of subgroups in subgruopset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed GPU memory pods Fair Share and Queue Order calculations
 - Interpret negative or zero half-life value as disabled [#818](https://github.com/NVIDIA/KAI-Scheduler/pull/818) [itsomri](https://github.com/itsomri)
 
+### Changed
+- Removed the constraint that prohibited direct nesting of subgroups alongside podsets within the same subgroupset.
+
 ## [v0.12.0] - 2025-12-24
 
 ### Added

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/factory.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/factory.go
@@ -74,7 +74,7 @@ func createSubGroupInfos(allSubGroups map[string]*v2alpha2.SubGroup, children ma
 		if hasChildren {
 			subGroupSets[name] = NewSubGroupSet(name, topologyConstrainInfo)
 		} else {
-			podSets[name] = NewPodSet(name, subGroup.MinMember, topologyConstrainInfo)
+			podSets[name] = NewPodSet(name, max(subGroup.MinMember, 1), topologyConstrainInfo)
 		}
 	}
 }

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset.go
@@ -5,7 +5,6 @@ package subgroup_info
 
 import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/topology_info"
-	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/log"
 )
 
 type SubGroupSet struct {
@@ -25,21 +24,11 @@ func NewSubGroupSet(name string, topologyConstraint *topology_info.TopologyConst
 }
 
 func (sgs *SubGroupSet) AddSubGroup(subGroup *SubGroupSet) {
-	if len(sgs.podSets) > 0 {
-		log.InfraLogger.V(6).Warnf("subgroup %s already references podsets and "+
-			"cannot have additional nested subgroup %s", sgs.GetName(), subGroup.GetName())
-		return
-	}
 	subGroup.SetParent(sgs)
 	sgs.groups = append(sgs.groups, subGroup)
 }
 
 func (sgs *SubGroupSet) AddPodSet(podSet *PodSet) {
-	if len(sgs.groups) > 0 {
-		log.InfraLogger.V(6).Warnf("subgroup %s already has nested subgroups, "+
-			"it cannot references podset %s", sgs.GetName(), podSet.GetName())
-		return
-	}
 	podSet.SetParent(sgs)
 	sgs.podSets = append(sgs.podSets, podSet)
 }

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
@@ -44,18 +44,6 @@ func TestAddSubGroup(t *testing.T) {
 	}
 }
 
-func TestAddSubGroupAfterPodSet(t *testing.T) {
-	parent := NewSubGroupSet("parent", nil)
-	podSet := newTestPodSet("podset", 1)
-	parent.AddPodSet(podSet)
-	child := NewSubGroupSet("child", nil)
-	parent.AddSubGroup(child)
-	groups := parent.GetChildGroups()
-	if len(groups) != 0 {
-		t.Errorf("expected no subgroups to be added if podsets present, got %d", len(groups))
-	}
-}
-
 func TestAddPodSet(t *testing.T) {
 	parent := NewSubGroupSet("parent", nil)
 	podSet := newTestPodSet("podset", 2)
@@ -66,18 +54,6 @@ func TestAddPodSet(t *testing.T) {
 	}
 	if ps[0] != podSet {
 		t.Errorf("did not get correct podset after adding")
-	}
-}
-
-func TestAddPodSetAfterSubGroup(t *testing.T) {
-	parent := NewSubGroupSet("parent", nil)
-	child := NewSubGroupSet("child", nil)
-	parent.AddSubGroup(child)
-	podSet := newTestPodSet("podset", 3)
-	parent.AddPodSet(podSet)
-	ps := parent.GetChildPodSets()
-	if len(ps) != 0 {
-		t.Errorf("expected no podsets to be added if subgroup exists, got %d", len(ps))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

Removed the constraint that prohibited direct nesting of subgroups alongside podsets within the same subgroupset.
It caused an unexpected scheduling behavior when podgroup referenced direct leaf subgroup and intermediate subgroups with topology constraints. 
The API allows it and after examination of the code I couldn't find a real reason not to support it.

<!-- What does this PR do and why? -->

## Related Issues

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

The following drawing describes the workload that was partially scheduled before this change.
<img width="1097" height="416" alt="Screenshot 2026-01-06 at 11 34 22" src="https://github.com/user-attachments/assets/bef0a435-0fad-49fa-9632-c4db29e5be4a" />

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
