### PR TITLE
fix: Added periodic reservation sync to binder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed a bug where topology constrains with equal required and preferred levels would cause preferred level not to be found.
 - Fixed GPU memory pods Fair Share and Queue Order calculations
 - Interpret negative or zero half-life value as disabled [#818](https://github.com/NVIDIA/KAI-Scheduler/pull/818) [itsomri](https://github.com/itsomri)
+- Binder now periodically syncs reservation pods to ensure cleanup [#846](https://github.com/NVIDIA/KAI-Scheduler/pull/846) [itsomri](https://github.com/itsomri)
 
 ### Changed
 - Removed the constraint that prohibited direct nesting of subgroups alongside podsets within the same subgroupset.

--- a/cmd/binder/app/options.go
+++ b/cmd/binder/app/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	ResourceReservationPodImage          string
 	ResourceReservationAppLabel          string
 	ResourceReservationAllocationTimeout int
+	ResourceReservationSyncPeriodSeconds int
 	ResourceReservationPodResourcesJSON  string
 	ScalingPodNamespace                  string
 	QPS                                  float64
@@ -58,6 +59,9 @@ func InitOptions(fs *pflag.FlagSet) *Options {
 	fs.IntVar(&options.ResourceReservationAllocationTimeout,
 		"resource-reservation-allocation-timeout", 40,
 		"Resource reservation allocation timeout in seconds")
+	fs.IntVar(&options.ResourceReservationSyncPeriodSeconds,
+		"resource-reservation-sync-period", 60,
+		"Resource reservation sync period in seconds. Set to 0 to disable periodic sync.")
 	fs.StringVar(&options.ResourceReservationPodResourcesJSON,
 		"resource-reservation-pod-resources", "",
 		"JSON-serialized ResourceRequirements for GPU reservation pods (optional, empty means not set)")


### PR DESCRIPTION
## Description

This PR adds a background periodic sync to the binder to ensure reservation pod eventual consistency


## Checklist

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
