### PR TITLE
refactor: simplify job queue

### DIFF
--- a/pkg/scheduler/actions/utils/input_jobs.go
+++ b/pkg/scheduler/actions/utils/input_jobs.go
@@ -63,8 +63,6 @@ func (jobsOrder *JobsOrderByQueues) InitializeWithJobs(
 			continue
 		}
 
-		jobsOrder.addJobToQueue(job)
+		jobsOrder.PushJob(job)
 	}
-
-	jobsOrder.buildActiveQueues()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

simplify pkg/scheduler/actions/utils/job_order_by_queue.go by only using `PushJob` in pkg/scheduler/actions/utils/input_jobs.go

<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
