### PR TITLE
feat: add CEL selector in dra.go

### DIFF
--- a/test/e2e/modules/resources/capacity/dra.go
+++ b/test/e2e/modules/resources/capacity/dra.go
@@ -9,14 +9,17 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/k8s_utils"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/dynamic-resource-allocation/cel"
 )
 
-// SkipIfInsufficientDynamicResources checks if there are enough NodeName-type resourceSlices that have at least devicePerNode devices
+// SkipIfInsufficientDynamicResources skips the test if there aren't enough nodes with the required devices.
 func SkipIfInsufficientDynamicResources(clientset kubernetes.Interface, deviceClassName string, nodes, devicePerNode int) {
 	devicesByNode := ListDevicesByNode(clientset, deviceClassName)
 
@@ -33,7 +36,9 @@ func SkipIfInsufficientDynamicResources(clientset kubernetes.Interface, deviceCl
 	}
 }
 
-func ListDevicesByNode(clientset kubernetes.Interface, deviceClass string) map[string]int {
+// ListDevicesByNode counts devices per node that match the given DeviceClass selectors (CEL).
+// If the DeviceClass doesn't exist, the test is skipped. If it has no selectors, all devices match.
+func ListDevicesByNode(clientset kubernetes.Interface, deviceClassName string) map[string]int {
 	resourceSlices, err := clientset.ResourceV1().ResourceSlices().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -42,28 +47,90 @@ func ListDevicesByNode(clientset kubernetes.Interface, deviceClass string) map[s
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to list resource slices")
 	}
 
+	deviceClass, err := clientset.ResourceV1().DeviceClasses().Get(context.TODO(), deviceClassName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			ginkgo.Skip(fmt.Sprintf("DeviceClass %s not found, skipping", deviceClassName))
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to get device class %s", deviceClassName))
+	}
+
+	features := k8s_utils.GetK8sFeatures()
+	celCache := cel.NewCache(10, cel.Features{EnableConsumableCapacity: features.EnableConsumableCapacity})
+
+	var compiledSelectors []cel.CompilationResult
+	for _, selector := range deviceClass.Spec.Selectors {
+		if selector.CEL != nil && selector.CEL.Expression != "" {
+			compiled := celCache.GetOrCompile(selector.CEL.Expression)
+			if compiled.Error != nil {
+				gomega.Expect(compiled.Error).To(gomega.BeNil(), "Failed to compile CEL expression: %s", selector.CEL.Expression)
+			}
+			compiledSelectors = append(compiledSelectors, compiled)
+		}
+	}
+
 	devicesByNode := map[string]int{}
+	ctx := context.Background()
+
 	for _, slice := range resourceSlices.Items {
 		if slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
 			continue
 		}
 
-		// TODO: This is NOT the proper way to filter devices: the correct way is to check for each device if it matches
-		// the device class CEL selector. We'll need to address it if we want more complicated tests.
-		if slice.Spec.Driver != deviceClass {
-			continue
+		nodeName := *slice.Spec.NodeName
+		if _, ok := devicesByNode[nodeName]; !ok {
+			devicesByNode[nodeName] = 0
 		}
 
-		if _, ok := devicesByNode[*slice.Spec.NodeName]; !ok {
-			devicesByNode[*slice.Spec.NodeName] = 0
-		}
+		for _, device := range slice.Spec.Devices {
+			celDevice := convertToCelDevice(slice.Spec.Driver, device)
 
-		devicesByNode[*slice.Spec.NodeName] = devicesByNode[*slice.Spec.NodeName] + len(slice.Spec.Devices)
+			// DeviceClass selectors are AND'ed: each selector must match.
+			matches := true
+			for _, compiled := range compiledSelectors {
+				matched, _, err := compiled.DeviceMatches(ctx, celDevice)
+				if err != nil {
+					ginkgo.GinkgoWriter.Printf("Warning: Failed to evaluate CEL expression for device %s: %v\n", device.Name, err)
+					matches = false
+					break
+				}
+				if !matched {
+					matches = false
+					break
+				}
+			}
+
+			if matches {
+				devicesByNode[nodeName]++
+			}
+		}
 	}
 
 	return devicesByNode
 }
 
+// convertToCelDevice converts a ResourceSlice Device to cel.Device format.
+func convertToCelDevice(driver string, device resourceapi.Device) cel.Device {
+	attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+	capacity := make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity)
+
+	for k, v := range device.Attributes {
+		attributes[k] = v
+	}
+
+	for k, v := range device.Capacity {
+		capacity[k] = v
+	}
+
+	return cel.Device{
+		Driver:                   driver,
+		Attributes:               attributes,
+		Capacity:                 capacity,
+		AllowMultipleAllocations: device.AllowMultipleAllocations,
+	}
+}
+
+// CleanupResourceClaims deletes all ResourceClaims with the engine-e2e label in the given namespace.
 func CleanupResourceClaims(ctx context.Context, clientset kubernetes.Interface, namespace string) {
 	err := clientset.ResourceV1beta1().ResourceClaims(namespace).
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

The original test code used slice.Spec.Driver != deviceClass to filter devices, which is incorrect. DeviceClass names are not the same as drivers, and we should use CEL selectors to determine if a device belongs to a DeviceClass.


<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
