### PR TITLE
docs: document running tests when Docker credential helper fails (e.g. WSL)

### DIFF
--- a/docs/developer/building-from-source.md
+++ b/docs/developer/building-from-source.md
@@ -32,3 +32,40 @@ To build and deploy KAI Scheduler from source, follow these steps:
    ```sh
    helm upgrade -i kai-scheduler -n kai-scheduler --create-namespace ./charts/kai-scheduler-0.0.0.tgz
    ```
+
+## Testing
+
+From the repository root, run `make test` (Helm chart + Go tests in Docker).
+
+### When `make test` fails (e.g. WSL: `docker-credential-desktop.exe` not in PATH)
+
+**Option 1 — Fix Docker config (WSL):**
+
+```sh
+cp ~/.docker/config.json ~/.docker/config.json.bak
+echo '{}' > ~/.docker/config.json
+make test
+```
+
+Restore for private registry: `cp ~/.docker/config.json.bak ~/.docker/config.json`. Docker Desktop may restore `credsStore` on restart. See [Docker Desktop WSL](https://docs.docker.com/desktop/wsl/).
+
+**Option 2 — Run without Docker:**
+
+- Unit tests: `go test ./pkg/... ./cmd/... -count=1 -short` (envtest-dependent packages may fail; exit 1 is expected).
+- Integration (envtest): use `ENVTEST_K8S_VERSION` from `build/makefile/testenv.mk` (e.g. 1.34.0; do not use `latest`):
+  ```sh
+  make envtest
+  KUBEBUILDER_ASSETS="$(bin/setup-envtest use 1.34.0 -p path --bin-dir bin)" go test ./pkg/... -timeout 30m
+  ```
+- Validation: `make validate`, `make lint`.
+
+### Version reference
+
+| What | Defined in | Example |
+|------|------------|---------|
+| envtest K8s | `build/makefile/testenv.mk` → `ENVTEST_K8S_VERSION` | 1.34.0 |
+| envtest tool | `build/makefile/testenv.mk` → `ENVTEST_VERSION` | release-0.20 |
+| Go / builder | `build/makefile/golang.mk`, `build/builder/Dockerfile` | 1.24.4-bullseye |
+
+Use Makefile/Dockerfile values; do not use `latest`.
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->


## Description
Document how to run tests when Docker works and when `make test` fails (e.g. WSL + Docker Desktop credential helper).

- **building-from-source.md:** Testing section — `make test`; Option 1: fix Docker config (backup/clear `~/.docker/config.json`); Option 2: run without Docker (unit, envtest, validate). Version reference table (envtest K8s, envtest tool, Go/builder) — use Makefile values, not `latest`.
- **AGENTS.md:** Same flow under "Running tests when Docker is unavailable or credential helper fails": fix Docker (WSL) or run without Docker; version note.
<!-- What does this PR do and why? -->

## Related Issues

Closes #939 

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive testing guide with setup instructions and Docker troubleshooting steps
* Provided alternative test commands for environments without Docker
* Included Kubernetes version reference information for testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->