### PR TITLE
fix: use kaibot token to backport PRs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -20,4 +20,4 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           github_token: ${{ secrets.KAIBOT_TOKEN }}
-          pull_title: "${pull_title}"
+          pull_title: "${pull_title} wow"


### PR DESCRIPTION
# Description
Backport of #946 to `v0.12`.