### PR TITLE
docs: Fixed command for taking scheduler snapshot

### DIFF
--- a/docs/plugins/snapshot.md
+++ b/docs/plugins/snapshot.md
@@ -27,15 +27,25 @@ The snapshot plugin is a framework plugin that provides an HTTP endpoint to capt
   - ResourceSlices
   - DeviceClasses
 
-### Usage
+### Capturing a Snapshot
 
 The plugin registers an HTTP endpoint `/get-snapshot` that returns a ZIP file containing a JSON snapshot of the cluster state.
-Example for the scheduler pod that is deployed in `kai` namespace:
+
+To capture a snapshot, port-forward to the scheduler pod and call the endpoint:
 ```bash
-kubectl port-forward -n kai deployment/scheduler 8081 &
-curl -vv "localhost:8081/get-snapshot"  > snapshot.gzip
+kubectl port-forward -n kai-scheduler deployment/kai-scheduler-default 8081 &
+sleep 2
+curl -vv "localhost:8081/get-snapshot" > snapshot.gzip
+```
+
+### Analyzing a Snapshot
+
+Use the snapshot tool to analyze a captured snapshot:
+```bash
 ./bin/snapshot-tool-amd64 --filename snapshot.gzip --verbosity 8
 ```
+
+See the [Snapshot Tool](#snapshot-tool) section below for more details.
 
 ### Response Format
 


### PR DESCRIPTION
## Description

Fixed `snapshot.md`:
- Fixed the command to take the scheduler snapshot (use kai-scheduler namespace and kai-scheduler-default deployment)
- Clearly separated taking a snapshot and analyzing it

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
