### PR TITLE
fix: exclude Releasing pods from max pods predicate count

### DIFF
--- a/pkg/scheduler/api/node_info/node_info_storage_test.go
+++ b/pkg/scheduler/api/node_info/node_info_storage_test.go
@@ -118,6 +118,7 @@ func TestNodeInfoStorage_AddPod(t *testing.T) {
 		PodInfos: map[common_info.PodID]*pod_info.PodInfo{
 			pod1Info.UID: pod1Info,
 		},
+		AllocatedPodCount:      1, // 1 Running pod
 		LegacyMIGTasks:         map[common_info.PodID]string{},
 		MemoryOfEveryGpuOnNode: DefaultGpuMemory,
 		GpuSharingNodeInfo:     *newGpuSharingNodeInfo(),

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -206,9 +206,11 @@ func (pp *predicatesPlugin) evaluateTaskOnPredicates(
 	if task.IsSharedGPURequest() {
 		podsCountForTask += 1 // we need to include a *potential* reservation pod for fraction
 	}
-	if len(k8sNodeInfo.Pods)+podsCountForTask > node.MaxTaskNum {
-		log.InfraLogger.V(6).Infof("NodePodNumber predicates Task <%s/%s> on Node <%s> failed",
-			task.Namespace, task.Name, node.Name)
+	// Use node.AllocatedPodCount which excludes Releasing pods
+	if node.AllocatedPodCount+podsCountForTask > node.MaxTaskNum {
+		log.InfraLogger.V(6).Infof("NodePodNumber predicates Task <%s/%s> on Node <%s> failed: "+
+			"allocated pods (%d) + new pods (%d) > max (%d)",
+			task.Namespace, task.Name, node.Name, node.AllocatedPodCount, podsCountForTask, node.MaxTaskNum)
 		return common_info.NewFitError(task.Name, task.Namespace, node.Name, api.NodePodNumberExceeded)
 	}
 


### PR DESCRIPTION
## Description

This fixes a bug where the max pods predicate incorrectly counted pods in Releasing state (being preempted/evicted) toward the node's max pod limit, preventing new pods from scheduling even when slots were freeing up.

## Checklist

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
