### PR TITLE
fix(scheduler): Update maxNodeResource for gpu dras

### DIFF
--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -4,15 +4,19 @@
 package predicates
 
 import (
-	"reflect"
+	"context"
+	"strconv"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ksf "k8s.io/kube-scheduler/framework"
+	"k8s.io/utils/ptr"
 
 	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/resources"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
@@ -20,9 +24,10 @@ import (
 
 func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 	type args struct {
-		nodePoolName string
-		nodesMap     map[string]*node_info.NodeInfo
-		pod          *v1.Pod
+		nodePoolName   string
+		nodesMap       map[string]*node_info.NodeInfo
+		resourceClaims []*resourceapi.ResourceClaim
+		pod            *v1.Pod
 	}
 	type expected struct {
 		status *ksf.Status
@@ -45,6 +50,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						}),
 					},
 				},
+				resourceClaims: []*resourceapi.ResourceClaim{},
 				pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -89,6 +95,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						}),
 					},
 				},
+				resourceClaims: []*resourceapi.ResourceClaim{},
 				pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -134,6 +141,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						}),
 					},
 				},
+				resourceClaims: []*resourceapi.ResourceClaim{},
 				pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -179,6 +187,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						}),
 					},
 				},
+				resourceClaims: []*resourceapi.ResourceClaim{},
 				pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -224,6 +233,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						}),
 					},
 				},
+				resourceClaims: []*resourceapi.ResourceClaim{},
 				pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -270,6 +280,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						}),
 					},
 				},
+				resourceClaims: []*resourceapi.ResourceClaim{},
 				pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name1",
@@ -298,10 +309,225 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mnr := NewMaxNodeResourcesPredicate(tt.args.nodesMap, tt.args.nodePoolName)
-			if _, status := mnr.PreFilter(nil, nil, tt.args.pod, nil); !reflect.DeepEqual(status, tt.expected.status) {
+			mnr := NewMaxNodeResourcesPredicate(tt.args.nodesMap, tt.args.resourceClaims, tt.args.nodePoolName)
+			_, status := mnr.PreFilter(context.TODO(), nil, tt.args.pod, nil)
+			if !statusEqual(status, tt.expected.status) {
 				t.Errorf("PreFilter() = %v, want %v", status, tt.expected.status)
 			}
 		})
 	}
+}
+
+func makeDRAResourceSlice(name, nodeName, driver string, deviceCount int) *resourceapi.ResourceSlice {
+	devices := make([]resourceapi.Device, deviceCount)
+	for i := 0; i < deviceCount; i++ {
+		devices[i] = resourceapi.Device{Name: name + "-device-" + strconv.Itoa(i)}
+	}
+	return &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourceapi.ResourceSliceSpec{
+			NodeName: ptr.To(nodeName),
+			Driver:   driver,
+			Devices:  devices,
+		},
+	}
+}
+
+func buildNodesFromResourceSlices(slices []*resourceapi.ResourceSlice, nodeBases map[string]v1.ResourceList) map[string]*node_info.NodeInfo {
+	slicesByNode := make(map[string][]*resourceapi.ResourceSlice)
+	for _, slice := range slices {
+		if slice.Spec.NodeName != nil {
+			slicesByNode[*slice.Spec.NodeName] = append(slicesByNode[*slice.Spec.NodeName], slice)
+		}
+	}
+	nodesMap := make(map[string]*node_info.NodeInfo)
+	for nodeName, baseList := range nodeBases {
+		allocatable := resource_info.ResourceFromResourceList(baseList)
+		idle := allocatable.Clone()
+		ni := &node_info.NodeInfo{
+			Name:        nodeName,
+			Allocatable: allocatable,
+			Idle:        idle,
+			Releasing:   resource_info.EmptyResource(),
+			Used:        resource_info.EmptyResource(),
+		}
+		var draGPUCount int64
+		for _, slice := range slicesByNode[nodeName] {
+			if resources.IsGPUDeviceClass(slice.Spec.Driver) {
+				draGPUCount += int64(len(slice.Spec.Devices))
+			}
+		}
+		if draGPUCount > 0 {
+			ni.AddDRAGPUs(float64(draGPUCount))
+			ni.HasDRAGPUs = true
+		}
+		nodesMap[nodeName] = ni
+	}
+	return nodesMap
+}
+
+// TestMaxNodeResourcesPredicateDRA tests PreFilter with pods that use DRA ResourceClaims.
+// Node GPU capacity is derived from ResourceSlices (DRA) instead of extended resource nvidia.com/gpu.
+func TestMaxNodeResourcesPredicateDRA(t *testing.T) {
+	type args struct {
+		nodesMap       map[string]*node_info.NodeInfo
+		resourceClaims []*resourceapi.ResourceClaim
+		pod            *v1.Pod
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *ksf.Status
+	}{
+		{
+			"DRA claim within max node resources",
+			args{
+				nodesMap: buildNodesFromResourceSlices(
+					[]*resourceapi.ResourceSlice{
+						makeDRAResourceSlice("slice-n1", "n1", "nvidia.com/gpu", 1),
+						makeDRAResourceSlice("slice-n2", "n2", "nvidia.com/gpu", 1),
+					},
+					map[string]v1.ResourceList{
+						"n1": {
+							v1.ResourceCPU:     resource.MustParse("100m"),
+							v1.ResourceMemory:  resource.MustParse("200Mi"),
+							"kai.scheduler/r1": resource.MustParse("2"),
+						},
+						"n2": {
+							v1.ResourceCPU:     resource.MustParse("500m"),
+							v1.ResourceMemory:  resource.MustParse("200Mi"),
+							"kai.scheduler/r1": resource.MustParse("2"),
+						},
+					},
+				),
+				resourceClaims: []*resourceapi.ResourceClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gpu-claim-1",
+							Namespace: "n1",
+						},
+						Spec: resourceapi.ResourceClaimSpec{
+							Devices: resourceapi.DeviceClaim{
+								Requests: []resourceapi.DeviceRequest{
+									{
+										Name: "gpu-req",
+										Exactly: &resourceapi.ExactDeviceRequest{
+											DeviceClassName: "nvidia.com/gpu",
+											AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+											Count:           1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "n1",
+					},
+					Spec: v1.PodSpec{
+						ResourceClaims: []v1.PodResourceClaim{
+							{
+								Name:              "gpu-claim",
+								ResourceClaimName: ptr.To("gpu-claim-1"),
+							},
+						},
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"DRA claim exceeds max node resources",
+			args{
+				nodesMap: buildNodesFromResourceSlices(
+					[]*resourceapi.ResourceSlice{
+						makeDRAResourceSlice("slice-n1", "n1", "nvidia.com/gpu", 1),
+						makeDRAResourceSlice("slice-n2", "n2", "nvidia.com/gpu", 1),
+					},
+					map[string]v1.ResourceList{
+						"n1": {
+							v1.ResourceCPU:     resource.MustParse("100m"),
+							v1.ResourceMemory:  resource.MustParse("200Mi"),
+							"kai.scheduler/r1": resource.MustParse("2"),
+						},
+						"n2": {
+							v1.ResourceCPU:     resource.MustParse("500m"),
+							v1.ResourceMemory:  resource.MustParse("200Mi"),
+							"kai.scheduler/r1": resource.MustParse("2"),
+						},
+					},
+				),
+				resourceClaims: []*resourceapi.ResourceClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gpu-claim-2",
+							Namespace: "n1",
+						},
+						Spec: resourceapi.ResourceClaimSpec{
+							Devices: resourceapi.DeviceClaim{
+								Requests: []resourceapi.DeviceRequest{
+									{
+										Name: "gpu-req",
+										Exactly: &resourceapi.ExactDeviceRequest{
+											DeviceClassName: "nvidia.com/gpu",
+											AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+											Count:           2,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name1",
+						Namespace: "n1",
+					},
+					Spec: v1.PodSpec{
+						ResourceClaims: []v1.PodResourceClaim{
+							{
+								Name:              "gpu-claim",
+								ResourceClaimName: ptr.To("gpu-claim-2"),
+							},
+						},
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+							},
+						},
+					},
+				},
+			},
+			ksf.NewStatus(ksf.Unschedulable,
+				"The pod n1/name1 requires GPU: 2, CPU: 0 (cores), memory: 0 (GB). Max GPU resources available in a single node in the default node-pool is topped at 1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mnr := NewMaxNodeResourcesPredicate(tt.args.nodesMap, tt.args.resourceClaims, "")
+			_, status := mnr.PreFilter(context.TODO(), nil, tt.args.pod, nil)
+			if !statusEqual(status, tt.expected) {
+				t.Errorf("PreFilter() = %v, want %v", status, tt.expected)
+			}
+		})
+	}
+}
+
+func statusEqual(a, b *ksf.Status) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Code() == b.Code() && a.Message() == b.Message()
 }

--- a/pkg/scheduler/k8s_internal/predicates/predicates.go
+++ b/pkg/scheduler/k8s_internal/predicates/predicates.go
@@ -143,7 +143,7 @@ func NewSessionPredicates(ssn *framework.Session) k8s_internal.SessionPredicates
 		}
 	}
 
-	mnrPredicate := NewMaxNodeResourcesPredicate(ssn.ClusterInfo.Nodes, ssn.NodePoolName())
+	mnrPredicate := NewMaxNodeResourcesPredicate(ssn.ClusterInfo.Nodes, ssn.ClusterInfo.ResourceClaims, ssn.NodePoolName())
 	predicates[MaxNodePoolResources] = k8s_internal.SessionPredicate{
 		Name:                NodeScheduler,
 		IsPreFilterRequired: mnrPredicate.isPreFilterRequired,


### PR DESCRIPTION
## Description

1- Update the maxNodeResource predicate to calculate pod with gpu dra resources correctly
2- Update integration tests session builder with resourceClaim resources directly to the clusterInfo struct

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler predicate now processes resource allocation claims and includes DRA GPU counts in node resource eligibility evaluations

* **Tests**
  * Added comprehensive test coverage for pods requesting DRA GPU resources and resource claim allocation scenarios
  * Extended test utilities with resource claim and device class construction capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->