### PR TITLE
fix(scheduler): count MIG resources in preemption/reclaim GPU totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fixed a bug in ray gang scheduling where not all worker groups' minMember would be respected [#962](https://github.com/NVIDIA/KAI-Scheduler/pull/962) [itsomri](https://github.com/itsomri)
+- Fixed a bug where MIG-only pods were treated as 0 GPUs in preemption/reclaim accounting.
 
 ## [v0.12.11] - 2026-02-03
 ### Fixed

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus.go
@@ -179,7 +179,7 @@ func (ig *AccumulatedIdleGpus) updateRequiredResources(scenario *scenario.ByNode
 
 	var requiredResources []float64
 	for _, pod := range scenario.PendingTasks() {
-		requiredResources = append(requiredResources, pod.ResReq.GPUs())
+		requiredResources = append(requiredResources, pod.ResReq.GetSumGPUs())
 		ig.pendingTasksInState[pod.UID] = true
 	}
 	sort.Sort(sort.Reverse(sort.Float64Slice(requiredResources)))
@@ -206,7 +206,7 @@ func (ig *AccumulatedIdleGpus) updateWithVictim(
 	}
 
 	prevMinRelevantValue := ig.nodesNameToIdleGpus[minIdleGpusRelevant]
-	ig.nodesNameToIdleGpus[task.NodeName] += task.AcceptedResource.GPUs()
+	ig.nodesNameToIdleGpus[task.NodeName] += task.AcceptedResource.GetSumGPUs()
 
 	if ig.nodesNameToIdleGpus[task.NodeName] > prevMinRelevantValue {
 		ig.maxFreeGpuNodesSorted = orderedInsert(ig.maxFreeGpuNodesSorted, task.NodeName,

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus_mig_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus_mig_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package accumulated_scenario_filters
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
+)
+
+func TestAccumulatedIdleGpus_updateRequiredResources_countsMigPendingPods(t *testing.T) {
+	ig := &AccumulatedIdleGpus{
+		pendingTasksInState: map[common_info.PodID]bool{},
+	}
+
+	migPending := pod_info.NewTaskInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "uid-mig-pending",
+			Name:      "pending-mig",
+			Namespace: "n1",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	scen := scenario.NewByNodeScenario(
+		nil,
+		nil,
+		podgroup_info.NewPodGroupInfo("pg1", migPending),
+		[]*pod_info.PodInfo{},
+		[]*podgroup_info.PodGroupInfo{},
+	)
+
+	if err := ig.updateRequiredResources(scen, true); err != nil {
+		t.Fatalf("updateRequiredResources returned error: %v", err)
+	}
+
+	want := []float64{1}
+	if !reflect.DeepEqual(ig.requiredGpusSorted, want) {
+		t.Fatalf("requiredGpusSorted=%v, want %v", ig.requiredGpusSorted, want)
+	}
+}
+
+func TestAccumulatedIdleGpus_updateWithVictim_countsMigFreedGpus(t *testing.T) {
+	ig := &AccumulatedIdleGpus{
+		nodesNameToIdleGpus:     map[string]float64{"n1": 1.0, "n2": 2.0},
+		maxFreeGpuNodesSorted:   []string{"n2"},
+		recordedVictimsInCache:  map[common_info.PodID]bool{},
+		potentialVictimsInCache: map[common_info.PodID]bool{},
+	}
+
+	victim := &pod_info.PodInfo{
+		NodeName: "n1",
+		UID:      "uid-mig-victim",
+		AcceptedResource: &resource_info.ResourceRequirements{
+			GpuResourceRequirement: *resource_info.NewGpuResourceRequirementWithMig(map[v1.ResourceName]int64{
+				v1.ResourceName("nvidia.com/mig-2g.10gb"): 1,
+			}),
+		},
+	}
+
+	relevantCacheData := map[common_info.PodID]bool{}
+	minIdleGpusRelevant := ig.updateWithVictim(victim, "n2", relevantCacheData)
+
+	if minIdleGpusRelevant != "n1" {
+		t.Fatalf("minIdleGpusRelevant=%q, want %q", minIdleGpusRelevant, "n1")
+	}
+	if got := ig.nodesNameToIdleGpus["n1"]; got != 3.0 {
+		t.Fatalf("nodesNameToIdleGpus[n1]=%v, want %v", got, 3.0)
+	}
+	if !reflect.DeepEqual(ig.maxFreeGpuNodesSorted, []string{"n1"}) {
+		t.Fatalf("maxFreeGpuNodesSorted=%v, want %v", ig.maxFreeGpuNodesSorted, []string{"n1"})
+	}
+	if !reflect.DeepEqual(relevantCacheData, map[common_info.PodID]bool{"uid-mig-victim": true}) {
+		t.Fatalf("relevantCacheData=%v, want %v", relevantCacheData, map[common_info.PodID]bool{"uid-mig-victim": true})
+	}
+}

--- a/pkg/scheduler/plugins/proportion/reclaimable/mig_resources_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/mig_resources_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaimable
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
+	rs "github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/proportion/resource_share"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MIG resource handling in preemption", func() {
+	Context("getInvolvedResourcesNames", func() {
+		It("should detect GPU involvement for MIG-only resources", func() {
+			// Build a Resource with MIG scalar resources but gpus=0
+			migResource := resource_info.ResourceFromResourceList(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourceName("nvidia.com/mig-3g.20gb"): resource.MustParse("1"),
+			})
+
+			// gpus field should be 0 (MIG is stored in scalarResources)
+			Expect(migResource.GPUs()).To(Equal(float64(0)))
+
+			// But GetSumGPUs should return non-zero (3 GPU portions for mig-3g)
+			Expect(migResource.GetSumGPUs()).To(Equal(float64(3)))
+
+			involved := getInvolvedResourcesNames([]*resource_info.Resource{migResource})
+			Expect(involved).To(HaveKey(rs.GpuResource))
+			Expect(involved).To(HaveKey(rs.CpuResource))
+			Expect(involved).To(HaveKey(rs.MemoryResource))
+		})
+
+		It("should detect GPU involvement for regular GPU resources", func() {
+			gpuResource := resource_info.NewResource(1000, 1024*1024*1024, 2)
+
+			involved := getInvolvedResourcesNames([]*resource_info.Resource{gpuResource})
+			Expect(involved).To(HaveKey(rs.GpuResource))
+			Expect(involved).To(HaveKey(rs.CpuResource))
+			Expect(involved).To(HaveKey(rs.MemoryResource))
+		})
+
+		It("should detect GPU involvement for mixed MIG and regular GPU resources", func() {
+			mixedResource := resource_info.ResourceFromResourceList(v1.ResourceList{
+				v1.ResourceCPU:                           resource.MustParse("1"),
+				v1.ResourceMemory:                        resource.MustParse("1Gi"),
+				v1.ResourceName("nvidia.com/gpu"):        resource.MustParse("1"),
+				v1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("2"),
+			})
+
+			Expect(mixedResource.GPUs()).To(Equal(float64(1)))
+			Expect(mixedResource.GetSumGPUs()).To(Equal(float64(3))) // 1 whole + 2*1g
+
+			involved := getInvolvedResourcesNames([]*resource_info.Resource{mixedResource})
+			Expect(involved).To(HaveKey(rs.GpuResource))
+		})
+
+		It("should not include GPU for CPU/memory-only resources", func() {
+			cpuOnlyResource := resource_info.NewResource(1000, 1024*1024*1024, 0)
+
+			involved := getInvolvedResourcesNames([]*resource_info.Resource{cpuOnlyResource})
+			Expect(involved).NotTo(HaveKey(rs.GpuResource))
+			Expect(involved).To(HaveKey(rs.CpuResource))
+			Expect(involved).To(HaveKey(rs.MemoryResource))
+		})
+	})
+})

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable.go
@@ -277,7 +277,7 @@ func getInvolvedResourcesNames(resources []*resource_info.Resource) map[rs.Resou
 			involvedResources[rs.MemoryResource] = struct{}{}
 		}
 
-		if resource.GPUs() > 0 {
+		if resource.GetSumGPUs() > 0 {
 			involvedResources[rs.GpuResource] = struct{}{}
 		}
 	}

--- a/pkg/scheduler/plugins/proportion/utils/utils_test.go
+++ b/pkg/scheduler/plugins/proportion/utils/utils_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
+	rs "github.com/NVIDIA/KAI-scheduler/pkg/scheduler/plugins/proportion/resource_share"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proportion Utils suite")
+}
+
+var _ = Describe("QuantifyResource", func() {
+	It("should count MIG resources as GPUs", func() {
+		migResource := resource_info.ResourceFromResourceList(v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("2"),
+			v1.ResourceMemory: resource.MustParse("4Gi"),
+			v1.ResourceName("nvidia.com/mig-3g.20gb"): resource.MustParse("1"),
+		})
+
+		quantities := QuantifyResource(migResource)
+		Expect(quantities[rs.GpuResource]).To(Equal(float64(3)))
+		Expect(quantities[rs.CpuResource]).To(Equal(float64(2000))) // 2 cores = 2000 milliCPU
+	})
+
+	It("should count regular GPUs", func() {
+		gpuResource := resource_info.NewResource(1000, 1024*1024*1024, 2)
+
+		quantities := QuantifyResource(gpuResource)
+		Expect(quantities[rs.GpuResource]).To(Equal(float64(2)))
+	})
+
+	It("should count mixed MIG and regular GPUs", func() {
+		mixedResource := resource_info.ResourceFromResourceList(v1.ResourceList{
+			v1.ResourceCPU:                           resource.MustParse("1"),
+			v1.ResourceMemory:                        resource.MustParse("1Gi"),
+			v1.ResourceName("nvidia.com/gpu"):        resource.MustParse("1"),
+			v1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("2"),
+		})
+
+		quantities := QuantifyResource(mixedResource)
+		Expect(quantities[rs.GpuResource]).To(Equal(float64(3))) // 1 whole + 2*1g
+	})
+
+	It("should return zero GPU for CPU/memory-only resources", func() {
+		cpuResource := resource_info.NewResource(1000, 1024*1024*1024, 0)
+
+		quantities := QuantifyResource(cpuResource)
+		Expect(quantities[rs.GpuResource]).To(Equal(float64(0)))
+	})
+})


### PR DESCRIPTION
# Draft PR — NVIDIA/KAI-Scheduler (base: v0.12)

## Title
fix(scheduler): count MIG resources in preemption/reclaim GPU totals

## Body
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

MIG-only pods request GPU via MIG scalar resources (for example, `nvidia.com/mig-3g.20gb`) while `Resource.GPUs()` reflects only non-MIG `nvidia.com/gpu`. In the preemption/reclaim pipeline, three call sites used `GPUs()` and treated MIG-only pods as 0 GPUs, which breaks GPU quota/preemption behavior for MIG workloads.

This PR switches those accounting paths to use the summed GPU total (`GetSumGPUs()`), so MIG-only requests are properly counted. It also adds targeted unit tests covering MIG-only pending/victim accounting to prevent regressions.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

- Intentional narrow scope: this PR addresses preempt/reclaim accounting only. Other `GPUs()` call sites (for example in topology-related code paths) are out of scope and can be tracked separately.
