### PR TITLE
fix(e2e): flaky fill node test

### DIFF
--- a/test/e2e/modules/resources/capacity/dra.go
+++ b/test/e2e/modules/resources/capacity/dra.go
@@ -65,7 +65,7 @@ func ListDevicesByNode(clientset kubernetes.Interface, deviceClass string) map[s
 }
 
 func CleanupResourceClaims(ctx context.Context, clientset kubernetes.Interface, namespace string) {
-	err := clientset.ResourceV1beta1().ResourceClaims(namespace).
+	err := clientset.ResourceV1().ResourceClaims(namespace).
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=engine-e2e", constants.AppLabelName),
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

This partially fixes the flaky fill node DRA test. It will be completely fixed when we fix the DRA resource counting. 

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
