### PR TITLE
docs: minsubgroup design doc

### DIFF
--- a/docs/developer/designs/min-subgroups/README.md
+++ b/docs/developer/designs/min-subgroups/README.md
@@ -221,8 +221,7 @@ The following validations will be enforced via a Validating Webhook:
 
 **When using `minMember`:**
 1. `minMember` must be > 0
-2. For leaf SubGroups: `minMember` must be ≤ number of pods that will be assigned
-3. For mid-level SubGroups/PodGroups: Reserved for future use (currently must use `minSubGroup`)
+2. For mid-level SubGroups/PodGroups: Reserved for future use (currently must use `minSubGroup`)
 
 **When using `minSubGroup`:**
 1. `minSubGroup` must be > 0


### PR DESCRIPTION
## Description

Adds design document for hierarchical elastic workloads with subgroups via `minSubGroup`. Proposes extending PodGroup and SubGroup APIs with a `minSubGroup` field to specify the minimum number of child SubGroups required, enabling elastic gang scheduling where some replicas can fail while maintaining workload viability.

## Checklist

- [X] Self-reviewed
- [ ] Added/updated tests (if needed)
- [X] Updated documentation (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design documentation for hierarchical elastic workload scheduling, including configuration examples, validation rules, and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->