### PR TITLE
Allow Grove plugin to ignore PodGangs with specific annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Allow setting empty gpuPodRuntimeClassName during helm install [#972](https://github.com/NVIDIA/KAI-Scheduler/pull/972) [steved](https://github.com/steved)
 - Created scale tests scenarios for running scale tests for KAI [#967](https://github.com/NVIDIA/KAI-Scheduler/pull/967)
 - Implemented block-level segmentation for pytorchjobs [#938](https://github.com/NVIDIA/KAI-Scheduler/pull/938) [itsomri](https://github.com/itsomri)
+- Allow Grove plugin to ignore PodGangs with specific annotation [#1001](https://github.com/NVIDIA/KAI-Scheduler/pull/1001)
 
 ### Fixed
 - Fixed helm uninstall does not remove webhooks [#959](https://github.com/NVIDIA/KAI-Scheduler/pull/959) [faizan-exe](https://github.com/faizan-exe)

--- a/pkg/podgrouper/pod_controller.go
+++ b/pkg/podgrouper/pod_controller.go
@@ -116,6 +116,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	if metadata == nil {
+		return ctrl.Result{}, nil
+	}
+
 	if len(r.configs.NodePoolLabelKey) > 0 {
 		addNodePoolLabel(metadata, &pod, r.configs.NodePoolLabelKey)
 	}

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -24,6 +24,10 @@ const (
 	labelKeyPodGangName = "grove.io/podgang"
 )
 
+const (
+	annotationKeyIgnorePodGang = "grove.io/ignore"
+)
+
 type GroveGrouper struct {
 	client client.Client
 	*defaultgrouper.DefaultGrouper
@@ -61,6 +65,9 @@ func (gg *GroveGrouper) GetPodGroupMetadata(
 	if !ok {
 		return nil, fmt.Errorf("label for podgang name (key: %s) not found in pod %s/%s",
 			labelKeyPodGangName, pod.Namespace, pod.Name)
+	}
+	if _, ok := pod.Annotations[annotationKeyIgnorePodGang]; ok {
+		return nil, fmt.Errorf("podgang %s/%s annotated to be ignored", pod.Namespace, podGangName)
 	}
 	podGang, err := gg.fetchPodGang(pod.Namespace, podGangName)
 	if err != nil {

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -66,12 +66,12 @@ func (gg *GroveGrouper) GetPodGroupMetadata(
 		return nil, fmt.Errorf("label for podgang name (key: %s) not found in pod %s/%s",
 			labelKeyPodGangName, pod.Namespace, pod.Name)
 	}
-	if _, ok := pod.Annotations[annotationKeyIgnorePodGang]; ok {
-		return nil, fmt.Errorf("podgang %s/%s annotated to be ignored", pod.Namespace, podGangName)
-	}
 	podGang, err := gg.fetchPodGang(pod.Namespace, podGangName)
 	if err != nil {
 		return nil, err
+	}
+	if _, ok := podGang.Annotations[annotationKeyIgnorePodGang]; ok {
+		return nil, fmt.Errorf("podgang %s/%s annotated to be ignored", pod.Namespace, podGangName)
 	}
 
 	metadata, err := gg.DefaultGrouper.GetPodGroupMetadata(podGang, pod)

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -70,7 +70,7 @@ func (gg *GroveGrouper) GetPodGroupMetadata(
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := podGang.Annotations[annotationKeyIgnorePodGang]; ok {
+	if _, ok := podGang.GetAnnotations()[annotationKeyIgnorePodGang]; ok {
 		return nil, fmt.Errorf("podgang %s/%s annotated to be ignored", pod.Namespace, podGangName)
 	}
 

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -70,8 +70,10 @@ func (gg *GroveGrouper) GetPodGroupMetadata(
 	if err != nil {
 		return nil, err
 	}
+
+	// Ignore PodGang if it contains a specific annotation
 	if _, ok := podGang.GetAnnotations()[annotationKeyIgnorePodGang]; ok {
-		return nil, fmt.Errorf("podgang %s/%s annotated to be ignored", pod.Namespace, podGangName)
+		return nil, nil
 	}
 
 	metadata, err := gg.DefaultGrouper.GetPodGroupMetadata(podGang, pod)

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -6,6 +6,7 @@ package grove
 import (
 	"testing"
 
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgroup"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	"github.com/stretchr/testify/assert"

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -203,7 +203,7 @@ func TestGetPodGroupMetadata_IgnorePodGang(t *testing.T) {
 	grouper := NewGroveGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	metadata, err := grouper.GetPodGroupMetadata(nil, pod)
 	assert.Nil(t, err)
-	assert.EqualValues(t, nil, metadata)
+	assert.Equal(t, (*podgroup.Metadata)(nil), metadata)
 }
 
 func TestGetPodGroupMetadata_NestedValueErrors(t *testing.T) {

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -6,7 +6,6 @@ package grove
 import (
 	"testing"
 
-	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgroup"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	"github.com/stretchr/testify/assert"
@@ -204,7 +203,9 @@ func TestGetPodGroupMetadata_IgnorePodGang(t *testing.T) {
 	grouper := NewGroveGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	metadata, err := grouper.GetPodGroupMetadata(nil, pod)
 	assert.Nil(t, err)
-	assert.Equal(t, (*podgroup.Metadata)(nil), metadata)
+	if metadata != nil {
+		assert.Fail(t, "PodGang not ignored")
+	}
 }
 
 func TestGetPodGroupMetadata_NestedValueErrors(t *testing.T) {

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -203,7 +203,7 @@ func TestGetPodGroupMetadata_IgnorePodGang(t *testing.T) {
 	grouper := NewGroveGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
 	metadata, err := grouper.GetPodGroupMetadata(nil, pod)
 	assert.Nil(t, err)
-	assert.Equal(t, nil, metadata)
+	assert.EqualValues(t, nil, metadata)
 }
 
 func TestGetPodGroupMetadata_NestedValueErrors(t *testing.T) {

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -201,9 +201,9 @@ func TestGetPodGroupMetadata_IgnorePodGang(t *testing.T) {
 	}
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(podGang).Build()
 	grouper := NewGroveGrouper(client, defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client))
-	_, err := grouper.GetPodGroupMetadata(nil, pod)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "podgang test-ns/pgs1 annotated to be ignored")
+	metadata, err := grouper.GetPodGroupMetadata(nil, pod)
+	assert.Nil(t, err)
+	assert.Equal(t, nil, metadata)
 }
 
 func TestGetPodGroupMetadata_NestedValueErrors(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

<!-- What does this PR do and why? -->

This PR is to ensure that Grove PodGrouper plugin will ignore PodGangs which contain a `grove.io/ignore` annotation. With the upcoming Grove scheduler backend, Grove will start creating KAI PodGroups directly. Hence this specific Grove plugin needs to ignore all Grove PodGangs in future. This is a temporary measure to allow a smooth transition to the new scheduling backend framework in Grove.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
