### PR TITLE
Add test infrastructure and unit test for DRA allocation caching

### DIFF
--- a/pkg/common/k8s_utils/framework_handle.go
+++ b/pkg/common/k8s_utils/framework_handle.go
@@ -55,6 +55,10 @@ type K8sFramework struct {
 
 var _ k8sframework.Handle = &K8sFramework{}
 
+func (f *K8sFramework) SetSharedDRAManager(manager k8sframework.SharedDRAManager) {
+	f.sharedDRAManager = manager
+}
+
 func (f *K8sFramework) SharedDRAManager() k8sframework.SharedDRAManager {
 	if f.resourceClaimCache == nil {
 		rrInformer := f.informerFactory.Resource().V1().ResourceClaims().Informer()


### PR DESCRIPTION
- Add SetSharedDRAManager to K8sFramework for test injection
- Add SharedDRAManager field to TestMock for fake DRA manager injection
- Fix nil check for CacheRequirements in GetTestCacheMock
- Add TestAllocateUsesCachedAllocationFromPodInfo unit test that:
  - Fails on main (allocator called when cached allocation exists)
  - Passes with fix (cached allocation used, allocator not called)