### PR TITLE
ci: disable coderabbit comments about docstrings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,3 +7,6 @@ language: "en-US"
 reviews:
   auto_review:
     enabled: false
+  finishing_touches:
+    docstrings:
+      enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

We'll attempt to focus coderabbit to major and critical issue - removing comments about docstrings
## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
