### PR TITLE
feat(podgrouper): add Kubeflow Trainer v2 TrainJob support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Added support for Kubeflow Trainer v2 TrainJob workloads via skipTopOwner grouper pattern
 - Added `binder.cdiEnabled` Helm value to allow explicit override of CDI auto-detection for environments without ClusterPolicy
 - Added metric for tracking evicted pods in pod groups, including nodepool, eviction action, and gang size
 - Block scheduling of pods with shared (non-template) DRA GPU claims that lack a queue label or have a mismatched queue label [gshaibi](https://github.com/gshaibi)

--- a/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -380,6 +380,22 @@ rules:
   - patch
   - update
 - apiGroups:
+  - trainer.kubeflow.org
+  resources:
+  - trainjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - trainer.kubeflow.org
+  resources:
+  - trainjobs/finalizers
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - workspace.devfile.io
   resources:
   - devworkspaces

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -35,6 +35,7 @@ import (
 const (
 	apiGroupArgo                     = "argoproj.io"
 	apiGroupRunai                    = "run.ai"
+	apiGroupTrainer                  = "trainer.kubeflow.org"
 	kindTrainingWorkload             = "TrainingWorkload"
 	kindInteractiveWorkload          = "InteractiveWorkload"
 	kindDistributedWorkload          = "DistributedWorkload"
@@ -55,6 +56,8 @@ const (
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns;taskruns,verbs=get;list;watch
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/finalizers;taskruns/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=run.ai,resources=trainingworkloads;interactiveworkloads;distributedworkloads;inferenceworkloads;distributedinferenceworkloads,verbs=get;list;watch
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs/finalizers,verbs=patch;update;create
 
 type DefaultPluginsHub struct {
 	defaultPlugin *defaultgrouper.DefaultGrouper
@@ -308,6 +311,13 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 			Kind:    kind,
 		}] = skipTopOwnerGrouper
 	}
+
+	// TrainJob (Kubeflow Trainer v2) wraps a JobSet; skip TrainJob and delegate to JobSet grouper
+	table[metav1.GroupVersionKind{
+		Group:   apiGroupTrainer,
+		Version: "v1alpha1",
+		Kind:    "TrainJob",
+	}] = skipTopOwnerGrouper
 
 	// Dynamo uses Grove Grouper and needs to propagate metadata from DynamoGraphDeployment to PodGang and PodClique.
 	table[metav1.GroupVersionKind{

--- a/pkg/podgrouper/podgrouper/hub/hub_test.go
+++ b/pkg/podgrouper/podgrouper/hub/hub_test.go
@@ -79,6 +79,17 @@ var _ = Describe("SupportedTypes", func() {
 			hasPlugin := hub.HasMatchingPlugin(gvk)
 			Expect(hasPlugin).To(BeFalse())
 		})
+
+		It("should return skipTopOwner plugin for TrainJob", func() {
+			gvk := metav1.GroupVersionKind{
+				Group:   "trainer.kubeflow.org",
+				Version: "v1alpha1",
+				Kind:    "TrainJob",
+			}
+			plugin := hub.GetPodGrouperPlugin(gvk)
+			Expect(plugin).NotTo(BeNil())
+			Expect(plugin.Name()).To(BeEquivalentTo("SkipTopOwner Grouper"))
+		})
 	})
 
 	Context("Wildcard Version Tests", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

Add support for [Kubeflow Trainer v2](https://github.com/kubeflow/trainer) TrainJob workloads in KAI Scheduler's podgrouper.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/NVIDIA/KAI-Scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
 

