### PR TITLE
chore: rename constant for gpu resources names

### DIFF
--- a/pkg/admission/webhook/v1alpha2/gpusharing/gpu_sharing_test.go
+++ b/pkg/admission/webhook/v1alpha2/gpusharing/gpu_sharing_test.go
@@ -34,7 +34,7 @@ func TestValidate(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("1"),
+									constants.NvidiaGpuResource: resource.MustParse("1"),
 								},
 							},
 						},
@@ -56,7 +56,7 @@ func TestValidate(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("1"),
+									constants.NvidiaGpuResource: resource.MustParse("1"),
 								},
 							},
 						},
@@ -222,7 +222,7 @@ func TestMutate(t *testing.T) {
 							Name: "test-container",
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("1"),
+									constants.NvidiaGpuResource: resource.MustParse("1"),
 								},
 							},
 						},

--- a/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go
+++ b/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go
@@ -61,7 +61,7 @@ func TestMutate(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{constants.GpuResource: resource.MustParse("1")},
+								Limits: v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
 							},
 						},
 					},
@@ -73,7 +73,7 @@ func TestMutate(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{constants.GpuResource: resource.MustParse("1")},
+								Limits: v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
 							},
 						},
 					},
@@ -90,7 +90,7 @@ func TestMutate(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{constants.GpuResource: resource.MustParse("1")},
+								Limits: v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
 							},
 						},
 					},
@@ -102,7 +102,7 @@ func TestMutate(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{constants.GpuResource: resource.MustParse("1")},
+								Limits: v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
 							},
 						},
 					},

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -394,20 +394,20 @@ func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGr
 	// Build resource requirements starting with GPU resources
 	resources := v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			constants.GpuResource: *resource.NewQuantity(numberOfGPUsToReserve, resource.DecimalSI),
+			constants.NvidiaGpuResource: *resource.NewQuantity(numberOfGPUsToReserve, resource.DecimalSI),
 		},
 		Requests: v1.ResourceList{
-			constants.GpuResource: *resource.NewQuantity(numberOfGPUsToReserve, resource.DecimalSI),
+			constants.NvidiaGpuResource: *resource.NewQuantity(numberOfGPUsToReserve, resource.DecimalSI),
 		},
 	}
 
 	if rsc.podResources != nil {
 		if rsc.podResources.Limits != nil {
-			delete(rsc.podResources.Limits, constants.GpuResource)
+			delete(rsc.podResources.Limits, constants.NvidiaGpuResource)
 			maps.Copy(resources.Limits, rsc.podResources.Limits)
 		}
 		if rsc.podResources.Requests != nil {
-			delete(rsc.podResources.Requests, constants.GpuResource)
+			delete(rsc.podResources.Requests, constants.NvidiaGpuResource)
 			maps.Copy(resources.Requests, rsc.podResources.Requests)
 		}
 	}

--- a/pkg/binder/binding/resourcereservation/resource_reservation_test.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation_test.go
@@ -1128,8 +1128,8 @@ var _ = Describe("ResourceReservationService", func() {
 			Expect(container.Resources.Limits[v1.ResourceMemory]).To(Equal(resource.MustParse("200Mi")))
 
 			// Verify GPU resource is still set
-			gpuRequest := container.Resources.Requests[constants.GpuResource]
-			gpuLimit := container.Resources.Limits[constants.GpuResource]
+			gpuRequest := container.Resources.Requests[constants.NvidiaGpuResource]
+			gpuLimit := container.Resources.Limits[constants.NvidiaGpuResource]
 			Expect(gpuRequest.Value()).To(Equal(int64(1)))
 			Expect(gpuLimit.Value()).To(Equal(int64(1)))
 		})
@@ -1164,8 +1164,8 @@ var _ = Describe("ResourceReservationService", func() {
 			Expect(memLimitExists).To(BeFalse())
 
 			// Verify GPU resource is still set
-			gpuRequest := container.Resources.Requests[constants.GpuResource]
-			gpuLimit := container.Resources.Limits[constants.GpuResource]
+			gpuRequest := container.Resources.Requests[constants.NvidiaGpuResource]
+			gpuLimit := container.Resources.Limits[constants.NvidiaGpuResource]
 			Expect(gpuRequest.Value()).To(Equal(int64(1)))
 			Expect(gpuLimit.Value()).To(Equal(int64(1)))
 		})
@@ -1218,12 +1218,12 @@ var _ = Describe("ResourceReservationService", func() {
 				runtimeClassName:    "nvidia",
 				podResources: &v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceCPU:        resource.MustParse("10m"),
-						constants.GpuResource: resource.MustParse("999"), // This should be ignored
+						v1.ResourceCPU:              resource.MustParse("10m"),
+						constants.NvidiaGpuResource: resource.MustParse("999"), // This should be ignored
 					},
 					Limits: v1.ResourceList{
-						v1.ResourceCPU:        resource.MustParse("100m"),
-						constants.GpuResource: resource.MustParse("999"), // This should be ignored
+						v1.ResourceCPU:              resource.MustParse("100m"),
+						constants.NvidiaGpuResource: resource.MustParse("999"), // This should be ignored
 					},
 				},
 				scalingPodNamespace: scalingPodsNamespace,
@@ -1240,8 +1240,8 @@ var _ = Describe("ResourceReservationService", func() {
 			Expect(container.Resources.Limits[v1.ResourceCPU]).To(Equal(resource.MustParse("100m")))
 
 			// Verify GPU resources are NOT overridden - should always be 1
-			gpuRequest := container.Resources.Requests[constants.GpuResource]
-			gpuLimit := container.Resources.Limits[constants.GpuResource]
+			gpuRequest := container.Resources.Requests[constants.NvidiaGpuResource]
+			gpuLimit := container.Resources.Limits[constants.NvidiaGpuResource]
 			Expect(gpuRequest.Value()).To(Equal(int64(1)), "GPU request should be 1, not overridden by podResources")
 			Expect(gpuLimit.Value()).To(Equal(int64(1)), "GPU limit should be 1, not overridden by podResources")
 		})

--- a/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator.go
+++ b/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator.go
@@ -99,7 +99,7 @@ func validateMultiFractionRequest(hasGpuFractionsCount bool, gpuFractionsCountFr
 func getFirstGPULimit(pod *v1.Pod) *resource.Quantity {
 	containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
 	for _, container := range containers {
-		if limit, ok := container.Resources.Limits[constants.GpuResource]; ok {
+		if limit, ok := container.Resources.Limits[constants.NvidiaGpuResource]; ok {
 			return &limit
 		}
 	}

--- a/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator_test.go
+++ b/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator_test.go
@@ -54,7 +54,7 @@ func TestValidateGpuRequests(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("1"),
+									constants.NvidiaGpuResource: resource.MustParse("1"),
 								},
 							},
 						},
@@ -113,7 +113,7 @@ func TestValidateGpuRequests(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: *resource.NewMilliQuantity(2, resource.DecimalSI),
+									constants.NvidiaGpuResource: *resource.NewMilliQuantity(2, resource.DecimalSI),
 								},
 							},
 						},
@@ -151,7 +151,7 @@ func TestValidateGpuRequests(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("2"),
+									constants.NvidiaGpuResource: resource.MustParse("2"),
 								},
 							},
 						},
@@ -171,7 +171,7 @@ func TestValidateGpuRequests(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: *resource.NewMilliQuantity(2000, resource.DecimalSI),
+									constants.NvidiaGpuResource: *resource.NewMilliQuantity(2000, resource.DecimalSI),
 								},
 							},
 						},
@@ -210,14 +210,14 @@ func TestValidateGpuRequests(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("1"),
+									constants.NvidiaGpuResource: resource.MustParse("1"),
 								},
 							},
 						},
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: resource.MustParse("2"),
+									constants.NvidiaGpuResource: resource.MustParse("2"),
 								},
 							},
 						},
@@ -239,7 +239,7 @@ func TestValidateGpuRequests(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: *resource.NewMilliQuantity(1, resource.DecimalSI),
+									constants.NvidiaGpuResource: *resource.NewMilliQuantity(1, resource.DecimalSI),
 								},
 							},
 						},
@@ -266,7 +266,7 @@ func TestValidateGpuRequests(t *testing.T) {
 							Name: "SneakyGPUContainer",
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									constants.GpuResource: *resource.NewMilliQuantity(1, resource.DecimalSI),
+									constants.NvidiaGpuResource: *resource.NewMilliQuantity(1, resource.DecimalSI),
 								},
 							},
 						},

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -5,8 +5,9 @@ package constants
 
 const (
 	AppLabelName              = "app"
-	GpuResource               = "nvidia.com/gpu"
+	NvidiaGpuResource         = "nvidia.com/gpu"
 	NvidiaGpuMemory           = "nvidia.com/gpu.memory"
+	GpuResource               = "gpu"
 	UnlimitedResourceQuantity = float64(-1)
 
 	DefaultQueuePriority                  = 100

--- a/pkg/common/resources/dra_gpu_test.go
+++ b/pkg/common/resources/dra_gpu_test.go
@@ -48,7 +48,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
@@ -69,7 +69,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           0,
 									},
@@ -90,7 +90,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeAll,
 									},
 								},
@@ -110,14 +110,14 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
 								},
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           3,
 									},
@@ -145,7 +145,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 								},
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
@@ -198,7 +198,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  "UnknownMode",
 										Count:           5,
 									},
@@ -245,7 +245,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
@@ -274,7 +274,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 
 				result, err := ExtractDRAGPUResources(ctx, pod, fakeClient)
 				Expect(err).NotTo(HaveOccurred())
-				gpuQuantity, exists := result[constants.GpuResource]
+				gpuQuantity, exists := result[constants.NvidiaGpuResource]
 				Expect(exists).To(BeTrue(), "result should contain GPU resource")
 				Expect(gpuQuantity.Value()).To(Equal(int64(2)))
 			})
@@ -290,7 +290,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
@@ -310,7 +310,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           3,
 									},
@@ -344,7 +344,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 
 				result, err := ExtractDRAGPUResources(ctx, pod, fakeClient)
 				Expect(err).NotTo(HaveOccurred())
-				gpuQuantity, exists := result[constants.GpuResource]
+				gpuQuantity, exists := result[constants.NvidiaGpuResource]
 				Expect(exists).To(BeTrue(), "result should contain GPU resource")
 				Expect(gpuQuantity.Value()).To(Equal(int64(5)))
 			})
@@ -360,7 +360,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           1,
 									},
@@ -397,7 +397,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 
 				result, err := ExtractDRAGPUResources(ctx, pod, fakeClient)
 				Expect(err).NotTo(HaveOccurred())
-				gpuQuantity, exists := result[constants.GpuResource]
+				gpuQuantity, exists := result[constants.NvidiaGpuResource]
 				Expect(exists).To(BeTrue(), "result should contain GPU resource")
 				Expect(gpuQuantity.Value()).To(Equal(int64(1)))
 			})
@@ -505,7 +505,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
@@ -559,7 +559,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 
 				result, err := ExtractDRAGPUResources(ctx, pod, fakeClient)
 				Expect(err).NotTo(HaveOccurred())
-				gpuQuantity, exists := result[constants.GpuResource]
+				gpuQuantity, exists := result[constants.NvidiaGpuResource]
 				Expect(exists).To(BeTrue(), "result should contain GPU resource")
 				Expect(gpuQuantity.Value()).To(Equal(int64(2)))
 			})
@@ -577,7 +577,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 										Count:           2,
 									},
@@ -597,7 +597,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 							Requests: []resourceapi.DeviceRequest{
 								{
 									Exactly: &resourceapi.ExactDeviceRequest{
-										DeviceClassName: constants.GpuResource,
+										DeviceClassName: constants.NvidiaGpuResource,
 										AllocationMode:  resourceapi.DeviceAllocationModeAll,
 									},
 								},
@@ -630,7 +630,7 @@ var _ = Describe("DRA GPU Extraction", func() {
 
 				result, err := ExtractDRAGPUResources(ctx, pod, fakeClient)
 				Expect(err).NotTo(HaveOccurred())
-				gpuQuantity, exists := result[constants.GpuResource]
+				gpuQuantity, exists := result[constants.NvidiaGpuResource]
 				Expect(exists).To(BeTrue(), "result should contain GPU resource")
 				// ExactCount: 2, All: 1 (conservative estimate) = 3 total
 				Expect(gpuQuantity.Value()).To(Equal(int64(3)))

--- a/pkg/common/resources/gpu_sharing.go
+++ b/pkg/common/resources/gpu_sharing.go
@@ -26,10 +26,10 @@ func RequestsGPUFraction(pod *v1.Pod) bool {
 
 func RequestsWholeGPU(pod *v1.Pod) bool {
 	for _, container := range pod.Spec.Containers {
-		if _, ok := container.Resources.Requests[constants.GpuResource]; ok {
+		if _, ok := container.Resources.Requests[constants.NvidiaGpuResource]; ok {
 			return true
 		}
-		if _, ok := container.Resources.Limits[constants.GpuResource]; ok {
+		if _, ok := container.Resources.Limits[constants.NvidiaGpuResource]; ok {
 			return true
 		}
 	}

--- a/pkg/env-tests/binder_test.go
+++ b/pkg/env-tests/binder_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Binder", Ordered, func() {
 		It("Should bind a pod with a bind request", func(ctx context.Context) {
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")

--- a/pkg/env-tests/podgroupcontroller_test.go
+++ b/pkg/env-tests/podgroupcontroller_test.go
@@ -107,7 +107,7 @@ var _ = Describe("PodGroupController", Ordered, func() {
 		It("Should update podgroup status", func(ctx context.Context) {
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
@@ -153,7 +153,7 @@ var _ = Describe("PodGroupController", Ordered, func() {
 					return false, nil
 				}
 
-				if podgroup.Status.ResourcesStatus.Allocated[constants.GpuResource] != resource.MustParse("1") {
+				if podgroup.Status.ResourcesStatus.Allocated[constants.NvidiaGpuResource] != resource.MustParse("1") {
 					return false, nil
 				}
 

--- a/pkg/env-tests/queuecontroller_test.go
+++ b/pkg/env-tests/queuecontroller_test.go
@@ -103,7 +103,7 @@ var _ = Describe("QueueController", Ordered, func() {
 		It("Should update queue status", func(ctx context.Context) {
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
@@ -119,7 +119,7 @@ var _ = Describe("QueueController", Ordered, func() {
 
 			podgroupCopy := podgroup.DeepCopy()
 			podgroupCopy.Status.ResourcesStatus.Allocated = corev1.ResourceList{
-				constants.GpuResource: resource.MustParse("420"),
+				constants.NvidiaGpuResource: resource.MustParse("420"),
 			}
 			Expect(ctrlClient.Status().Patch(ctx, podgroupCopy, client.MergeFrom(&podgroup))).To(Succeed(), "Failed to patch test podgroup status")
 
@@ -135,7 +135,7 @@ var _ = Describe("QueueController", Ordered, func() {
 					return false, nil
 				}
 
-				if queue.Status.Allocated[constants.GpuResource] != resource.MustParse("420") {
+				if queue.Status.Allocated[constants.NvidiaGpuResource] != resource.MustParse("420") {
 					return false, nil
 				}
 

--- a/pkg/env-tests/scheduler_test.go
+++ b/pkg/env-tests/scheduler_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			// Create your pod as before
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
@@ -136,7 +136,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 		It("Should allow optional projected configmap references", func(ctx context.Context) {
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod-optional-configmap", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			testPod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
@@ -187,7 +187,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			// Create your pod as before
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			testPod.Spec.SchedulingGates = []corev1.PodSchedulingGate{
@@ -242,7 +242,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 		It("Should respect scheduling gates - podgroup", func(ctx context.Context) {
 			testPod1 := utils.CreatePodObject(testNamespace.Name, "test-pod-1", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			testPod1.Spec.SchedulingGates = []corev1.PodSchedulingGate{
@@ -254,7 +254,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 
 			testPod2 := utils.CreatePodObject(testNamespace.Name, "test-pod-2", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			testPod2.Spec.SchedulingGates = []corev1.PodSchedulingGate{
@@ -317,7 +317,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			// Create your pod as before
 			testPod := utils.CreatePodObject(testNamespace.Name, "test-pod", corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse("999"),
+					constants.NvidiaGpuResource: resource.MustParse("999"),
 				},
 			})
 			Expect(ctrlClient.Create(ctx, testPod)).To(Succeed(), "Failed to create test pod")
@@ -638,7 +638,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 		It("Schedule pods with rack topology constraints", func(ctx context.Context) {
 			// schedule a single gpu pod outside of the topology to try and "pull" the topology constraint workload pods outside of a valid rack
 			binPackingPullPod := utils.CreatePodObject(testNamespace.Name, "bin-packing-pull-pod", corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{constants.GpuResource: resource.MustParse("1")},
+				Limits: corev1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
 			})
 			binPackingPullPod.Spec.NodeSelector = map[string]string{
 				hostnameLabelKey: "test-node",
@@ -649,10 +649,10 @@ var _ = Describe("Scheduler", Ordered, func() {
 
 			singlePodResourceRequirements := corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse(fmt.Sprintf("%d", gpusPerNode-1)),
+					constants.NvidiaGpuResource: resource.MustParse(fmt.Sprintf("%d", gpusPerNode-1)),
 				},
 				Requests: corev1.ResourceList{
-					constants.GpuResource: resource.MustParse(fmt.Sprintf("%d", gpusPerNode-1)),
+					constants.NvidiaGpuResource: resource.MustParse(fmt.Sprintf("%d", gpusPerNode-1)),
 				},
 			}
 

--- a/pkg/env-tests/timeaware/timeaware.go
+++ b/pkg/env-tests/timeaware/timeaware.go
@@ -281,7 +281,7 @@ func RunSimulation(
 		a := map[common_info.QueueID]SimulationDataPoint{}
 		for queueID, fairshare := range fairshares {
 			a[queueID] = SimulationDataPoint{
-				Allocation: allocations[queueID][constants.GpuResource],
+				Allocation: allocations[queueID][constants.NvidiaGpuResource],
 				FairShare:  fairshare.GPUs(),
 			}
 		}
@@ -378,7 +378,7 @@ func queueJob(ctx context.Context, ctrlClient client.Client, namespace, queueNam
 		name := randomstring.HumanFriendlyEnglishString(10)
 		testPod := utils.CreatePodObject(namespace, name, corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				constants.GpuResource: resource.MustParse(fmt.Sprintf("%d", gpus)),
+				constants.NvidiaGpuResource: resource.MustParse(fmt.Sprintf("%d", gpus)),
 			},
 		})
 		err := ctrlClient.Create(ctx, testPod)

--- a/pkg/nodescaleadjuster/scale_adjuster/calculator.go
+++ b/pkg/nodescaleadjuster/scale_adjuster/calculator.go
@@ -30,7 +30,7 @@ func (c *calculator) calculateNumScalingDevices(scalingPods []*v1.Pod) int64 {
 	numScalingDevices := int64(0)
 	for _, pod := range scalingPods {
 		resReq := pod.Spec.Containers[0].Resources.Requests
-		numDevices := resReq[constants.GpuResource]
+		numDevices := resReq[constants.NvidiaGpuResource]
 		numScalingDevices += numDevices.Value()
 	}
 	return numScalingDevices
@@ -40,7 +40,7 @@ func (c *calculator) calculateMaxScalingDevices(scalingPods []*v1.Pod) int64 {
 	maxScalingDevices := int64(0)
 	for _, pod := range scalingPods {
 		resReq := pod.Spec.Containers[0].Resources.Requests
-		numDevices := resReq[constants.GpuResource]
+		numDevices := resReq[constants.NvidiaGpuResource]
 		maxScalingDevices = max(numDevices.Value(), maxScalingDevices)
 	}
 	return maxScalingDevices

--- a/pkg/nodescaleadjuster/scale_adjuster/scale_adjuster_test.go
+++ b/pkg/nodescaleadjuster/scale_adjuster/scale_adjuster_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Scale Adjuster Test Suite", func() {
 				Expect(err).To(BeNil())
 
 				if remainingPod.numDevices != nil {
-					actualNumDevices := pod.Spec.Containers[0].Resources.Limits[constants.GpuResource]
+					actualNumDevices := pod.Spec.Containers[0].Resources.Limits[constants.NvidiaGpuResource]
 					Expect(actualNumDevices.Value()).To(Equal(*remainingPod.numDevices))
 				}
 			}

--- a/pkg/nodescaleadjuster/scaler/scaler_test.go
+++ b/pkg/nodescaleadjuster/scaler/scaler_test.go
@@ -51,8 +51,8 @@ func TestCreateScalingPodWithMultipleDevices(t *testing.T) {
 	assert.Equal(t, 1, len(scalingPods.Items), "Expected one scaling pod")
 
 	container := scalingPods.Items[0].Spec.Containers[0]
-	gpuResourceRequest := container.Resources.Requests[constants.GpuResource]
-	gpuResourceLimits := container.Resources.Limits[constants.GpuResource]
+	gpuResourceRequest := container.Resources.Requests[constants.NvidiaGpuResource]
+	gpuResourceLimits := container.Resources.Limits[constants.NvidiaGpuResource]
 	assert.Equal(t, int64(3), gpuResourceRequest.Value())
 	assert.Equal(t, int64(3), gpuResourceLimits.Value())
 }

--- a/pkg/nodescaleadjuster/scaler/scaling_pod.go
+++ b/pkg/nodescaleadjuster/scaler/scaling_pod.go
@@ -24,10 +24,10 @@ func createScalingPodSpec(
 ) *corev1.Pod {
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			constants.GpuResource: *resource.NewQuantity(numDevices, resource.DecimalSI),
+			constants.NvidiaGpuResource: *resource.NewQuantity(numDevices, resource.DecimalSI),
 		},
 		Limits: corev1.ResourceList{
-			constants.GpuResource: *resource.NewQuantity(numDevices, resource.DecimalSI),
+			constants.NvidiaGpuResource: *resource.NewQuantity(numDevices, resource.DecimalSI),
 		},
 	}
 	for _, container := range unschedulablePod.Spec.Containers {

--- a/pkg/nodescaleadjuster/scaler/scaling_pod_test.go
+++ b/pkg/nodescaleadjuster/scaler/scaling_pod_test.go
@@ -110,7 +110,7 @@ func TestRequestedResources(t *testing.T) {
 	}
 
 	gpuReqRes := resource.MustParse("3")
-	if !requestedResources.Name(constants.GpuResource, resource.DecimalSI).Equal(gpuReqRes) {
+	if !requestedResources.Name(constants.NvidiaGpuResource, resource.DecimalSI).Equal(gpuReqRes) {
 		t.Errorf("Failed to aggregate memory requested resources")
 	}
 

--- a/pkg/nodescaleadjuster/test-utils/test_utils.go
+++ b/pkg/nodescaleadjuster/test-utils/test_utils.go
@@ -96,10 +96,10 @@ func CreateScalingPod(unschedulablePodNamespace, unschedulablePodName string, nu
 				{
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							constants.GpuResource: *resource.NewQuantity(int64(numDevices), resource.DecimalSI),
+							constants.NvidiaGpuResource: *resource.NewQuantity(int64(numDevices), resource.DecimalSI),
 						},
 						Limits: corev1.ResourceList{
-							constants.GpuResource: *resource.NewQuantity(int64(numDevices), resource.DecimalSI),
+							constants.NvidiaGpuResource: *resource.NewQuantity(int64(numDevices), resource.DecimalSI),
 						},
 					},
 				},

--- a/pkg/podgroupcontroller/controllers/resources/received.go
+++ b/pkg/podgroupcontroller/controllers/resources/received.go
@@ -29,6 +29,6 @@ func ExtractGPUSharingReceivedResources(ctx context.Context, pod *v1.Pod, kubeCl
 	}
 
 	fractionResource, err := calculateAllocatedFraction(ctx, pod, kubeClient)
-	resources[constants.GpuResource] = fractionResource
+	resources[constants.NvidiaGpuResource] = fractionResource
 	return resources, err
 }

--- a/pkg/podgroupcontroller/controllers/resources/received_test.go
+++ b/pkg/podgroupcontroller/controllers/resources/received_test.go
@@ -67,7 +67,7 @@ func Test_extractReceivedResources(t *testing.T) {
 				},
 				&v1.Node{},
 			},
-			v1.ResourceList{constants.GpuResource: resource.MustParse("0.4")},
+			v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("0.4")},
 			false,
 		},
 	}

--- a/pkg/podgroupcontroller/controllers/resources/requested.go
+++ b/pkg/podgroupcontroller/controllers/resources/requested.go
@@ -52,7 +52,7 @@ func ExtractGPUSharingRequestedResources(pod *v1.Pod) (v1.ResourceList, error) {
 					"Please check resource.Quantity restrictions. fraction <%s>, count: %d",
 					gpuFractionStr, fractionsCount)
 		}
-		resources[v1.ResourceName(constants.GpuResource)] = quantity
+		resources[v1.ResourceName(constants.NvidiaGpuResource)] = quantity
 	}
 
 	gpuMemoryStr, hasAnnotation := pod.Annotations[constants.GpuMemory]

--- a/pkg/podgroupcontroller/controllers/resources/requested_test.go
+++ b/pkg/podgroupcontroller/controllers/resources/requested_test.go
@@ -27,7 +27,7 @@ func Test_extractRequestedResources(t *testing.T) {
 					Annotations: map[string]string{constants.GpuFraction: "0.5"},
 				},
 			},
-			v1.ResourceList{constants.GpuResource: resource.MustParse("0.5")},
+			v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("0.5")},
 		},
 		{
 			"Pod with gpu multi fraction",
@@ -39,7 +39,7 @@ func Test_extractRequestedResources(t *testing.T) {
 					},
 				},
 			},
-			v1.ResourceList{constants.GpuResource: resource.MustParse("1")},
+			v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
 		},
 		{
 			"Pod with gpu memory",

--- a/pkg/scheduler/cache/cluster_info/cluster_info_test.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info_test.go
@@ -173,9 +173,9 @@ func TestSnapshotUsage(t *testing.T) {
 			usage: &queue_info.ClusterUsage{
 				Queues: map[common_info.QueueID]queue_info.QueueUsage{
 					"queue-1": {
-						corev1.ResourceCPU:          10,
-						corev1.ResourceMemory:       10,
-						commonconstants.GpuResource: 10,
+						corev1.ResourceCPU:                10,
+						corev1.ResourceMemory:             10,
+						commonconstants.NvidiaGpuResource: 10,
 					},
 				},
 			},
@@ -183,9 +183,9 @@ func TestSnapshotUsage(t *testing.T) {
 			expectedUsage: &queue_info.ClusterUsage{
 				Queues: map[common_info.QueueID]queue_info.QueueUsage{
 					"queue-1": {
-						corev1.ResourceCPU:          10,
-						corev1.ResourceMemory:       10,
-						commonconstants.GpuResource: 10,
+						corev1.ResourceCPU:                10,
+						corev1.ResourceMemory:             10,
+						commonconstants.NvidiaGpuResource: 10,
 					},
 				},
 			},
@@ -201,9 +201,9 @@ func TestSnapshotUsage(t *testing.T) {
 			usage: &queue_info.ClusterUsage{
 				Queues: map[common_info.QueueID]queue_info.QueueUsage{
 					"queue-1": {
-						corev1.ResourceCPU:          11,
-						corev1.ResourceMemory:       11,
-						commonconstants.GpuResource: 11,
+						corev1.ResourceCPU:                11,
+						corev1.ResourceMemory:             11,
+						commonconstants.NvidiaGpuResource: 11,
 					},
 				},
 			},

--- a/pkg/scheduler/cache/usagedb/prometheus/prometheus.go
+++ b/pkg/scheduler/cache/usagedb/prometheus/prometheus.go
@@ -114,7 +114,7 @@ func (p *PrometheusClient) GetResourceUsage() (*queue_info.ClusterUsage, error) 
 	defer cancel()
 
 	capacity := map[v1.ResourceName]float64{}
-	for _, resource := range []v1.ResourceName{commonconstants.GpuResource, v1.ResourceCPU, v1.ResourceMemory} {
+	for _, resource := range []v1.ResourceName{commonconstants.NvidiaGpuResource, v1.ResourceCPU, v1.ResourceMemory} {
 		resourceCapacity, err := p.queryResourceCapacity(ctx, p.capacityMetricsMap[string(resource)], p.usageWindowQuery)
 		if err != nil {
 			return nil, fmt.Errorf("error querying %s and capacity: %v", resource, err)
@@ -124,7 +124,7 @@ func (p *PrometheusClient) GetResourceUsage() (*queue_info.ClusterUsage, error) 
 
 	usage := queue_info.NewClusterUsage()
 
-	for _, resource := range []v1.ResourceName{commonconstants.GpuResource, v1.ResourceCPU, v1.ResourceMemory} {
+	for _, resource := range []v1.ResourceName{commonconstants.NvidiaGpuResource, v1.ResourceCPU, v1.ResourceMemory} {
 		capacityForResource, found := capacity[resource]
 		if !found {
 			capacityForResource = 1

--- a/pkg/scheduler/cache/usagedb/usagedb_test.go
+++ b/pkg/scheduler/cache/usagedb/usagedb_test.go
@@ -89,14 +89,14 @@ func TestGetResourceUsage(t *testing.T) {
 			name: "fresh data available",
 			setupLister: func(l *UsageLister) {
 				usage := queue_info.NewClusterUsage()
-				usage.Queues["queue1"] = queue_info.QueueUsage{constants.GpuResource: 5}
+				usage.Queues["queue1"] = queue_info.QueueUsage{constants.NvidiaGpuResource: 5}
 				now := time.Now()
 				l.lastUsageData = usage
 				l.lastUsageDataTime = &now
 			},
 			wantUsage: func() *queue_info.ClusterUsage {
 				usage := queue_info.NewClusterUsage()
-				usage.Queues["queue1"] = queue_info.QueueUsage{constants.GpuResource: 5}
+				usage.Queues["queue1"] = queue_info.QueueUsage{constants.NvidiaGpuResource: 5}
 				return usage
 			}(),
 		},

--- a/pkg/scheduler/plugins/proportion/capacity_policy/max_allowed_check_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/max_allowed_check_test.go
@@ -322,9 +322,9 @@ var _ = Describe("Max Allowed Policy Check", func() {
 					expectedResult: false,
 					expectedDetails: &v2alpha2.QuotaDetails{
 						QueueAllocatedResources: v1.ResourceList{
-							v1.ResourceCPU:        *resource.NewMilliQuantity(0, resource.DecimalSI),
-							v1.ResourceMemory:     *resource.NewQuantity(0, resource.DecimalSI),
-							constants.GpuResource: *resource.NewQuantity(0, resource.DecimalSI),
+							v1.ResourceCPU:              *resource.NewMilliQuantity(0, resource.DecimalSI),
+							v1.ResourceMemory:           *resource.NewQuantity(0, resource.DecimalSI),
+							constants.NvidiaGpuResource: *resource.NewQuantity(0, resource.DecimalSI),
 						},
 					},
 				},

--- a/pkg/scheduler/plugins/proportion/resource_share/queue_resource_share.go
+++ b/pkg/scheduler/plugins/proportion/resource_share/queue_resource_share.go
@@ -186,14 +186,14 @@ func (qrs *QueueResourceShare) SetQuotaResources(resource ResourceName, deserved
 
 func (qrs *QueueResourceShare) GetResourceUsage() queue_info.QueueUsage {
 	return queue_info.QueueUsage{
-		commonconstants.GpuResource: qrs.GPU.Usage,
-		v1.ResourceCPU:              qrs.CPU.Usage,
-		v1.ResourceMemory:           qrs.Memory.Usage,
+		commonconstants.NvidiaGpuResource: qrs.GPU.Usage,
+		v1.ResourceCPU:                    qrs.CPU.Usage,
+		v1.ResourceMemory:                 qrs.Memory.Usage,
 	}
 }
 
 func (qrs *QueueResourceShare) SetResourceUsage(usage queue_info.QueueUsage) {
-	qrs.GPU.Usage = usage[commonconstants.GpuResource]
+	qrs.GPU.Usage = usage[commonconstants.NvidiaGpuResource]
 	qrs.CPU.Usage = usage[v1.ResourceCPU]
 	qrs.Memory.Usage = usage[v1.ResourceMemory]
 }

--- a/pkg/scheduler/plugins/topology/topology_plugin_test.go
+++ b/pkg/scheduler/plugins/topology/topology_plugin_test.go
@@ -44,8 +44,8 @@ func TestTopologyPlugin_initializeTopologyTree(t *testing.T) {
 			},
 			Status: v1.NodeStatus{
 				Allocatable: v1.ResourceList{
-					"cpu":                 resource.MustParse("1"),
-					constants.GpuResource: resource.MustParse("1"),
+					"cpu":                       resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			},
 		},
@@ -62,8 +62,8 @@ func TestTopologyPlugin_initializeTopologyTree(t *testing.T) {
 			},
 			Status: v1.NodeStatus{
 				Allocatable: v1.ResourceList{
-					"cpu":                 resource.MustParse("1"),
-					constants.GpuResource: resource.MustParse("1"),
+					"cpu":                       resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			},
 		},
@@ -80,8 +80,8 @@ func TestTopologyPlugin_initializeTopologyTree(t *testing.T) {
 			},
 			Status: v1.NodeStatus{
 				Allocatable: v1.ResourceList{
-					"cpu":                 resource.MustParse("1"),
-					constants.GpuResource: resource.MustParse("3"),
+					"cpu":                       resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("3"),
 				},
 			},
 		},

--- a/test/e2e/modules/resources/capacity/calculator.go
+++ b/test/e2e/modules/resources/capacity/calculator.go
@@ -53,7 +53,7 @@ func GetNodesAllocatableResources(clientset kubernetes.Interface) (map[string]*R
 		perNodeResources[node.Name] = &ResourceList{
 			Cpu:            node.Status.Allocatable.Cpu().DeepCopy(),
 			Memory:         node.Status.Allocatable.Memory().DeepCopy(),
-			Gpu:            node.Status.Allocatable[constants.GpuResource].DeepCopy(),
+			Gpu:            node.Status.Allocatable[constants.NvidiaGpuResource].DeepCopy(),
 			GpuMemory:      calcNodeGpuMemory(node),
 			PodCount:       int(node.Status.Allocatable.Pods().Value()),
 			OtherResources: getOtherResourcesFromResourceList(node.Status.Allocatable),
@@ -113,7 +113,7 @@ func calcNodesResources(podList *corev1.PodList, nodeList *corev1.NodeList) map[
 		perNodeResources[node.Name] = &ResourceList{
 			Cpu:            node.Status.Allocatable.Cpu().DeepCopy(),
 			Memory:         node.Status.Allocatable.Memory().DeepCopy(),
-			Gpu:            node.Status.Allocatable[constants.GpuResource].DeepCopy(),
+			Gpu:            node.Status.Allocatable[constants.NvidiaGpuResource].DeepCopy(),
 			GpuMemory:      calcNodeGpuMemory(node),
 			PodCount:       int(node.Status.Allocatable.Pods().Value()),
 			OtherResources: getOtherResourcesFromResourceList(node.Status.Allocatable),
@@ -132,7 +132,7 @@ func calcNodesResources(podList *corev1.PodList, nodeList *corev1.NodeList) map[
 
 func calcNodeGpuMemory(node corev1.Node) resource.Quantity {
 	var nodeGpusMemory resource.Quantity
-	nodeGpus := node.Status.Allocatable[constants.GpuResource]
+	nodeGpus := node.Status.Allocatable[constants.NvidiaGpuResource]
 	if nodeGpusMemoryStr := node.Labels[constant.NvidiaGPUMemoryLabelName]; nodeGpusMemoryStr != "" {
 		singleGpuMemory, _ := strconv.Atoi(nodeGpusMemoryStr)
 		totalNodeGpuMemory := strconv.Itoa(singleGpuMemory * int(nodeGpus.Value()))
@@ -163,7 +163,7 @@ func ResourcesRequestToList(req corev1.ResourceList, podAnnotations map[string]s
 }
 
 func calcPodGpus(podAnnotations map[string]string, req corev1.ResourceList) resource.Quantity {
-	gpuReq := req[constants.GpuResource].DeepCopy()
+	gpuReq := req[constants.NvidiaGpuResource].DeepCopy()
 
 	if fractionalGpuStr := podAnnotations[constants.GpuFraction]; fractionalGpuStr != "" {
 		fractionalGpu := resource.MustParse(fractionalGpuStr)
@@ -187,7 +187,7 @@ func getOtherResourcesFromResourceList(list corev1.ResourceList) map[corev1.Reso
 		if key == corev1.ResourceCPU ||
 			key == corev1.ResourceMemory ||
 			key == corev1.ResourcePods ||
-			key == constants.GpuResource {
+			key == constants.NvidiaGpuResource {
 			continue
 		}
 		otherResources[key] = value

--- a/test/e2e/modules/resources/rd/node.go
+++ b/test/e2e/modules/resources/rd/node.go
@@ -84,7 +84,7 @@ func FindNodeWithNoGPU(ctx context.Context, client runtimeClient.Client, kubeCli
 		if len(node.Spec.Taints) > 0 {
 			continue
 		}
-		gpuResource := node.Status.Capacity[constants.GpuResource]
+		gpuResource := node.Status.Capacity[constants.NvidiaGpuResource]
 		hasDevicePluginGPUs := gpuResource.CmpInt64(0) > 0
 		hasDRAGPUs := draDevicesByNode[node.Name] > 0
 		if !hasDevicePluginGPUs && !hasDRAGPUs {
@@ -98,7 +98,7 @@ func FindNodeWithEnoughGPUs(ctx context.Context, client runtimeClient.Client, nu
 	allNodes := corev1.NodeList{}
 	Expect(client.List(ctx, &allNodes)).To(Succeed())
 	for _, node := range allNodes.Items {
-		gpusQty, found := node.Status.Allocatable[constants.GpuResource]
+		gpusQty, found := node.Status.Allocatable[constants.NvidiaGpuResource]
 		if !found {
 			continue
 		}
@@ -115,7 +115,7 @@ func FindNodesWithEnoughGPUs(ctx context.Context, client runtimeClient.Client, n
 	var gpuNodes []*corev1.Node
 	Expect(client.List(ctx, &allNodes)).To(Succeed())
 	for index, node := range allNodes.Items {
-		gpusQty, found := node.Status.Allocatable[constants.GpuResource]
+		gpusQty, found := node.Status.Allocatable[constants.NvidiaGpuResource]
 		if !found || gpusQty.IsZero() {
 			continue
 		}
@@ -132,7 +132,7 @@ func FindNodesWithExactGPUs(ctx context.Context, client runtimeClient.Client, nu
 	var gpuNodes []*corev1.Node
 	Expect(client.List(ctx, &allNodes)).To(Succeed())
 	for index, node := range allNodes.Items {
-		gpusQty, found := node.Status.Allocatable[constants.GpuResource]
+		gpusQty, found := node.Status.Allocatable[constants.NvidiaGpuResource]
 		if !found || gpusQty.IsZero() {
 			continue
 		}

--- a/test/e2e/modules/resources/rd/topology.go
+++ b/test/e2e/modules/resources/rd/topology.go
@@ -80,7 +80,7 @@ func CreateRackZoneTopology(
 
 	gpuNodesMap := map[int][]string{}
 	for _, node := range nodes.Items {
-		gpuCountQuantity := node.Status.Allocatable[v1.ResourceName(constants.GpuResource)]
+		gpuCountQuantity := node.Status.Allocatable[v1.ResourceName(constants.NvidiaGpuResource)]
 		gpuCount := int(gpuCountQuantity.Value())
 		if gpuCount == 0 {
 			continue // skip nodes without GPUs

--- a/test/e2e/scale/kwok_test.go
+++ b/test/e2e/scale/kwok_test.go
@@ -390,7 +390,7 @@ var _ = Describe("Kwok scale test", Ordered, Label(labels.Scale), func() {
 										ctx, testCtx, queue,
 										v1.ResourceRequirements{
 											Limits: map[v1.ResourceName]resource.Quantity{
-												constants.GpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
+												constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
 											},
 										}, defaultPodsPerDistributedJob,
 										map[string]string{}, nil,

--- a/test/e2e/scale/kwok_test_functions.go
+++ b/test/e2e/scale/kwok_test_functions.go
@@ -50,12 +50,12 @@ const (
 var (
 	SingleGPURequirement = v1.ResourceRequirements{
 		Limits: map[v1.ResourceName]resource.Quantity{
-			constants.GpuResource: *resource.NewQuantity(1, resource.DecimalSI),
+			constants.NvidiaGpuResource: *resource.NewQuantity(1, resource.DecimalSI),
 		},
 	}
 	FullNodeGPURequirement = v1.ResourceRequirements{
 		Limits: map[v1.ResourceName]resource.Quantity{
-			constants.GpuResource: *resource.NewQuantity(gpusPerNode, resource.DecimalSI),
+			constants.NvidiaGpuResource: *resource.NewQuantity(gpusPerNode, resource.DecimalSI),
 		},
 	}
 )
@@ -95,7 +95,7 @@ func fillClusterWithJobs(
 	}
 
 	GinkgoLogr.Info("Creating pods")
-	gpuQuantity := resourceRequirements.Limits[constants.GpuResource]
+	gpuQuantity := resourceRequirements.Limits[constants.NvidiaGpuResource]
 	gpusPerJob := int(gpuQuantity.Value())
 	totalNumberOfJobs = (numberOfNodes * gpusPerNode) / gpusPerJob
 
@@ -158,7 +158,7 @@ func distributedJobsScaleTestInternal(
 				ctx, testCtx, testQueue,
 				v1.ResourceRequirements{
 					Limits: map[v1.ResourceName]resource.Quantity{
-						constants.GpuResource: *resource.NewQuantity(int64(gpuPerPod), resource.DecimalSI),
+						constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpuPerPod), resource.DecimalSI),
 					},
 				}, podsPerDistributedJob,
 				map[string]string{}, topologyConstraint,
@@ -271,7 +271,7 @@ func reclaimForOneLargeJob(ctx context.Context, testCtx *testcontext.TestContext
 		ctx, testCtx, reclaimSingleGPUJobsQueue,
 		v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
+				constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
 			},
 		},
 		numberOfPods, map[string]string{},

--- a/test/e2e/suites/allocate/node_order/placement_strategy_test.go
+++ b/test/e2e/suites/allocate/node_order/placement_strategy_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Placement strategy", Label(labels.Operated), Ordered, func() {
 		It("Schedule on same node", func(ctx context.Context) {
 			pod1 := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			pod1, err := rd.CreatePod(ctx, testCtx.KubeClientset, pod1)
@@ -88,7 +88,7 @@ var _ = Describe("Placement strategy", Label(labels.Operated), Ordered, func() {
 
 			pod2 := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			pod2, err = rd.CreatePod(ctx, testCtx.KubeClientset, pod2)
@@ -153,7 +153,7 @@ var _ = Describe("Placement strategy", Label(labels.Operated), Ordered, func() {
 		It("Schedule on different nodes", func(ctx context.Context) {
 			pod1 := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			pod1, err := rd.CreatePod(ctx, testCtx.KubeClientset, pod1)
@@ -161,7 +161,7 @@ var _ = Describe("Placement strategy", Label(labels.Operated), Ordered, func() {
 
 			pod2 := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			pod2, err = rd.CreatePod(ctx, testCtx.KubeClientset, pod2)

--- a/test/e2e/suites/allocate/node_order/resource_type_test.go
+++ b/test/e2e/suites/allocate/node_order/resource_type_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Resource Type Plugins", Ordered, func() {
 })
 
 func isCPUOnlyNode(node *v1.Node, clientset kubernetes.Interface) bool {
-	gpus, found := node.Status.Capacity[constants.GpuResource]
+	gpus, found := node.Status.Capacity[constants.NvidiaGpuResource]
 	hasDevicePluginGPUs := found && gpus.CmpInt64(0) > 0
 	if hasDevicePluginGPUs {
 		return false

--- a/test/e2e/suites/allocate/predicates/affinity_test.go
+++ b/test/e2e/suites/allocate/predicates/affinity_test.go
@@ -139,7 +139,7 @@ func submitPod(
 ) *v1.Pod {
 	requirements := v1.ResourceRequirements{
 		Limits: map[v1.ResourceName]resource.Quantity{
-			constants.GpuResource: resource.MustParse("1"),
+			constants.NvidiaGpuResource: resource.MustParse("1"),
 		},
 	}
 	pod := rd.CreatePodObject(queue, requirements)

--- a/test/e2e/suites/allocate/predicates/restrict_node_scheduling_test.go
+++ b/test/e2e/suites/allocate/predicates/restrict_node_scheduling_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Restrict node scheduling", Label(labels.Operated), Ordered, fu
 		It("Scheduling GPU pod", func(ctx context.Context) {
 			gpuPod := rd.CreatePodObject(testCtx.Queues[0], corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 
@@ -163,7 +163,7 @@ var _ = Describe("Restrict node scheduling", Label(labels.Operated), Ordered, fu
 
 			gpuPod := rd.CreatePodObject(testCtx.Queues[0], corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 

--- a/test/e2e/suites/allocate/priority/order_test.go
+++ b/test/e2e/suites/allocate/priority/order_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Order jobs allocation queue", Label(labels.Operated), Ordered,
 		configurations.DisableScheduler(ctx, testCtx)
 		lowPriorityPod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		lowPriorityPod.Name = "low-priority-pod"
@@ -88,7 +88,7 @@ var _ = Describe("Order jobs allocation queue", Label(labels.Operated), Ordered,
 
 		highPriorityPod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		highPriorityPod.Name = "high-priority-pod"
@@ -108,7 +108,7 @@ var _ = Describe("Order jobs allocation queue", Label(labels.Operated), Ordered,
 		configurations.DisableScheduler(ctx, testCtx)
 		lowPriorityPod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		lowPriorityPod.Name = "low-priority-pod"
@@ -118,7 +118,7 @@ var _ = Describe("Order jobs allocation queue", Label(labels.Operated), Ordered,
 
 		highPriorityPod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		highPriorityPod.Name = "high-priority-pod"

--- a/test/e2e/suites/allocate/quota/exceed_limit_test.go
+++ b/test/e2e/suites/allocate/quota/exceed_limit_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Limit quota", func() {
 
 		pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 

--- a/test/e2e/suites/allocate/quota/over_quota_test.go
+++ b/test/e2e/suites/allocate/quota/over_quota_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Over quota", func() {
 
 		pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		pod.Spec.PriorityClassName = nonPreemptiblePriorityClass

--- a/test/e2e/suites/allocate/quota/quota_test.go
+++ b/test/e2e/suites/allocate/quota/quota_test.go
@@ -119,7 +119,7 @@ func createPodForEachQueue(ctx context.Context, testCtx *testcontext.TestContext
 	for queueIndex := 1; queueIndex <= numOfSharingQueues; queueIndex++ {
 		pod := rd.CreatePodObject(testCtx.Queues[queueIndex], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		pod.Labels["singletest"] = testPodsIdentifiyingLabel

--- a/test/e2e/suites/allocate/resources/resources_test.go
+++ b/test/e2e/suites/allocate/resources/resources_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Schedule pod with resource request", Ordered, func() {
 		It("Whole GPU request", func(ctx context.Context) {
 			pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 

--- a/test/e2e/suites/allocate/topology/topology_test.go
+++ b/test/e2e/suites/allocate/topology/topology_test.go
@@ -82,9 +82,9 @@ var _ = Describe("Topology", Ordered, func() {
 			}
 
 			gpusPerNode := testTopologyData.TopologyNodes[gpuNodesNames[0]].
-				Status.Allocatable[v1.ResourceName(constants.GpuResource)]
+				Status.Allocatable[v1.ResourceName(constants.NvidiaGpuResource)]
 			podResource := v1.ResourceList{
-				v1.ResourceName(constants.GpuResource): gpusPerNode,
+				v1.ResourceName(constants.NvidiaGpuResource): gpusPerNode,
 			}
 
 			pods := createDistributedWorkload(ctx, testCtx, 2, podResource, topologyConstraint)
@@ -111,9 +111,9 @@ var _ = Describe("Topology", Ordered, func() {
 			}
 
 			gpusPerNode := testTopologyData.TopologyNodes[gpuNodesNames[0]].
-				Status.Allocatable[v1.ResourceName(constants.GpuResource)]
+				Status.Allocatable[v1.ResourceName(constants.NvidiaGpuResource)]
 			podResource := v1.ResourceList{
-				v1.ResourceName(constants.GpuResource): gpusPerNode,
+				v1.ResourceName(constants.NvidiaGpuResource): gpusPerNode,
 			}
 
 			pods := createDistributedWorkload(ctx, testCtx, 2, podResource, topologyConstraint)
@@ -141,10 +141,10 @@ var _ = Describe("Topology", Ordered, func() {
 			}
 
 			gpusPerNode := testTopologyData.TopologyNodes[gpuNodesNames[0]].
-				Status.Allocatable[v1.ResourceName(constants.GpuResource)]
+				Status.Allocatable[v1.ResourceName(constants.NvidiaGpuResource)]
 			halfGpusPerNode := int64(gpusPerNode.AsFloat64Slow() / 2)
 			podResource := v1.ResourceList{
-				v1.ResourceName(constants.GpuResource): *resource.NewQuantity(halfGpusPerNode, resource.DecimalSI),
+				v1.ResourceName(constants.NvidiaGpuResource): *resource.NewQuantity(halfGpusPerNode, resource.DecimalSI),
 			}
 
 			pods := createDistributedWorkload(ctx, testCtx, 2, podResource, topologyConstraint)
@@ -171,9 +171,9 @@ var _ = Describe("Topology", Ordered, func() {
 			}
 
 			gpusPerNode := testTopologyData.TopologyNodes[gpuNodesNames[0]].
-				Status.Allocatable[v1.ResourceName(constants.GpuResource)]
+				Status.Allocatable[v1.ResourceName(constants.NvidiaGpuResource)]
 			podResource := v1.ResourceList{
-				v1.ResourceName(constants.GpuResource): gpusPerNode,
+				v1.ResourceName(constants.NvidiaGpuResource): gpusPerNode,
 			}
 
 			pods := createDistributedWorkload(ctx, testCtx, 2, podResource, topologyConstraint)
@@ -224,9 +224,9 @@ var _ = Describe("Topology", Ordered, func() {
 			}
 
 			gpusPerNode := testTopologyData.TopologyNodes[gpuNodesNames[0]].
-				Status.Allocatable[v1.ResourceName(constants.GpuResource)]
+				Status.Allocatable[v1.ResourceName(constants.NvidiaGpuResource)]
 			podResource := v1.ResourceList{
-				v1.ResourceName(constants.GpuResource): gpusPerNode,
+				v1.ResourceName(constants.NvidiaGpuResource): gpusPerNode,
 			}
 
 			pods := createDistributedWorkload(ctx, testCtx, 4, podResource, topologyConstraint)

--- a/test/e2e/suites/api/crds/podgroup/conditions_test.go
+++ b/test/e2e/suites/api/crds/podgroup/conditions_test.go
@@ -73,7 +73,7 @@ var _ = Describe("PodGroup Conditions", Ordered, func() {
 		It("sets condition with NonPreemptibleOverQuota reason on PodGroup", func(ctx context.Context) {
 			pod := rd.CreatePodObject(testQueue, v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			pod.Spec.PriorityClassName = nonPreemptiblePriorityClass
@@ -100,7 +100,7 @@ var _ = Describe("PodGroup Conditions", Ordered, func() {
 			It("sets condition with reason on PodGroup", func(ctx context.Context) {
 				pod := rd.CreatePodObject(testQueue, v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						constants.GpuResource: resource.MustParse("1"),
+						constants.NvidiaGpuResource: resource.MustParse("1"),
 					},
 				})
 				createdPod, err := rd.CreatePod(ctx, testCtx.KubeClientset, pod)
@@ -114,7 +114,7 @@ var _ = Describe("PodGroup Conditions", Ordered, func() {
 			It("sets condition with reason on PodGroup", func(ctx context.Context) {
 				pod := rd.CreatePodObject(testQueue, v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						constants.GpuResource: resource.MustParse("1"),
+						constants.NvidiaGpuResource: resource.MustParse("1"),
 					},
 				})
 				createdPod, err := rd.CreatePod(ctx, testCtx.KubeClientset, pod)

--- a/test/e2e/suites/consolidation/consolidation_test.go
+++ b/test/e2e/suites/consolidation/consolidation_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Consolidation", Ordered, func() {
 		testQueue := testCtx.Queues[0]
 		requirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 
@@ -121,7 +121,7 @@ var _ = Describe("Consolidation", Ordered, func() {
 		gpuQuantity := resource.NewQuantity(numReleasedGPUs, resource.DecimalSI)
 		testedPod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: *gpuQuantity,
+				constants.NvidiaGpuResource: *gpuQuantity,
 			},
 		})
 		testedPod, err = rd.CreatePod(ctx, testCtx.KubeClientset, testedPod)
@@ -198,7 +198,7 @@ var _ = Describe("Consolidation", Ordered, func() {
 		// schedule new pod requiring full GPU
 		testedPod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		})
 		testedPod.Name = "consolidator-pod"

--- a/test/e2e/suites/integrations/third_party/kubeflow.org/jax/jax_test.go
+++ b/test/e2e/suites/integrations/third_party/kubeflow.org/jax/jax_test.go
@@ -65,10 +65,10 @@ var _ = Describe("JAX integration", Ordered, func() {
 	It("should run the pods of the Jax", func(ctx context.Context) {
 		singleGPURequest := v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 			Requests: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 

--- a/test/e2e/suites/integrations/third_party/kubeflow.org/tfjob/tfjob_test.go
+++ b/test/e2e/suites/integrations/third_party/kubeflow.org/tfjob/tfjob_test.go
@@ -67,10 +67,10 @@ var _ = Describe("TFJob integration", Ordered, func() {
 	It("should run the pods of the TFJob", func(ctx context.Context) {
 		singleGPURequest := v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 			Requests: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 

--- a/test/e2e/suites/integrations/third_party/kubeflow.org/xgboost/xgboost_test.go
+++ b/test/e2e/suites/integrations/third_party/kubeflow.org/xgboost/xgboost_test.go
@@ -66,10 +66,10 @@ var _ = Describe("XGBoost integration", Ordered, func() {
 	It("should run the pods of the XGBoost", func(ctx context.Context) {
 		singleGPURequest := v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 			Requests: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 

--- a/test/e2e/suites/integrations/third_party/leader_worker_set/leader_worker_set_test.go
+++ b/test/e2e/suites/integrations/third_party/leader_worker_set/leader_worker_set_test.go
@@ -58,10 +58,10 @@ var _ = Describe("Leader worker set Integration", Ordered, func() {
 	It("Leader worker set - 2 groups", func(ctx context.Context) {
 		singleGPURequest := v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 			Requests: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		numOfGroups := 2
@@ -101,10 +101,10 @@ var _ = Describe("Leader worker set Integration", Ordered, func() {
 	It("Leader worker set - handle leader ready before workers startup policy", func(ctx context.Context) {
 		singleGPURequest := v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 			Requests: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		numOfGroups := 2

--- a/test/e2e/suites/integrations/third_party/ray.io/ray_test.go
+++ b/test/e2e/suites/integrations/third_party/ray.io/ray_test.go
@@ -134,10 +134,10 @@ var _ = Describe("Ray integration", Ordered, func() {
 			workerGroupB.MaxReplicas = ptr.To(int32(5))
 			workerGroupB.Template.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Requests: v1.ResourceList{
-					constants.GpuResource: resource.MustParse("99"),
+					constants.NvidiaGpuResource: resource.MustParse("99"),
 				},
 				Limits: v1.ResourceList{
-					constants.GpuResource: resource.MustParse("99"),
+					constants.NvidiaGpuResource: resource.MustParse("99"),
 				},
 			}
 

--- a/test/e2e/suites/preempt/preempt_distributed_test.go
+++ b/test/e2e/suites/preempt/preempt_distributed_test.go
@@ -73,10 +73,10 @@ var _ = Describe("preempt Distributed Jobs", Ordered, func() {
 
 			resources := v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 				Requests: v1.ResourceList{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			}
 
@@ -94,8 +94,8 @@ var _ = Describe("preempt Distributed Jobs", Ordered, func() {
 
 			preemptorGpu := gpusPerNode
 			preemptorResources := resources.DeepCopy()
-			preemptorResources.Requests[constants.GpuResource] = resource.MustParse(fmt.Sprintf("%d", preemptorGpu))
-			preemptorResources.Limits[constants.GpuResource] = resource.MustParse(fmt.Sprintf("%d", preemptorGpu))
+			preemptorResources.Requests[constants.NvidiaGpuResource] = resource.MustParse(fmt.Sprintf("%d", preemptorGpu))
+			preemptorResources.Limits[constants.NvidiaGpuResource] = resource.MustParse(fmt.Sprintf("%d", preemptorGpu))
 
 			_, pods := pod_group.CreateDistributedJob(
 				ctx, testCtx.KubeClientset, testCtx.ControllerClient,

--- a/test/e2e/suites/preempt/preempt_elastic_test.go
+++ b/test/e2e/suites/preempt/preempt_elastic_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Priority Preemption with Elastic Jobs", Ordered, func() {
 
 		lowPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 
@@ -93,7 +93,7 @@ var _ = Describe("Priority Preemption with Elastic Jobs", Ordered, func() {
 		// higher priority pod
 		highPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("2"),
+				constants.NvidiaGpuResource: resource.MustParse("2"),
 			},
 		}
 
@@ -132,7 +132,7 @@ var _ = Describe("Priority Preemption with Elastic Jobs", Ordered, func() {
 
 		lowPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 
@@ -145,7 +145,7 @@ var _ = Describe("Priority Preemption with Elastic Jobs", Ordered, func() {
 		// higher priority pod
 		highPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("2"),
+				constants.NvidiaGpuResource: resource.MustParse("2"),
 			},
 		}
 

--- a/test/e2e/suites/preempt/preempt_pod_order_test.go
+++ b/test/e2e/suites/preempt/preempt_pod_order_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Priority pod order preemption with Elastic Jobs", Ordered, fun
 		for i := 0; i < podForPodGroupNum; i++ {
 			pod := rd.CreatePodWithPodGroupReference(testQueue, pgName, v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			})
 			pod.Labels[rd.PodGroupLabelName] = pgName
@@ -97,7 +97,7 @@ var _ = Describe("Priority pod order preemption with Elastic Jobs", Ordered, fun
 		// higher priority pod
 		highPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("2"),
+				constants.NvidiaGpuResource: resource.MustParse("2"),
 			},
 		}
 

--- a/test/e2e/suites/reclaim/helpers.go
+++ b/test/e2e/suites/reclaim/helpers.go
@@ -24,7 +24,7 @@ func CreatePod(ctx context.Context, testCtx *testcontext.TestContext, q *v2.Queu
 	pod := rd.CreatePodObject(q, v1.ResourceRequirements{})
 	if gpus >= 1 {
 		pod.Spec.Containers[0].Resources.Limits = map[v1.ResourceName]resource.Quantity{
-			constants.GpuResource: resource.MustParse(fmt.Sprintf("%f", gpus)),
+			constants.NvidiaGpuResource: resource.MustParse(fmt.Sprintf("%f", gpus)),
 		}
 	} else if gpus > 0 {
 		pod.Annotations = map[string]string{

--- a/test/e2e/suites/reclaim/hierarchy_level_fairness_specs.go
+++ b/test/e2e/suites/reclaim/hierarchy_level_fairness_specs.go
@@ -129,10 +129,10 @@ func DescribeHierarchyLevelFairnessSpecs() bool {
 			It("reclaim after changing hierarchy level fairness type", func(ctx context.Context) {
 				resources := v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						constants.GpuResource: resource.MustParse("1"),
+						constants.NvidiaGpuResource: resource.MustParse("1"),
 					},
 					Requests: v1.ResourceList{
-						constants.GpuResource: resource.MustParse("1"),
+						constants.NvidiaGpuResource: resource.MustParse("1"),
 					},
 				}
 

--- a/test/e2e/suites/reclaim/reclaim_distributed_specs.go
+++ b/test/e2e/suites/reclaim/reclaim_distributed_specs.go
@@ -72,10 +72,10 @@ func DescribeReclaimDistributedSpecs() bool {
 
 				resources := v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						constants.GpuResource: resource.MustParse("1"),
+						constants.NvidiaGpuResource: resource.MustParse("1"),
 					},
 					Requests: v1.ResourceList{
-						constants.GpuResource: resource.MustParse("1"),
+						constants.NvidiaGpuResource: resource.MustParse("1"),
 					},
 				}
 
@@ -93,8 +93,8 @@ func DescribeReclaimDistributedSpecs() bool {
 
 				reclaimerGPUs := gpusPerNode
 				reclaimerResources := resources.DeepCopy()
-				reclaimerResources.Requests[constants.GpuResource] = resource.MustParse(fmt.Sprintf("%d", reclaimerGPUs))
-				reclaimerResources.Limits[constants.GpuResource] = resource.MustParse(fmt.Sprintf("%d", reclaimerGPUs))
+				reclaimerResources.Requests[constants.NvidiaGpuResource] = resource.MustParse(fmt.Sprintf("%d", reclaimerGPUs))
+				reclaimerResources.Limits[constants.NvidiaGpuResource] = resource.MustParse(fmt.Sprintf("%d", reclaimerGPUs))
 
 				_, pods := pod_group.CreateDistributedJob(
 					ctx, testCtx.KubeClientset, testCtx.ControllerClient,

--- a/test/e2e/suites/reclaim/reclaim_elastic_specs.go
+++ b/test/e2e/suites/reclaim/reclaim_elastic_specs.go
@@ -59,7 +59,7 @@ func DescribeReclaimElasticSpecs() bool {
 
 			reclaimeePodRequirements := v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			}
 
@@ -78,7 +78,7 @@ func DescribeReclaimElasticSpecs() bool {
 
 			reclaimerPodRequirements := v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("2"),
+					constants.NvidiaGpuResource: resource.MustParse("2"),
 				},
 			}
 
@@ -113,7 +113,7 @@ func DescribeReclaimElasticSpecs() bool {
 
 			reclaimeePodRequirements := v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("1"),
+					constants.NvidiaGpuResource: resource.MustParse("1"),
 				},
 			}
 			reclaimeePodGroup, reclaimeePods := pod_group.CreateWithPods(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
@@ -123,7 +123,7 @@ func DescribeReclaimElasticSpecs() bool {
 
 			reclaimerPodRequirements := v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
-					constants.GpuResource: resource.MustParse("2"),
+					constants.NvidiaGpuResource: resource.MustParse("2"),
 				},
 			}
 			reclaimerPod := rd.CreatePodObject(reclaimerQueue, reclaimerPodRequirements)

--- a/test/e2e/suites/reclaim/reclaim_elastic_test.go
+++ b/test/e2e/suites/reclaim/reclaim_elastic_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimeePodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		reclaimeePodGroup, reclaimeePods := pod_group.CreateWithPods(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
@@ -69,7 +69,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimerPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		_, reclaimerPods := pod_group.CreateDistributedJob(
@@ -97,7 +97,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimeePodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		reclaimeePodGroup, reclaimeePods := pod_group.CreateWithPods(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
@@ -109,7 +109,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimerPodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		_, reclaimerPods := pod_group.CreateDistributedJob(
@@ -138,7 +138,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimeePodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		reclaimeePodGroup, reclaimeePods := pod_group.CreateWithPods(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
@@ -148,7 +148,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimer1PodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		_, reclaimer1Pods := pod_group.CreatePrefixedDistributedJob(
@@ -168,7 +168,7 @@ var _ = Describe("Reclaim with Elastic Jobs", Ordered, func() {
 
 		reclaimer2PodRequirements := v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		_, reclaimer2Pods := pod_group.CreatePrefixedDistributedJob(

--- a/test/e2e/suites/reclaim/reclaim_specs.go
+++ b/test/e2e/suites/reclaim/reclaim_specs.go
@@ -203,7 +203,7 @@ func DescribeReclaimSpecs() bool {
 				for range 10 {
 					job := rd.CreateBatchJobObject(reclaimee1Queue, v1.ResourceRequirements{
 						Limits: map[v1.ResourceName]resource.Quantity{
-							constants.GpuResource: resource.MustParse("1"),
+							constants.NvidiaGpuResource: resource.MustParse("1"),
 						},
 					})
 					err := testCtx.ControllerClient.Create(ctx, job)
@@ -213,7 +213,7 @@ func DescribeReclaimSpecs() bool {
 				for range 10 {
 					job := rd.CreateBatchJobObject(reclaimee2Queue, v1.ResourceRequirements{
 						Limits: map[v1.ResourceName]resource.Quantity{
-							constants.GpuResource: resource.MustParse("1"),
+							constants.NvidiaGpuResource: resource.MustParse("1"),
 						},
 					})
 					err := testCtx.ControllerClient.Create(ctx, job)
@@ -237,7 +237,7 @@ func DescribeReclaimSpecs() bool {
 
 				reclaimerPod := rd.CreatePodObject(reclaimerQueue, v1.ResourceRequirements{
 					Limits: map[v1.ResourceName]resource.Quantity{
-						constants.GpuResource: resource.MustParse("3"),
+						constants.NvidiaGpuResource: resource.MustParse("3"),
 					},
 				})
 				reclaimerPod, err = rd.CreatePod(ctx, testCtx.KubeClientset, reclaimerPod)

--- a/test/e2e/suites/timeaware/timeaware_test.go
+++ b/test/e2e/suites/timeaware/timeaware_test.go
@@ -73,10 +73,10 @@ var _ = Describe("Time Aware Fairness", Label("timeaware", "nightly"), Ordered, 
 
 		resources := v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 			Limits: v1.ResourceList{
-				constants.GpuResource: resource.MustParse("1"),
+				constants.NvidiaGpuResource: resource.MustParse("1"),
 			},
 		}
 		_, queueAPods := pod_group.CreateWithPods(
@@ -97,7 +97,7 @@ var _ = Describe("Time Aware Fairness", Label("timeaware", "nightly"), Ordered, 
 		Eventually(func(g Gomega) {
 			updatedQueue, qErr := testCtx.KubeAiSchedClientset.SchedulingV2().Queues("").Get(ctx, queueA.Name, metav1.GetOptions{})
 			g.Expect(qErr).NotTo(HaveOccurred())
-			allocated := updatedQueue.Status.Allocated[constants.GpuResource]
+			allocated := updatedQueue.Status.Allocated[constants.NvidiaGpuResource]
 			g.Expect(allocated.Value()).To(BeNumerically(">=", idleGPUs), "Expected Queue status allocated GPUs to reach full cluster usage")
 		}, prometheusUsageTimeout, 5*time.Second).Should(Succeed())
 


### PR DESCRIPTION
## Description

rename `GpuResource` constant with value `nvidia.com/gpu` to `NvidiaGpuResource` and add a new constant `GpuResource` with the value `gpu`

## Related Issues

Fixes #

## Checklist


- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes


## Additional Notes

