### PR TITLE
perf(scheduler): use index-based lookup for victim job dedup in preemption solver

### DIFF
--- a/pkg/scheduler/actions/benchmark_test.go
+++ b/pkg/scheduler/actions/benchmark_test.go
@@ -66,6 +66,11 @@ func BenchmarkReclaimAction_MediumCluster(b *testing.B) {
 	benchmarkReclaim(b, 50, 200)
 }
 
+// BenchmarkReclaimAction_LargeCluster benchmarks reclaim with 200 nodes, 1000 jobs
+func BenchmarkReclaimAction_LargeCluster(b *testing.B) {
+	benchmarkReclaim(b, 200, 1000)
+}
+
 func benchmarkReclaim(b *testing.B, numNodes, numJobs int) {
 	ctrl := gomock.NewController(b)
 	defer ctrl.Finish()
@@ -88,6 +93,11 @@ func BenchmarkPreemptAction_SmallCluster(b *testing.B) {
 // BenchmarkPreemptAction_MediumCluster benchmarks preempt with 50 nodes, 200 jobs
 func BenchmarkPreemptAction_MediumCluster(b *testing.B) {
 	benchmarkPreempt(b, 50, 200)
+}
+
+// BenchmarkPreemptAction_LargeCluster benchmarks preempt with 200 nodes, 1000 jobs
+func BenchmarkPreemptAction_LargeCluster(b *testing.B) {
+	benchmarkPreempt(b, 200, 1000)
 }
 
 func benchmarkPreempt(b *testing.B, numNodes, numJobs int) {

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -252,25 +252,14 @@ func getVictimJobsFromVictimTasks(
 func extractJobsFromTasks(
 	tasks []*pod_info.PodInfo, scenario *scenario.ByNodeScenario) map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo {
 	jobs := map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo{}
+	seenJobRepresentatives := map[*podgroup_info.PodGroupInfo]bool{}
 	for _, task := range tasks {
-		jobAlreadyExists := false
-		if possibleDuplicates, ok := jobs[task.Job]; ok {
-			for _, possibleDuplicate := range possibleDuplicates {
-				for _, podInfo := range possibleDuplicate.GetAllPodsMap() {
-					if podInfo.UID == task.UID {
-						jobAlreadyExists = true
-						break
-					}
-				}
-				if jobAlreadyExists {
-					break
-				}
-			}
+		matchingJob := scenario.GetVictimJobRepresentativeById(task)
+		if seenJobRepresentatives[matchingJob] {
+			continue
 		}
-		if !jobAlreadyExists {
-			matchingJob := scenario.GetVictimJobRepresentativeById(task)
-			jobs[matchingJob.UID] = append(jobs[matchingJob.UID], matchingJob)
-		}
+		seenJobRepresentatives[matchingJob] = true
+		jobs[matchingJob.UID] = append(jobs[matchingJob.UID], matchingJob)
 	}
 	return jobs
 }

--- a/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api"
@@ -264,6 +265,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 					ClusterInfo: &api.ClusterInfo{PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
 						"pg1": podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID("uid-name1"),
 								Name:      "name1",
 								Namespace: "n1",
 								Annotations: map[string]string{
@@ -274,6 +276,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 						})),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID("uid-name2"),
 								Name:      "name2",
 								Namespace: "n1",
 								Annotations: map[string]string{
@@ -288,6 +291,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				potentialVictimsTasks: []*pod_info.PodInfo{
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name1"),
 							Name:      "name1",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -300,6 +304,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name2"),
 							Name:      "name2",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -313,6 +318,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 			args: args{
 				victimPodInfo: pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("uid-name1"),
 						Name:      "name1",
 						Namespace: "n1",
 						Annotations: map[string]string{
@@ -325,6 +331,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 			},
 			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					UID:       types.UID("uid-name1"),
 					Name:      "name1",
 					Namespace: "n1",
 					Annotations: map[string]string{
@@ -341,6 +348,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 					ClusterInfo: &api.ClusterInfo{PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
 						"pg1": podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID("uid-name1"),
 								Name:      "name1",
 								Namespace: "n1",
 								Annotations: map[string]string{
@@ -351,6 +359,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 						})),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID("uid-name2"),
 								Name:      "name2",
 								Namespace: "n1",
 								Annotations: map[string]string{
@@ -365,6 +374,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				potentialVictimsTasks: []*pod_info.PodInfo{
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name1"),
 							Name:      "name1",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -377,6 +387,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name2"),
 							Name:      "name2",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -390,6 +401,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 			args: args{
 				victimPodInfo: pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("uid-name3"),
 						Name:      "name3",
 						Namespace: "n1",
 						Annotations: map[string]string{
@@ -409,6 +421,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 					ClusterInfo: &api.ClusterInfo{PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
 						"pg1": podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID("uid-name1"),
 								Name:      "name1",
 								Namespace: "n1",
 								Annotations: map[string]string{
@@ -419,6 +432,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 						})),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID("uid-name2"),
 								Name:      "name2",
 								Namespace: "n1",
 								Annotations: map[string]string{
@@ -433,6 +447,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				potentialVictimsTasks: []*pod_info.PodInfo{
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name1"),
 							Name:      "name1",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -445,6 +460,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name2"),
 							Name:      "name2",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -458,6 +474,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 			args: args{
 				victimPodInfo: pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("uid-name1"),
 						Name:      "name1",
 						Namespace: "n1",
 						Annotations: map[string]string{
@@ -469,6 +486,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				tasks: []*pod_info.PodInfo{
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
+							UID:       types.UID("uid-name1.2"),
 							Name:      "name1.2",
 							Namespace: "n1",
 							Annotations: map[string]string{
@@ -481,6 +499,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 			},
 			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					UID:       types.UID("uid-name1"),
 					Name:      "name1",
 					Namespace: "n1",
 					Annotations: map[string]string{


### PR DESCRIPTION
## Description

Replace O(V*J*P) triple-nested loop in `extractJobsFromTasks` and O(J*P) linear scan in `GetVictimJobRepresentativeById` with O(1) map-based lookups, improving preemption/reclaim scalability for large clusters.

### Changes

1. **`by_pod_solver.go` - `extractJobsFromTasks`**: Replaced triple-nested loop (iterate tasks → iterate existing job representatives → iterate pods in each representative) with a `map[*PodGroupInfo]bool` set tracking seen job representatives. Reduces dedup from O(V*J*P) to O(V).

2. **`base_scenario.go` - `GetVictimJobRepresentativeById`**: Added `taskToJobRepresentative` index (`map[PodID]*PodGroupInfo`) to `BaseScenario`, populated during `appendTasksAsVictimJob`. Reduces per-call lookup from O(J*P) to O(1).

3. **`benchmark_test.go`**: Added `BenchmarkPreemptAction_LargeCluster` and `BenchmarkReclaimAction_LargeCluster` (200 nodes, 1000 jobs) to exercise preemption/reclaim at scale.

4. **`base_scenario_test.go`**: Updated `GetVictimJobRepresentativeById` unit tests to use explicit pod UIDs, matching production invariants.

### Complexity improvement

| Function | Before | After |
|---|---|---|
| `extractJobsFromTasks` | O(V * J * P) | O(V) |
| `GetVictimJobRepresentativeById` | O(J * P) per call | O(1) per call |

Where V = victim tasks, J = job representative fragments per PodGroupID, P = pods per job.

## Related Issues

Part of hyper-scale improvements roadmap.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. Internal optimization only - no API or behavior changes.

## Additional Notes

### Benchmark results (Apple M3 Pro)

New large-cluster benchmarks:
```
BenchmarkPreemptAction_LargeCluster-12     5     231 ms/op     33.5 MB/op     192k allocs/op
BenchmarkReclaimAction_LargeCluster-12     9     127 ms/op     15.3 MB/op     129k allocs/op
```