### PR TITLE
docs: document Docker prerequisites and WSL credential-helper fix for make test

### DIFF
--- a/docs/developer/building-from-source.md
+++ b/docs/developer/building-from-source.md
@@ -1,4 +1,27 @@
 # Building from Source
+
+## Prerequisites
+
+- **Docker** (with a working credential helper): All `make build` and `make test` targets that involve building or running container images require Docker to be installed and properly configured.
+  - On **WSL (Windows Subsystem for Linux)** with Docker Desktop: Docker Desktop's credential helper (`docker-credential-desktop.exe`) is a Windows executable and is **not available** inside WSL. If `make test` or `make build` fails with an error like `exec: "docker-credential-desktop.exe": executable file not found in $PATH`, fix this by editing `~/.docker/config.json` inside WSL and removing or replacing the `credsStore` entry:
+    ```json
+    {
+      "credsStore": ""
+    }
+    ```
+    Then run `docker login` from within WSL to re-authenticate.
+  - Alternatively, you can run individual Go unit tests **without Docker** using:
+    ```sh
+    go test ./...
+    ```
+    This skips the Docker builder image and runs unit tests directly on the host. Integration/envtest tests that require a Kubernetes API server still need Docker.
+
+- **Go** `1.24+`: Required if you run `go test ./...` or build binaries directly on the host.
+- **Helm** `3.x`: Required for packaging and testing the Helm chart (`make test-chart`).
+- **kind** (optional): For loading images into a local cluster.
+
+## Build and Deploy Steps
+
 To build and deploy KAI Scheduler from source, follow these steps:
 
 1. Clone the repository:


### PR DESCRIPTION
Fixes #939

## Summary

`make test` fails in WSL environments because Docker Desktop's credential helper (`docker-credential-desktop.exe`) is a Windows binary not available in the Linux `$PATH`.

## Changes

Added a **Prerequisites** section to `docs/developer/building-from-source.md` that:
- Explicitly lists **Docker** as a required prerequisite (previously undocumented)
- Explains the WSL/Docker Desktop credential helper problem and how to fix it (edit `~/.docker/config.json` to clear `credsStore`)
- Shows how to run unit tests **without Docker** using `go test ./...` for environments where Docker is unavailable
- Lists Go, Helm, and kind as additional prerequisites

## Testing

Documentation-only change; no code modified.