### PR TITLE
fix: skip runtimeClassName injection when gpuPodRuntimeClassName is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Implemented block-level segmentation for pytorchjobs [#938](https://github.com/NVIDIA/KAI-Scheduler/pull/938) [itsomri](https://github.com/itsomri)
 
 ### Fixed
+- Fixed admission webhook to skip runtimeClassName injection when gpuPodRuntimeClassName is empty [#1035](https://github.com/NVIDIA/KAI-Scheduler/pull/1035)
 - Fixed helm uninstall does not remove webhooks [#959](https://github.com/NVIDIA/KAI-Scheduler/pull/959) [faizan-exe](https://github.com/faizan-exe)
 - Fixed security vulnerability where PodGang could reference pods in other namespaces, preventing cross-namespace manipulation
 - Fixed pod controller logging to use request namespace/name instead of empty pod object fields when pod is not found

--- a/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement.go
+++ b/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement.go
@@ -30,6 +30,11 @@ func (p *RuntimeEnforcement) Validate(pod *v1.Pod) error {
 }
 
 func (p *RuntimeEnforcement) Mutate(pod *v1.Pod) error {
+	// Skip runtimeClassName injection entirely when configured with empty string
+	if p.gpuPodRuntimeClassName == "" {
+		return nil
+	}
+
 	// in order to no collide with custom reservation pods runtimeClass
 	if resourcereservation.IsGPUReservationPod(pod) {
 		return nil

--- a/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go
+++ b/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go
@@ -82,6 +82,33 @@ func TestMutate(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name:                   "empty gpuPodRuntimeClassName skips runtimeClass injection",
+			gpuPodRuntimeClassName: "",
+			incomingPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
+							},
+						},
+					},
+				},
+			},
+			expectedOutboundPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{constants.NvidiaGpuResource: resource.MustParse("1")},
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name:                   "pod with GPU request and runtimeClassName set",
 			gpuPodRuntimeClassName: constants.DefaultRuntimeClassName,
 			incomingPod: &v1.Pod{


### PR DESCRIPTION
## Summary

When `gpuPodRuntimeClassName` is set to empty string (`""`), the admission webhook should not inject `runtimeClassName` into GPU pods. Currently, even with an empty value, the `Mutate` function still proceeds to evaluate the pod and may set `runtimeClassName` to an empty string.

This fix adds an early return in `RuntimeEnforcement.Mutate()` when `gpuPodRuntimeClassName` is empty, completely skipping the runtimeClassName injection.

## Problem

With GPU Operator v25.10.0+, `nvidia` is configured as the default containerd runtime. KAI scheduler's admission webhook injecting `runtimeClassName: nvidia` triggers the `management.nvidia.com` CDI management path, causing pod startup failures:

```
Error: failed to inject CDI devices: unresolvable CDI devices
management.nvidia.com/gpu=GPU-<UUID>: unknown
```

The `--gpu-pod-runtime-class-name` flag help text already documents "Set to empty string to disable", but the `Mutate` function did not check for this case.

## Changes

- `runtime_enforcement.go`: Add early return when `gpuPodRuntimeClassName` is empty
- `runtime_enforcement_test.go`: Add test case for empty string behavior

## Test plan

- [x] Existing unit tests pass
- [x] New test case verifies GPU pods are not mutated when `gpuPodRuntimeClassName` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)