### PR TITLE
feat(api): enforce lowercase validation on SubGroup name and parent fields

### DIFF
--- a/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: podgroups.scheduling.run.ai
 spec:
   group: scheduling.run.ai
@@ -112,13 +112,17 @@ spec:
                       minimum: 1
                       type: integer
                     name:
-                      description: Name uniquely identifies the SubGroup within the
-                        PodGroup.
+                      description: |-
+                        Name uniquely identifies the SubGroup within the PodGroup.
+                        Must consist of lowercase alphanumeric characters or hyphens.
                       minLength: 1
+                      pattern: ^[a-z0-9][a-z0-9\-]*$
                       type: string
                     parent:
-                      description: Parent is an optional attribute that specifies
-                        the name of the parent SubGroup
+                      description: |-
+                        Parent is an optional attribute that specifies the name of the parent SubGroup.
+                        Must consist of lowercase alphanumeric characters or hyphens, matching the Name pattern.
+                      pattern: ^[a-z0-9][a-z0-9\-]*$
                       type: string
                     topologyConstraint:
                       description: TopologyConstraint defines the topology constraints

--- a/pkg/apis/scheduling/v2alpha2/podgroup_types.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_types.go
@@ -109,7 +109,9 @@ func ParsePreemptibility(value string) (Preemptibility, error) {
 
 type SubGroup struct {
 	// Name uniquely identifies the SubGroup within the PodGroup.
+	// Must consist of lowercase alphanumeric characters or hyphens.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9\-]*$`
 	Name string `json:"name"`
 
 	// MinMember defines the minimal number of members to run this SubGroup;
@@ -117,8 +119,10 @@ type SubGroup struct {
 	// +kubebuilder:validation:Minimum=1
 	MinMember int32 `json:"minMember,omitempty"`
 
-	// Parent is an optional attribute that specifies the name of the parent SubGroup
+	// Parent is an optional attribute that specifies the name of the parent SubGroup.
+	// Must consist of lowercase alphanumeric characters or hyphens, matching the Name pattern.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^[a-z0-9][a-z0-9\-]*$`
 	Parent *string `json:"parent,omitempty"`
 
 	// TopologyConstraint defines the topology constraints for this SubGroup

--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
@@ -19,29 +19,29 @@ func TestValidateSubGroups(t *testing.T) {
 		{
 			name: "Valid DAG single root",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "C", Parent: ptr.To("B"), MinMember: 1},
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "c", Parent: ptr.To("b"), MinMember: 1},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "Valid DAG multiple roots",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", MinMember: 1},
-				{Name: "C", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "D", Parent: ptr.To("B"), MinMember: 1},
+				{Name: "a", MinMember: 1},
+				{Name: "b", MinMember: 1},
+				{Name: "c", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "d", Parent: ptr.To("b"), MinMember: 1},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "Missing parent",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", Parent: ptr.To("X"), MinMember: 1}, // parent X does not exist
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("x"), MinMember: 1}, // parent X does not exist
 			},
-			wantErr: errors.New("parent X of B was not found"),
+			wantErr: errors.New("parent x of b was not found"),
 		},
 		{
 			name:      "Empty list",
@@ -51,46 +51,54 @@ func TestValidateSubGroups(t *testing.T) {
 		{
 			name: "Duplicate subgroup names",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "A", MinMember: 1}, // duplicate
+				{Name: "a", MinMember: 1},
+				{Name: "a", MinMember: 1}, // duplicate
 			},
-			wantErr: errors.New("duplicate subgroup name A"),
+			wantErr: errors.New("duplicate subgroup name a"),
 		},
 		{
 			name: "Cycle in graph (A -> B -> C -> A) - duplicate subgroup name",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "C", Parent: ptr.To("B"), MinMember: 1},
-				{Name: "A", Parent: ptr.To("C"), MinMember: 1}, // creates a cycle
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "c", Parent: ptr.To("b"), MinMember: 1},
+				{Name: "a", Parent: ptr.To("c"), MinMember: 1}, // creates a cycle
 			},
-			wantErr: errors.New("duplicate subgroup name A"), // duplicate is caught before cycle
+			wantErr: errors.New("duplicate subgroup name a"), // duplicate is caught before cycle
 		},
 		{
 			name: "Self-parent subgroup (cycle of length 1)",
 			subGroups: []SubGroup{
-				{Name: "A", Parent: ptr.To("A"), MinMember: 1},
+				{Name: "a", Parent: ptr.To("a"), MinMember: 1},
 			},
 			wantErr: errors.New("cycle detected in subgroups"),
 		},
 		{
 			name: "Cycle in graph (A -> B -> C -> A)",
 			subGroups: []SubGroup{
-				{Name: "A", Parent: ptr.To("C"), MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "C", Parent: ptr.To("B"), MinMember: 1}, // creates a cycle
+				{Name: "a", Parent: ptr.To("c"), MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "c", Parent: ptr.To("b"), MinMember: 1}, // creates a cycle
 			},
 			wantErr: errors.New("cycle detected in subgroups"),
 		},
 		{
 			name: "Multiple disjoint cycles",
 			subGroups: []SubGroup{
-				{Name: "A", Parent: ptr.To("B"), MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1}, // cycle A <-> B
-				{Name: "C", Parent: ptr.To("D"), MinMember: 1},
-				{Name: "D", Parent: ptr.To("C"), MinMember: 1}, // cycle C <-> D
+				{Name: "a", Parent: ptr.To("b"), MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1}, // cycle A <-> B
+				{Name: "c", Parent: ptr.To("d"), MinMember: 1},
+				{Name: "d", Parent: ptr.To("c"), MinMember: 1}, // cycle C <-> D
 			},
 			wantErr: errors.New("cycle detected in subgroups"),
+		},
+		{
+			name: "All lowercase subgroup names accepted",
+			subGroups: []SubGroup{
+				{Name: "group-a", MinMember: 1},
+				{Name: "group-b", Parent: ptr.To("group-a"), MinMember: 1},
+			},
+			wantErr: nil,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Adds kubebuilder validation pattern constraints to `SubGroup.Name` and `SubGroup.Parent` fields in `PodGroupSpec` to enforce lowercase alphanumeric characters and hyphens only.

**Pattern:** `^[a-z0-9][a-z0-9\-]*$`

This ensures consistent naming conventions and prevents accidental use of uppercase letters in SubGroup identifiers.

## Changes

- `pkg/apis/scheduling/v2alpha2/podgroup_types.go`: Added `+kubebuilder:validation:Pattern` markers on `SubGroup.Name` and `SubGroup.Parent` fields, with updated doc comments
- `pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go`: Updated test fixtures to use lowercase names (consistent with the new constraint); added a test case for hyphenated lowercase names
- `deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml`: Regenerated via `make generate manifests` (controller-gen v0.20.1)

## Context

This is a clean re-submission of #1034, which was closed after reviewer feedback from @gshaibi noting that the CRD YAML had been committed without running `make generate manifests` properly (it was placed in the wrong `config/crd/bases/` directory instead of `deployments/kai-scheduler/crds/`).

This PR:
1. Contains only Go source changes + the CRD YAML properly regenerated via `make generate manifests`
2. Does **not** include the incorrect `config/crd/bases/` file
3. The CRD YAML is the output of running `make generate manifests` on the modified sources

## Testing

Existing webhook tests updated and passing with `go test ./pkg/apis/scheduling/v2alpha2/...`