### PR TITLE
chore: auto-resolve CHANGELOG.md merge conflicts with union strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Description

Add `.gitattributes` with `merge=union` for `CHANGELOG.md` so that concurrent additions to the same changelog section are merged automatically instead of producing conflict markers.

This is a common issue where two developers add a line to the same section of the changelog, resulting in a trivial conflict. The `union` merge driver is a built-in Git strategy that keeps both sides, eliminating these conflicts.

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Additional Notes

- `union` is a built-in Git merge driver — no extra configuration needed for cloners.
- Works for both `git merge` and `git rebase`.