### PR TITLE
fix(queue-controller): use Spec.Queue field indexer for resource aggregation (#1049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.12.9] - 2026-01-21
 
 ### Fixed
+- Fixed a bug where queue status did not reflect its podgroups resources correctly [#1049](https://github.com/NVIDIA/KAI-Scheduler/pull/1049)
 - ClusterPolicy CDI parsing for gpu-operator > v25.10.0
 - Fixed missing `repository`, `tag`, and `pullPolicy` fields in `resourceReservationImage` section of kai-config Helm template [#895](https://github.com/NVIDIA/KAI-Scheduler/pull/895) [dttung2905](https://github.com/dttung2905)
 

--- a/cmd/queuecontroller/app/app.go
+++ b/cmd/queuecontroller/app/app.go
@@ -78,7 +78,7 @@ func Run(opts *Options, clientConfig *rest.Config, ctx context.Context) error {
 	if err = (&controllers.QueueReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, opts.SchedulingQueueLabelKey, opts.SkipControllerNameValidation); err != nil {
+	}).SetupWithManager(mgr, opts.SkipControllerNameValidation); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Queue")
 		return nil
 	}

--- a/cmd/queuecontroller/app/options.go
+++ b/cmd/queuecontroller/app/options.go
@@ -16,7 +16,6 @@ const (
 
 type Options struct {
 	EnableLeaderElection         bool
-	SchedulingQueueLabelKey      string
 	EnableWebhook                bool
 	SkipControllerNameValidation bool // Set true for env tests
 
@@ -34,7 +33,6 @@ func InitOptions(fs *flag.FlagSet) *Options {
 	o := &Options{}
 
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	fs.StringVar(&o.SchedulingQueueLabelKey, "queue-label-key", constants.DefaultQueueLabel, "Scheduling queue label key name.")
 	fs.BoolVar(&o.EnableWebhook, "enable-webhook", true, "Enable webhook for controller manager.")
 	fs.BoolVar(&o.SkipControllerNameValidation, "skip-controller-name-validation", false, "Skip controller name validation.")
 	fs.StringVar(&o.MetricsAddress, "metrics-listen-address", defaultMetricsAddress, "The address the metrics endpoint binds to.")

--- a/pkg/operator/operands/queue_controller/resources.go
+++ b/pkg/operator/operands/queue_controller/resources.go
@@ -257,7 +257,6 @@ func (q *QueueController) webhookClientConfig(namespace, path string, cabundle [
 func buildArgsList(kaiConfig *kaiv1.Config) []string {
 	config := kaiConfig.Spec.QueueController
 	args := []string{
-		"--queue-label-key", *kaiConfig.Spec.Global.QueueLabelKey,
 		"--metrics-listen-address", fmt.Sprintf(":%d", *config.ControllerService.Metrics.Port),
 	}
 	if config.Replicas != nil && *config.Replicas > 1 {

--- a/pkg/queuecontroller/common/common.go
+++ b/pkg/queuecontroller/common/common.go
@@ -4,5 +4,6 @@
 package common
 
 const (
-	ParentQueueIndexName = ".spec.parentQueue"
+	ParentQueueIndexName   = ".spec.parentQueue"
+	PodGroupQueueIndexName = ".spec.queue"
 )

--- a/pkg/queuecontroller/controllers/resource_updater/resource_updater.go
+++ b/pkg/queuecontroller/controllers/resource_updater/resource_updater.go
@@ -18,7 +18,6 @@ import (
 
 type ResourceUpdater struct {
 	client.Client
-	QueueLabelKey string
 }
 
 func (ru *ResourceUpdater) UpdateQueue(ctx context.Context, queue *v2.Queue) error {
@@ -60,12 +59,10 @@ func (ru *ResourceUpdater) sumChildQueueResources(ctx context.Context, queue *v2
 }
 
 func (ru *ResourceUpdater) sumPodGroupsResources(ctx context.Context, queue *v2.Queue) error {
-	listOption := client.MatchingLabels{
-		ru.QueueLabelKey: queue.Name,
-	}
-
 	queuePodGroups := v2alpha2.PodGroupList{}
-	err := ru.Client.List(ctx, &queuePodGroups, listOption)
+	err := ru.Client.List(ctx, &queuePodGroups, client.MatchingFields{
+		common.PodGroupQueueIndexName: queue.Name,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/queuecontroller/controllers/suite_test.go
+++ b/pkg/queuecontroller/controllers/suite_test.go
@@ -129,7 +129,7 @@ var _ = Describe("QueueController", Ordered, func() {
 			Scheme: mgr.GetScheme(),
 		}
 
-		err = controller.SetupWithManager(mgr, "kai.scheduler/queue", false)
+		err = controller.SetupWithManager(mgr, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		managerDone = make(chan struct{})


### PR DESCRIPTION
## Summary
- Backport of #1049 to v0.12
- Fixed a bug where queue status did not reflect its podgroups resources correctly because the queue controller used a label selector (`kai.scheduler/queue`) instead of `Spec.Queue` to find PodGroups belonging to a queue

## Test plan
- [x] CI passes on v0.12