### PR TITLE
fix(queue-controller): use Spec.Queue field indexer for resource aggregation (#1049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Fixed a bug where queue status did not reflect its podgroups resources correctly [#1049](https://github.com/NVIDIA/KAI-Scheduler/pull/1049)
 - Fixed plugin server (snapshot and job-order endpoints) listening on all interfaces by binding to localhost only.
 
 ## [v0.9.12] - 2026-01-21

--- a/cmd/queuecontroller/app/app.go
+++ b/cmd/queuecontroller/app/app.go
@@ -84,7 +84,7 @@ func Run() error {
 	if err = (&controllers.QueueReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, opts.SchedulingQueueLabelKey); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Queue")
 		return nil
 	}

--- a/cmd/queuecontroller/app/options.go
+++ b/cmd/queuecontroller/app/options.go
@@ -15,8 +15,7 @@ const (
 )
 
 type Options struct {
-	EnableLeaderElection    bool
-	SchedulingQueueLabelKey string
+	EnableLeaderElection bool
 
 	MetricsAddress                 string
 	MetricsNamespace               string
@@ -30,7 +29,6 @@ type Options struct {
 
 func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	fs.StringVar(&o.SchedulingQueueLabelKey, "queue-label-key", constants.DefaultQueueLabel, "Scheduling queue label key name.")
 	fs.StringVar(&o.MetricsAddress, "metrics-listen-address", defaultMetricsAddress, "The address the metrics endpoint binds to.")
 	fs.StringVar(&o.MetricsNamespace, "metrics-namespace", constants.DefaultMetricsNamespace, "Metrics namespace.")
 	fs.Var(&o.QueueLabelToMetricLabel, "queue-label-to-metric-label", "Map of queue label keys to metric label keys, e.g. 'foo=bar,baz=qux'.")

--- a/pkg/operator/operands/queue_controller/resources.go
+++ b/pkg/operator/operands/queue_controller/resources.go
@@ -258,7 +258,6 @@ func webhookClientConfig(namespace, name, path string, cabundle []byte, port int
 func buildArgsList(kaiConfig *kaiv1.Config) []string {
 	config := kaiConfig.Spec.QueueController
 	args := []string{
-		"--queue-label-key", *kaiConfig.Spec.Global.QueueLabelKey,
 		"--metrics-listen-address", fmt.Sprintf(":%d", *config.ControllerService.Metrics.Port),
 	}
 	if config.Replicas != nil && *config.Replicas > 1 {

--- a/pkg/queuecontroller/common/common.go
+++ b/pkg/queuecontroller/common/common.go
@@ -4,5 +4,6 @@
 package common
 
 const (
-	ParentQueueIndexName = ".spec.parentQueue"
+	ParentQueueIndexName   = ".spec.parentQueue"
+	PodGroupQueueIndexName = ".spec.queue"
 )

--- a/pkg/queuecontroller/controllers/queue_controller.go
+++ b/pkg/queuecontroller/controllers/queue_controller.go
@@ -85,16 +85,21 @@ func (r *QueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *QueueReconciler) SetupWithManager(mgr ctrl.Manager, queueLabelKey string) error {
+func (r *QueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := mgr.GetFieldIndexer().IndexField(context.Background(), &v2.Queue{}, common.ParentQueueIndexName,
 		indexQueueByParent)
 	if err != nil {
-		return fmt.Errorf("failed to setup queue parent indexer: %v", err)
+		return fmt.Errorf("failed to setup queue parent indexer: %w", err)
+	}
+
+	err = mgr.GetFieldIndexer().IndexField(context.Background(), &v2alpha2.PodGroup{}, common.PodGroupQueueIndexName,
+		indexPodGroupByQueue)
+	if err != nil {
+		return fmt.Errorf("failed to setup podgroup queue indexer: %w", err)
 	}
 
 	r.resourceUpdater = resource_updater.ResourceUpdater{
-		Client:        r.Client,
-		QueueLabelKey: queueLabelKey,
+		Client: r.Client,
 	}
 	r.childQueuesUpdater = childqueues_updater.ChildQueuesUpdater{
 		Client: r.Client,
@@ -115,6 +120,14 @@ func indexQueueByParent(object client.Object) []string {
 		return []string{}
 	}
 	return []string{queue.Spec.ParentQueue}
+}
+
+func indexPodGroupByQueue(object client.Object) []string {
+	pg := object.(*v2alpha2.PodGroup)
+	if pg.Spec.Queue == "" {
+		return []string{}
+	}
+	return []string{pg.Spec.Queue}
 }
 
 func enqueueQueue(_ context.Context, q client.Object) []reconcile.Request {

--- a/pkg/queuecontroller/controllers/resource_updater/resource_updater.go
+++ b/pkg/queuecontroller/controllers/resource_updater/resource_updater.go
@@ -18,7 +18,6 @@ import (
 
 type ResourceUpdater struct {
 	client.Client
-	QueueLabelKey string
 }
 
 func (ru *ResourceUpdater) UpdateQueue(ctx context.Context, queue *v2.Queue) error {
@@ -60,12 +59,10 @@ func (ru *ResourceUpdater) sumChildQueueResources(ctx context.Context, queue *v2
 }
 
 func (ru *ResourceUpdater) sumPodGroupsResources(ctx context.Context, queue *v2.Queue) error {
-	listOption := client.MatchingLabels{
-		ru.QueueLabelKey: queue.Name,
-	}
-
 	queuePodGroups := v2alpha2.PodGroupList{}
-	err := ru.Client.List(ctx, &queuePodGroups, listOption)
+	err := ru.Client.List(ctx, &queuePodGroups, client.MatchingFields{
+		common.PodGroupQueueIndexName: queue.Name,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/queuecontroller/controllers/suite_test.go
+++ b/pkg/queuecontroller/controllers/suite_test.go
@@ -126,7 +126,7 @@ var _ = Describe("QueueController", Ordered, func() {
 			Scheme: mgr.GetScheme(),
 		}
 
-		err = controller.SetupWithManager(mgr, "kai.scheduler/queue")
+		err = controller.SetupWithManager(mgr)
 		Expect(err).ToNot(HaveOccurred())
 
 		managerDone = make(chan struct{})


### PR DESCRIPTION
## Summary
- Backport of #1049 to v0.9
- Fixed a bug where queue status did not reflect its podgroups resources correctly because the queue controller used a label selector (`kai.scheduler/queue`) instead of `Spec.Queue` to find PodGroups belonging to a queue

## Test plan
- [ ] CI passes on v0.9