### PR TITLE
ci(deps): group k8s.io dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,28 +12,52 @@ updates:
       interval: "weekly"
   # Enable version updates for Go modules
   - package-ecosystem: "gomod"
-    # Look for Go modules in the `root` directory
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
   # Enable version updates for Go modules on supported version branches
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "v0.12"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "v0.9"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "v0.6"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "v0.4"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"


### PR DESCRIPTION
## Description

Add dependabot `groups` configuration to batch all `k8s.io/*` and `sigs.k8s.io/*` dependency updates into a single PR per branch.

Currently, dependabot opens ~15 individual PRs for each `k8s.io` sub-package (api, apimachinery, apiserver, component-base, etc.) per branch. Since these packages are tightly coupled and must be upgraded together, the individual PRs cannot be merged independently and just create noise.

With grouping, dependabot will create **one PR per branch** for all Kubernetes-related Go modules.

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Additional Notes

After merging, the existing individual `k8s.io` dependabot PRs should be closed — dependabot will open new grouped PRs on its next scheduled run.