### PR TITLE
refactor(scheduler): adding resouce vector class

### DIFF
--- a/pkg/scheduler/api/resource_info/resource_vector.go
+++ b/pkg/scheduler/api/resource_info/resource_vector.go
@@ -1,0 +1,323 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resource_info
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type ResourceVector []float64
+
+type ResourceVectorMap struct {
+	resourceNames []string
+	namesToIndex  map[string]int
+}
+
+// NewResourceVectorMap creates a new ResourceVectorMap initialized with base resources.
+func NewResourceVectorMap() *ResourceVectorMap {
+	result := &ResourceVectorMap{
+		resourceNames: []string{},
+		namesToIndex:  make(map[string]int),
+	}
+
+	// Add core resources first to ensure consistent ordering
+	coreResources := []string{string(v1.ResourceCPU), string(v1.ResourceMemory), constants.GpuResource, string(v1.ResourcePods)}
+	for _, resourceName := range coreResources {
+		result.AddResource(resourceName)
+	}
+
+	return result
+}
+
+func NewResourceVector(indexMap *ResourceVectorMap) ResourceVector {
+	return make(ResourceVector, len(indexMap.resourceNames))
+}
+
+func NewSingleGpuVector(indexMap *ResourceVectorMap) ResourceVector {
+	vec := NewResourceVector(indexMap)
+	gpuIdx := indexMap.GetIndex(constants.GpuResource)
+	if gpuIdx >= 0 {
+		vec.Set(gpuIdx, 1)
+	}
+	return vec
+}
+
+// NewResourceVectorWithValues is a convenience function for tests only.
+func NewResourceVectorWithValues(milliCPU, memory, gpus float64, indexMap *ResourceVectorMap) ResourceVector {
+	vec := NewResourceVector(indexMap)
+	cpuIdx := indexMap.GetIndex(string(v1.ResourceCPU))
+	memIdx := indexMap.GetIndex(string(v1.ResourceMemory))
+	gpuIdx := indexMap.GetIndex(constants.GpuResource)
+	if cpuIdx < 0 || memIdx < 0 || gpuIdx < 0 {
+		panic("resource vector map missing core resource indexes")
+	}
+	vec.Set(cpuIdx, milliCPU)
+	vec.Set(memIdx, memory)
+	vec.Set(gpuIdx, gpus)
+	return vec
+}
+
+func NewResourceVectorFromResourceList(resourceList v1.ResourceList, indexMap *ResourceVectorMap) ResourceVector {
+	vec := NewResourceVector(indexMap)
+
+	for resourceName, rQuant := range resourceList {
+		normalizedName := normalizeResourceName(string(resourceName))
+		idx := indexMap.GetIndex(normalizedName)
+		if idx >= 0 {
+			vec[idx] += convertResourceToFloat64(resourceName, rQuant)
+		}
+	}
+
+	return vec
+}
+
+func (v *ResourceVector) Add(other ResourceVector) {
+	if len(*v) < len(other) {
+		extended := make(ResourceVector, len(other))
+		copy(extended, *v)
+		*v = extended
+	}
+	for i := range other {
+		(*v)[i] += other[i]
+	}
+}
+
+func (v *ResourceVector) Sub(other ResourceVector) {
+	if len(*v) < len(other) {
+		extended := make(ResourceVector, len(other))
+		copy(extended, *v)
+		*v = extended
+	}
+	for i := range other {
+		(*v)[i] -= other[i]
+	}
+}
+
+func (v ResourceVector) Clone() ResourceVector {
+	cloned := make(ResourceVector, len(v))
+	copy(cloned, v)
+	return cloned
+}
+
+func (v ResourceVector) LessEqual(other ResourceVector) bool {
+	minLen := min(len(v), len(other))
+	for i := 0; i < minLen; i++ {
+		if v[i] > other[i] {
+			return false
+		}
+	}
+	// v's extras must be <= 0 (compared against implicit 0 in other)
+	for i := minLen; i < len(v); i++ {
+		if v[i] > 0 {
+			return false
+		}
+	}
+	// other's extras must be >= 0 (implicit 0 in v must be <= them)
+	for i := minLen; i < len(other); i++ {
+		if other[i] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (v ResourceVector) Get(index int) float64 {
+	if index < 0 || index >= len(v) {
+		return 0
+	}
+	return v[index]
+}
+
+func (v ResourceVector) Set(index int, value float64) {
+	if index >= 0 && index < len(v) {
+		v[index] = value
+	}
+}
+
+func (m *ResourceVectorMap) GetIndex(resourceName string) int {
+	resourceName = normalizeResourceName(resourceName)
+	if idx, exists := m.namesToIndex[resourceName]; exists {
+		return idx
+	}
+	return -1
+}
+
+func (m *ResourceVectorMap) AddResource(resourceName string) {
+	resourceName = normalizeResourceName(resourceName)
+	if _, exists := m.namesToIndex[resourceName]; exists {
+		return
+	}
+	m.namesToIndex[resourceName] = len(m.resourceNames)
+	m.resourceNames = append(m.resourceNames, resourceName)
+}
+
+func (m *ResourceVectorMap) AddResourceList(resourceList v1.ResourceList) {
+	for resourceName := range resourceList {
+		m.AddResource(string(resourceName))
+	}
+}
+
+func (m *ResourceVectorMap) Len() int {
+	return len(m.resourceNames)
+}
+
+func (m *ResourceVectorMap) ResourceAt(index int) string {
+	if index < 0 || index >= len(m.resourceNames) {
+		return ""
+	}
+	return m.resourceNames[index]
+}
+
+func BuildResourceVectorMap(nodeResources []v1.ResourceList) *ResourceVectorMap {
+	result := NewResourceVectorMap()
+	for _, rList := range nodeResources {
+		result.AddResourceList(rList)
+	}
+	return result
+}
+
+func convertResourceToFloat64(rName v1.ResourceName, rQuant resource.Quantity) float64 {
+	if rName == v1.ResourceCPU {
+		return float64(rQuant.MilliValue())
+	}
+	return float64(rQuant.Value())
+}
+
+func isGpuResource(resourceName string) bool {
+	return strings.HasSuffix(resourceName, constants.GpuResource)
+}
+
+func normalizeResourceName(resourceName string) string {
+	if isGpuResource(resourceName) {
+		return constants.GpuResource
+	}
+	return resourceName
+}
+
+func (r *Resource) ToVector(indexMap *ResourceVectorMap) ResourceVector {
+	vec := NewResourceVector(indexMap)
+
+	vec.Set(indexMap.GetIndex(string(v1.ResourceCPU)), r.milliCpu)
+	vec.Set(indexMap.GetIndex(string(v1.ResourceMemory)), r.memory)
+	vec.Set(indexMap.GetIndex(constants.GpuResource), r.gpus)
+
+	for name, val := range r.scalarResources {
+		if idx := indexMap.GetIndex(string(name)); idx >= 0 {
+			vec.Set(idx, float64(val))
+		}
+	}
+
+	return vec
+}
+
+func (r *Resource) FromVector(vec ResourceVector, indexMap *ResourceVectorMap) {
+	r.milliCpu = vec.Get(indexMap.GetIndex(string(v1.ResourceCPU)))
+	r.memory = vec.Get(indexMap.GetIndex(string(v1.ResourceMemory)))
+	r.gpus = vec.Get(indexMap.GetIndex(constants.GpuResource))
+}
+
+func (r *ResourceRequirements) ToVector(indexMap *ResourceVectorMap) ResourceVector {
+	vec := NewResourceVector(indexMap)
+
+	vec.Set(indexMap.GetIndex(string(v1.ResourceCPU)), r.milliCpu)
+	vec.Set(indexMap.GetIndex(string(v1.ResourceMemory)), r.memory)
+	vec.Set(indexMap.GetIndex(constants.GpuResource), r.GPUs()+float64(r.GetDraGpusCount()))
+
+	for name, val := range r.scalarResources {
+		if idx := indexMap.GetIndex(string(name)); idx >= 0 {
+			vec.Set(idx, float64(val))
+		}
+	}
+
+	for name, val := range r.MigResources() {
+		if idx := indexMap.GetIndex(string(name)); idx >= 0 {
+			vec.Set(idx, float64(val))
+		}
+	}
+
+	return vec
+}
+
+func (r *ResourceRequirements) FromVector(vec ResourceVector, indexMap *ResourceVectorMap) {
+	r.milliCpu = vec.Get(indexMap.GetIndex(string(v1.ResourceCPU)))
+	r.memory = vec.Get(indexMap.GetIndex(string(v1.ResourceMemory)))
+
+	gpuVal := vec.Get(indexMap.GetIndex(constants.GpuResource))
+	if gpuVal >= 1 {
+		r.GpuResourceRequirement = *NewGpuResourceRequirementWithGpus(gpuVal, 0)
+	} else if gpuVal > 0 {
+		r.GpuResourceRequirement = *NewGpuResourceRequirement()
+		r.GpuResourceRequirement.portion = gpuVal
+		r.GpuResourceRequirement.count = 1
+	}
+}
+
+func (v ResourceVector) SetMax(other ResourceVector) {
+	for i := range min(len(v), len(other)) {
+		if other[i] > v[i] {
+			v[i] = other[i]
+		}
+	}
+}
+
+func (v ResourceVector) IsZero() bool {
+	for _, val := range v {
+		if val != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func DetailedResourceString(vec ResourceVector, gpuReq *GpuResourceRequirement, m *ResourceVectorMap) string {
+	cpuIdx := m.GetIndex(string(v1.ResourceCPU))
+	memIdx := m.GetIndex(string(v1.ResourceMemory))
+
+	messageBuilder := strings.Builder{}
+	messageBuilder.WriteString(fmt.Sprintf(
+		"GPU: %s, CPU: %s (cores), memory: %s (GB)",
+		HumanizeResource(gpuReq.GetGpusQuota(), 1),
+		HumanizeResource(vec.Get(cpuIdx), MilliCPUToCores),
+		HumanizeResource(vec.Get(memIdx), MemoryToGB),
+	))
+
+	for i := 0; i < m.Len(); i++ {
+		name := m.ResourceAt(i)
+		if name == string(v1.ResourceCPU) || name == string(v1.ResourceMemory) || name == constants.GpuResource {
+			continue
+		}
+		if IsMigResource(v1.ResourceName(name)) {
+			continue
+		}
+		val := vec.Get(i)
+		if val == 0 {
+			continue
+		}
+		rName := v1.ResourceName(name)
+		if rName == v1.ResourceEphemeralStorage || rName == v1.ResourceStorage {
+			val = val / MemoryToGB
+			messageBuilder.WriteString(fmt.Sprintf(", %s: %s (GB)", name, HumanizeResource(val, 1)))
+		} else {
+			messageBuilder.WriteString(fmt.Sprintf(", %s: %s", name, HumanizeResource(val, 1)))
+		}
+	}
+	for migName, migQuant := range gpuReq.MigResources() {
+		messageBuilder.WriteString(fmt.Sprintf(", mig %s: %d", migName, migQuant))
+	}
+	return messageBuilder.String()
+}
+
+func (v ResourceVector) ToResourceQuantities(indexMap *ResourceVectorMap) map[string]float64 {
+	result := make(map[string]float64, indexMap.Len())
+	for i := 0; i < indexMap.Len(); i++ {
+		name := indexMap.ResourceAt(i)
+		result[name] = v.Get(i)
+	}
+	return result
+}

--- a/pkg/scheduler/api/resource_info/resource_vector_benchmark_test.go
+++ b/pkg/scheduler/api/resource_info/resource_vector_benchmark_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resource_info
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkResourceVectorLessEqual(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		size int
+	}{
+		{"100resources", 100},
+		{"500resources", 500},
+		{"1000resources", 1000},
+		{"2000resources", 2000},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			indexMap := ResourceVectorMap{
+				resourceNames: make([]string, 0, bm.size),
+				namesToIndex:  make(map[string]int, bm.size),
+			}
+			for i := 0; i < bm.size; i++ {
+				indexMap.AddResource(fmt.Sprintf("resource-%d", i))
+			}
+
+			vec1 := NewResourceVector(&indexMap)
+			vec2 := NewResourceVector(&indexMap)
+			for i := 0; i < len(vec1); i++ {
+				vec1[i] = float64(i+1) * 100
+				vec2[i] = float64(i+2) * 100
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = vec1.LessEqual(vec2)
+			}
+		})
+	}
+}
+
+func BenchmarkResourceVectorAdd(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		size int
+	}{
+		{"100resources", 100},
+		{"500resources", 500},
+		{"1000resources", 1000},
+		{"2000resources", 2000},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			indexMap := ResourceVectorMap{
+				resourceNames: make([]string, 0, bm.size),
+				namesToIndex:  make(map[string]int, bm.size),
+			}
+			for i := 0; i < bm.size; i++ {
+				indexMap.AddResource(fmt.Sprintf("resource-%d", i))
+			}
+
+			vec1 := NewResourceVector(&indexMap)
+			vec2 := NewResourceVector(&indexMap)
+			for i := 0; i < len(vec1); i++ {
+				vec1[i] = float64(i+1) * 100
+				vec2[i] = float64(i+2) * 100
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				vecCopy := vec1.Clone()
+				vecCopy.Add(vec2)
+			}
+		})
+	}
+}
+
+func BenchmarkResourceVectorSub(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		size int
+	}{
+		{"100resources", 100},
+		{"500resources", 500},
+		{"1000resources", 1000},
+		{"2000resources", 2000},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			indexMap := ResourceVectorMap{
+				resourceNames: make([]string, 0, bm.size),
+				namesToIndex:  make(map[string]int, bm.size),
+			}
+			for i := 0; i < bm.size; i++ {
+				indexMap.AddResource(fmt.Sprintf("resource-%d", i))
+			}
+
+			vec1 := NewResourceVector(&indexMap)
+			vec2 := NewResourceVector(&indexMap)
+			for i := 0; i < len(vec1); i++ {
+				vec1[i] = float64(i+2) * 100
+				vec2[i] = float64(i+1) * 100
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				vecCopy := vec1.Clone()
+				vecCopy.Sub(vec2)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/api/resource_info/resource_vector_test.go
+++ b/pkg/scheduler/api/resource_info/resource_vector_test.go
@@ -1,0 +1,369 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resource_info
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+)
+
+const (
+	resourceCPU    = string(v1.ResourceCPU)
+	resourceMemory = string(v1.ResourceMemory)
+
+	cpuMedium = 1000
+	cpuLarge  = 2000
+
+	oneGiB = 1024 * 1024 * 1024
+	twoGiB = 2 * oneGiB
+
+	gpuOne   = 1
+	gpuTwo   = 2
+	gpuThree = 3
+
+	vecValSmall       = 50
+	vecValMedium      = 100
+	vecValLarge       = 150
+	vecValMemSmall    = 500
+	vecValMemMedium   = 1000
+	vecValMemLarge    = 1500
+	vecValModified    = 999
+	vecValDecimal     = 100.5
+	vecValMemDecimal  = 1000.25
+	vecValGPUDecimal  = 2.5
+	vecValSetLarge    = 2000
+	vecValSetDecimal  = 4.5
+	vecValLessSmaller = 99
+
+	customResourceResA = "resource-a"
+	customResourceResB = "resource-b"
+
+	customResourceQtyMedium = 5
+	customResourceQtyLarge  = 10
+)
+
+func buildTestVectorMap(resourceNames ...string) *ResourceVectorMap {
+	rList := v1.ResourceList{}
+	for _, name := range resourceNames {
+		rList[v1.ResourceName(name)] = resource.MustParse("1")
+	}
+	return BuildResourceVectorMap([]v1.ResourceList{rList})
+}
+
+var _ = Describe("ResourceVector", func() {
+	Describe("Add", func() {
+		It("should add two vectors of equal length", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall, gpuOne}
+
+			vec1.Add(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValLarge, vecValMemLarge, gpuThree}))
+		})
+
+		It("should extend shorter vector when adding mismatched lengths", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall, gpuOne}
+
+			vec1.Add(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValLarge, vecValMemLarge, gpuOne}))
+
+			vec3 := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+			vec4 := ResourceVector{vecValSmall, vecValMemSmall}
+
+			vec3.Add(vec4)
+			Expect(vec3).To(Equal(ResourceVector{vecValLarge, vecValMemLarge, gpuTwo}))
+		})
+	})
+
+	Describe("Sub", func() {
+		It("should subtract two vectors of equal length", func() {
+			vec1 := ResourceVector{vecValLarge, vecValMemLarge, gpuThree}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall, gpuOne}
+
+			vec1.Sub(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}))
+		})
+
+		It("should extend shorter vector when subtracting mismatched lengths", func() {
+			vec1 := ResourceVector{vecValLarge, vecValMemLarge}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall, gpuOne}
+
+			vec1.Sub(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, -gpuOne}))
+
+			vec3 := ResourceVector{vecValLarge, vecValMemLarge, gpuThree}
+			vec4 := ResourceVector{vecValSmall, vecValMemSmall}
+
+			vec3.Sub(vec4)
+			Expect(vec3).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, gpuThree}))
+		})
+	})
+
+	Describe("Clone", func() {
+		It("should create a deep copy of the vector", func() {
+			original := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+			cloned := original.Clone()
+
+			// Verify contents are equal
+			Expect(cloned[0]).To(Equal(original[0]))
+			Expect(cloned[1]).To(Equal(original[1]))
+			Expect(cloned[2]).To(Equal(original[2]))
+
+			// Verify they're independent - modify clone
+			cloned[0] = vecValModified
+			Expect(original[0]).To(Equal(float64(vecValMedium)))
+			Expect(cloned[0]).To(Equal(float64(vecValModified)))
+		})
+	})
+
+	Describe("LessEqual", func() {
+		It("should compare vectors of equal length correctly", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+			vec2 := ResourceVector{vecValLarge, vecValMemLarge, gpuThree}
+			vec3 := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+
+			Expect(vec1.LessEqual(vec2)).To(BeTrue())
+			Expect(vec1.LessEqual(vec3)).To(BeTrue())
+			Expect(vec2.LessEqual(vec1)).To(BeFalse())
+
+			vec4 := ResourceVector{vecValLessSmaller, vecValMemMedium, gpuTwo}
+			Expect(vec1.LessEqual(vec4)).To(BeFalse())
+		})
+
+		It("should handle mismatched lengths with implicit zeros", func() {
+			// vec1 shorter - implicit 0s compared against vec2 extras (positive, so true)
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium}
+			vec2 := ResourceVector{vecValLarge, vecValMemLarge, gpuThree}
+			Expect(vec1.LessEqual(vec2)).To(BeTrue())
+
+			// vec1 shorter - implicit 0s compared against vec2 extras (negative, so false)
+			vec3 := ResourceVector{vecValMedium, vecValMemMedium}
+			vec4 := ResourceVector{vecValLarge, vecValMemLarge, -1}
+			Expect(vec3.LessEqual(vec4)).To(BeFalse())
+
+			// vec1 longer with positive extras - compared against implicit 0 (so false)
+			vec5 := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+			vec6 := ResourceVector{vecValLarge, vecValMemLarge}
+			Expect(vec5.LessEqual(vec6)).To(BeFalse())
+
+			// vec1 longer with zero/negative extras - compared against implicit 0 (so true)
+			vec7 := ResourceVector{vecValMedium, vecValMemMedium, 0}
+			vec8 := ResourceVector{vecValLarge, vecValMemLarge}
+			Expect(vec7.LessEqual(vec8)).To(BeTrue())
+
+			vec9 := ResourceVector{vecValMedium, vecValMemMedium, -1}
+			vec10 := ResourceVector{vecValLarge, vecValMemLarge}
+			Expect(vec9.LessEqual(vec10)).To(BeTrue())
+		})
+	})
+
+	Describe("Get", func() {
+		It("should return the value at the specified index", func() {
+			vec := ResourceVector{vecValDecimal, vecValMemDecimal, vecValGPUDecimal}
+
+			Expect(vec.Get(0)).To(Equal(vecValDecimal))
+			Expect(vec.Get(1)).To(Equal(vecValMemDecimal))
+			Expect(vec.Get(2)).To(Equal(vecValGPUDecimal))
+		})
+	})
+
+	Describe("Set", func() {
+		It("should set the value at the specified index", func() {
+			vec := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+
+			vec.Set(0, vecValLarge)
+			Expect(vec[0]).To(Equal(float64(vecValLarge)))
+
+			vec.Set(1, vecValSetLarge)
+			Expect(vec[1]).To(Equal(float64(vecValSetLarge)))
+
+			vec.Set(2, vecValSetDecimal)
+			Expect(vec[2]).To(Equal(vecValSetDecimal))
+		})
+	})
+})
+
+var _ = Describe("ResourceVectorMap", func() {
+	Describe("GetIndex", func() {
+		It("should return the correct index for known resource names", func() {
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			Expect(indexMap.GetIndex(resourceCPU)).To(Equal(0))
+			Expect(indexMap.GetIndex(resourceMemory)).To(Equal(1))
+			Expect(indexMap.GetIndex(commonconstants.GpuResource)).To(Equal(2))
+			Expect(indexMap.GetIndex("not-exist")).To(Equal(-1))
+			Expect(indexMap.GetIndex("")).To(Equal(-1))
+		})
+	})
+})
+
+var _ = Describe("NewResourceVector", func() {
+	It("should create a vector of zeros with the correct length", func() {
+		indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+		vec := NewResourceVector(indexMap)
+
+		Expect(vec).To(HaveLen(4))
+		Expect(vec).To(Equal(ResourceVector{0, 0, 0, 0}))
+	})
+})
+
+var _ = Describe("BuildResourceVectorMap", func() {
+	It("should create a map with core resources in correct order", func() {
+		nodeResources := []v1.ResourceList{
+			{
+				v1.ResourceCPU:    *resource.NewMilliQuantity(cpuMedium, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(oneGiB, resource.DecimalSI),
+				v1.ResourceName(commonconstants.NvidiaGpuResource): *resource.NewQuantity(gpuTwo, resource.DecimalSI),
+			},
+		}
+
+		indexMap := BuildResourceVectorMap(nodeResources)
+
+		Expect(indexMap.Len()).To(Equal(4))
+		Expect(indexMap.ResourceAt(0)).To(Equal(resourceCPU))
+		Expect(indexMap.ResourceAt(1)).To(Equal(resourceMemory))
+		Expect(indexMap.ResourceAt(2)).To(Equal(commonconstants.GpuResource))
+		Expect(indexMap.ResourceAt(3)).To(Equal(string(v1.ResourcePods)))
+	})
+
+	It("should handle multiple nodes with different resource sets", func() {
+		nodeResources := []v1.ResourceList{
+			{
+				v1.ResourceCPU:                      *resource.NewMilliQuantity(cpuMedium, resource.DecimalSI),
+				v1.ResourceMemory:                   *resource.NewQuantity(oneGiB, resource.DecimalSI),
+				v1.ResourceName(customResourceResA): *resource.NewQuantity(customResourceQtyLarge, resource.DecimalSI),
+			},
+			{
+				v1.ResourceCPU:    *resource.NewMilliQuantity(cpuLarge, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(twoGiB, resource.DecimalSI),
+				v1.ResourceName(commonconstants.NvidiaGpuResource): *resource.NewQuantity(gpuTwo, resource.DecimalSI),
+				v1.ResourceName(customResourceResB):                *resource.NewQuantity(customResourceQtyMedium, resource.DecimalSI),
+			},
+		}
+
+		indexMap := BuildResourceVectorMap(nodeResources)
+
+		Expect(indexMap.GetIndex(resourceCPU)).To(BeNumerically(">=", 0))
+		Expect(indexMap.GetIndex(resourceMemory)).To(BeNumerically(">=", 0))
+		Expect(indexMap.GetIndex(commonconstants.GpuResource)).To(BeNumerically(">=", 0))
+		Expect(indexMap.GetIndex(customResourceResA)).To(BeNumerically(">=", 0))
+		Expect(indexMap.GetIndex(customResourceResB)).To(BeNumerically(">=", 0))
+	})
+
+	It("should include GPU resource even when not present in all nodes", func() {
+		nodeResources := []v1.ResourceList{
+			{
+				v1.ResourceCPU:    *resource.NewMilliQuantity(cpuMedium, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(oneGiB, resource.DecimalSI),
+			},
+		}
+
+		indexMap := BuildResourceVectorMap(nodeResources)
+
+		Expect(indexMap.GetIndex("gpu-memory")).To(Equal(-1))
+		Expect(indexMap.Len()).To(Equal(4))
+	})
+
+	It("should normalize non-nvidia GPU resources into generic gpu type", func() {
+		const amdGpuResource = "amd.com/gpu"
+
+		nodeResources := []v1.ResourceList{
+			{
+				v1.ResourceCPU:                  *resource.NewMilliQuantity(cpuMedium, resource.DecimalSI),
+				v1.ResourceMemory:               *resource.NewQuantity(oneGiB, resource.DecimalSI),
+				v1.ResourceName(amdGpuResource): *resource.NewQuantity(gpuTwo, resource.DecimalSI),
+			},
+		}
+
+		indexMap := BuildResourceVectorMap(nodeResources)
+
+		Expect(indexMap.GetIndex("gpu-memory")).To(Equal(-1))
+		Expect(indexMap.Len()).To(Equal(4))
+	})
+})
+
+var _ = Describe("Resource conversion", func() {
+	Describe("ToVector/FromVector", func() {
+		It("should convert Resource to vector and back", func() {
+			r := NewResource(cpuMedium, twoGiB, gpuTwo)
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			vec := r.ToVector(indexMap)
+
+			Expect(vec).To(HaveLen(4))
+			Expect(vec.Get(indexMap.GetIndex(resourceCPU))).To(Equal(float64(cpuMedium)))
+			Expect(vec.Get(indexMap.GetIndex(resourceMemory))).To(Equal(float64(twoGiB)))
+			Expect(vec.Get(indexMap.GetIndex(commonconstants.GpuResource))).To(Equal(float64(gpuTwo)))
+		})
+
+		It("should convert vector to Resource", func() {
+			vec := ResourceVector{cpuMedium, twoGiB, gpuTwo}
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			r := EmptyResource()
+			r.FromVector(vec, indexMap)
+
+			Expect(r.milliCpu).To(Equal(float64(cpuMedium)))
+			Expect(r.memory).To(Equal(float64(twoGiB)))
+			Expect(r.gpus).To(Equal(float64(gpuTwo)))
+		})
+
+		It("should support round-trip conversion", func() {
+			original := NewResource(cpuMedium, twoGiB, gpuTwo)
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			vec := original.ToVector(indexMap)
+			restored := EmptyResource()
+			restored.FromVector(vec, indexMap)
+
+			Expect(restored.milliCpu).To(Equal(original.milliCpu))
+			Expect(restored.memory).To(Equal(original.memory))
+			Expect(restored.gpus).To(Equal(original.gpus))
+		})
+	})
+
+	Describe("ResourceRequirements", func() {
+		It("should convert ResourceRequirements to vector", func() {
+			req := NewResourceRequirements(gpuTwo, cpuMedium, twoGiB)
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			vec := req.ToVector(indexMap)
+
+			Expect(vec).To(HaveLen(4))
+			Expect(vec.Get(indexMap.GetIndex(resourceCPU))).To(Equal(float64(cpuMedium)))
+			Expect(vec.Get(indexMap.GetIndex(resourceMemory))).To(Equal(float64(twoGiB)))
+			Expect(vec.Get(indexMap.GetIndex(commonconstants.GpuResource))).To(Equal(float64(gpuTwo)))
+		})
+
+		It("should convert vector to ResourceRequirements", func() {
+			vec := ResourceVector{cpuMedium, twoGiB, gpuTwo}
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			req := EmptyResourceRequirements()
+			req.FromVector(vec, indexMap)
+
+			Expect(req.milliCpu).To(Equal(float64(cpuMedium)))
+			Expect(req.memory).To(Equal(float64(twoGiB)))
+			Expect(req.GPUs()).To(Equal(float64(gpuTwo)))
+		})
+	})
+
+	Describe("ToResourceQuantities", func() {
+		It("should convert vector back to quantities map", func() {
+			vec := ResourceVector{cpuMedium, twoGiB, gpuTwo}
+			indexMap := buildTestVectorMap(resourceCPU, resourceMemory, commonconstants.NvidiaGpuResource)
+
+			rq := vec.ToResourceQuantities(indexMap)
+
+			Expect(rq[resourceCPU]).To(Equal(float64(cpuMedium)))
+			Expect(rq[resourceMemory]).To(Equal(float64(twoGiB)))
+			Expect(rq[commonconstants.GpuResource]).To(Equal(float64(gpuTwo)))
+		})
+	})
+})


### PR DESCRIPTION
## Description

Introduces ResourceVector ([]float64) and ResourceVectorMap types as the foundation for vectorized resource accounting in the scheduler, as described in the [vectorization design doc](https://github.com/NVIDIA/KAI-Scheduler/blob/main/docs/developer/designs/vectorizing-resources/README.md)

## Checklist


- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)