### PR TITLE
refactor(scheduler): add vector fields to NodeInfo, PodInfo, PodGroup…

### DIFF
--- a/pkg/scheduler/actions/common/minimal_job_comparison_test.go
+++ b/pkg/scheduler/actions/common/minimal_job_comparison_test.go
@@ -392,7 +392,7 @@ func JobFromPodSignatureData(jobTestInfo []podTestsInfo) *podgroup_info.PodGroup
 				map[string]string{
 					commonconstants.PodGroupAnnotationForPod: "test",
 				},
-			))
+			), nil, resource_info.NewResourceVectorMap())
 	}
 	return podgroup_info.NewPodGroupInfo(
 		"test", tasks...,

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus_test.go
@@ -362,7 +362,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 					[]*pod_info.PodInfo{},
 					[]*podgroup_info.PodGroupInfo{},
 				),
@@ -399,7 +399,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 					[]*pod_info.PodInfo{},
 					[]*podgroup_info.PodGroupInfo{},
 				),
@@ -441,7 +441,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 					[]*pod_info.PodInfo{},
 					[]*podgroup_info.PodGroupInfo{},
 				),
@@ -481,7 +481,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 					[]*pod_info.PodInfo{},
 					[]*podgroup_info.PodGroupInfo{},
 				),
@@ -509,11 +509,13 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 				nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
 				nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
 
-				node1 := node_info.NewNodeInfo(&v1.Node{
+				n1 := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "n1",
 					},
-				}, nodePodAffinityInfo)
+				}
+				vectorMap1 := resource_info.BuildResourceVectorMap([]v1.ResourceList{n1.Status.Allocatable})
+				node1 := node_info.NewNodeInfo(n1, nodePodAffinityInfo, vectorMap1)
 
 				potentialVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -539,7 +541,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				node1.AddTask(potentialVictim1)
 
@@ -566,7 +568,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 									},
 								},
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						[]*pod_info.PodInfo{potentialVictim1},
 						[]*podgroup_info.PodGroupInfo{},
 					),
@@ -596,11 +598,13 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 				nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
 				nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
 
-				node1 := node_info.NewNodeInfo(&v1.Node{
+				n1 := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "n1",
 					},
-				}, nodePodAffinityInfo)
+				}
+				vectorMap1 := resource_info.BuildResourceVectorMap([]v1.ResourceList{n1.Status.Allocatable})
+				node1 := node_info.NewNodeInfo(n1, nodePodAffinityInfo, vectorMap1)
 
 				potentialVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -626,7 +630,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				node1.AddTask(potentialVictim1)
 
@@ -653,7 +657,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 									},
 								},
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						[]*pod_info.PodInfo{potentialVictim1},
 						[]*podgroup_info.PodGroupInfo{},
 					),
@@ -680,11 +684,13 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 				nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
 				nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
 
-				node1 := node_info.NewNodeInfo(&v1.Node{
+				n1 := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "n1",
 					},
-				}, nodePodAffinityInfo)
+				}
+				vectorMap1 := resource_info.BuildResourceVectorMap([]v1.ResourceList{n1.Status.Allocatable})
+				node1 := node_info.NewNodeInfo(n1, nodePodAffinityInfo, vectorMap1)
 
 				recordedVictim := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -710,7 +716,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				node1.AddTask(recordedVictim)
 
@@ -737,7 +743,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 									},
 								},
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						[]*pod_info.PodInfo{},
 						[]*podgroup_info.PodGroupInfo{podgroup_info.NewPodGroupInfo("rv1pg", recordedVictim)},
 					),
@@ -784,7 +790,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 					[]*pod_info.PodInfo{},
 					[]*podgroup_info.PodGroupInfo{podgroup_info.NewPodGroupInfo("rv1pg", pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -807,7 +813,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					}))},
+					}, nil, resource_info.NewResourceVectorMap()))},
 				),
 				isFirstScenario: false,
 			},
@@ -851,7 +857,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 					[]*pod_info.PodInfo{},
 					[]*podgroup_info.PodGroupInfo{podgroup_info.NewPodGroupInfo("rv1pg", pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -874,7 +880,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 								},
 							},
 						},
-					}))},
+					}, nil, resource_info.NewResourceVectorMap()))},
 				),
 				isFirstScenario: false,
 			},
@@ -976,11 +982,13 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 				nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
 				nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
 
-				node1 := node_info.NewNodeInfo(&v1.Node{
+				n1 := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "n1",
 					},
-				}, nodePodAffinityInfo)
+				}
+				vectorMap1 := resource_info.BuildResourceVectorMap([]v1.ResourceList{n1.Status.Allocatable})
+				node1 := node_info.NewNodeInfo(n1, nodePodAffinityInfo, vectorMap1)
 
 				potentialVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1006,7 +1014,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				recordedVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1032,7 +1040,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				node1.AddTask(potentialVictim1)
 				node1.AddTask(recordedVictim1)
@@ -1062,7 +1070,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									UID:       "uid5",
@@ -1080,7 +1088,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									UID:       "uid6",
@@ -1098,7 +1106,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						[]*pod_info.PodInfo{
 							potentialVictim1,
@@ -1128,11 +1136,13 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 				nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
 				nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
 
-				node1 := node_info.NewNodeInfo(&v1.Node{
+				n1 := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "n1",
 					},
-				}, nodePodAffinityInfo)
+				}
+				vectorMap1 := resource_info.BuildResourceVectorMap([]v1.ResourceList{n1.Status.Allocatable})
+				node1 := node_info.NewNodeInfo(n1, nodePodAffinityInfo, vectorMap1)
 
 				potentialVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1158,7 +1168,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				recordedVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1184,7 +1194,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				node1.AddTask(potentialVictim1)
 				node1.AddTask(recordedVictim1)
@@ -1214,7 +1224,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									UID:       "uid5",
@@ -1232,7 +1242,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									UID:       "uid6",
@@ -1250,7 +1260,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						[]*pod_info.PodInfo{
 							potentialVictim1,
@@ -1280,14 +1290,16 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 				nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
 				nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
 
-				node1 := node_info.NewNodeInfo(&v1.Node{
+				n1 := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "n1",
 						Labels: map[string]string{
 							commonconstants.NvidiaGpuMemory: "100",
 						},
 					},
-				}, nodePodAffinityInfo)
+				}
+				vectorMap1 := resource_info.BuildResourceVectorMap([]v1.ResourceList{n1.Status.Allocatable})
+				node1 := node_info.NewNodeInfo(n1, nodePodAffinityInfo, vectorMap1)
 
 				potentialVictim1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1308,7 +1320,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				node1.AddTask(potentialVictim1)
 
@@ -1336,7 +1348,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 										},
 									},
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						[]*pod_info.PodInfo{potentialVictim1},
 						[]*podgroup_info.PodGroupInfo{},

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/node_affinities/node_affinities_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/node_affinities/node_affinities_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
 	k8splugins "github.com/NVIDIA/KAI-scheduler/pkg/scheduler/k8s_internal/plugins"
@@ -70,7 +71,7 @@ func newNode(name string, labels map[string]string) *v1.Node {
 }
 
 func newNodeInfo(node *v1.Node) *node_info.NodeInfo {
-	return node_info.NewNodeInfo(node, nil)
+	return node_info.NewNodeInfo(node, nil, resource_info.NewResourceVectorMap())
 }
 
 func podWithNodeSelector(uid, name, jobID string, selector map[string]string) *pod_info.PodInfo {
@@ -86,7 +87,7 @@ func podWithNodeSelector(uid, name, jobID string, selector map[string]string) *p
 		Spec: v1.PodSpec{
 			NodeSelector: selector,
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }
 
 func podWithNodeAffinity(uid, name, jobID, labelKey, labelValue string) *pod_info.PodInfo {
@@ -118,7 +119,7 @@ func podWithNodeAffinity(uid, name, jobID, labelKey, labelValue string) *pod_inf
 				},
 			},
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }
 
 func podWithNodeAffinityMatchFields(uid, name, jobID, targetNodeName string) *pod_info.PodInfo {
@@ -150,7 +151,7 @@ func podWithNodeAffinityMatchFields(uid, name, jobID, targetNodeName string) *po
 				},
 			},
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }
 
 func podWithPreferredNodeAffinityOnly(uid, name, jobID, labelKey, labelValue string, weight int32) *pod_info.PodInfo {
@@ -183,7 +184,7 @@ func podWithPreferredNodeAffinityOnly(uid, name, jobID, labelKey, labelValue str
 				},
 			},
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }
 
 func podWithoutAffinity(uid, name, jobID string) *pod_info.PodInfo {
@@ -197,7 +198,7 @@ func podWithoutAffinity(uid, name, jobID string) *pod_info.PodInfo {
 			},
 		},
 		Spec: v1.PodSpec{},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }
 
 func victimPodOnNode(uid, name, jobID, nodeName string) *pod_info.PodInfo {
@@ -213,7 +214,7 @@ func victimPodOnNode(uid, name, jobID, nodeName string) *pod_info.PodInfo {
 		Spec: v1.PodSpec{
 			NodeName: nodeName,
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }
 
 func TestNewNodeAffinitiesFilter_NilScenario(t *testing.T) {

--- a/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
 )
 
@@ -57,7 +58,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{},
 			},
@@ -75,7 +76,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				victimsJobsTaskGroups: map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo{
 					"pg1": {
@@ -104,7 +105,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{},
 			},
@@ -119,7 +120,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			expected: expected{
@@ -133,7 +134,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "name2",
@@ -143,7 +144,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				victimsJobsTaskGroups: map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo{
 					"pg1": {
@@ -175,7 +176,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
@@ -187,7 +188,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 				},
 			},
 			args: args{
@@ -204,7 +205,7 @@ func TestPodSimpleScenario_AddPotentialVictimsTasks(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				victimsJobsTaskGroups: map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo{
 					"pg1": {
@@ -271,7 +272,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name2",
@@ -281,7 +282,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -295,7 +296,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
@@ -307,7 +308,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 				},
 			},
 			args: args{
@@ -320,7 +321,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 						},
 					},
 					Spec: v1.PodSpec{},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				tasks: make([]*pod_info.PodInfo, 0),
 			},
 			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
@@ -332,7 +333,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			})),
+			}, nil, resource_info.NewResourceVectorMap())),
 		},
 		{
 			name: "Task not given to the scenario",
@@ -348,7 +349,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name2",
@@ -358,7 +359,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -372,7 +373,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
@@ -384,7 +385,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 				},
 			},
 			args: args{
@@ -397,7 +398,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 						},
 					},
 					Spec: v1.PodSpec{},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				tasks: make([]*pod_info.PodInfo, 0),
 			},
 			want: nil,
@@ -416,7 +417,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name2",
@@ -426,7 +427,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -440,7 +441,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				recordedVictimsJobs: []*podgroup_info.PodGroupInfo{
 					podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
@@ -452,7 +453,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					})),
+					}, nil, resource_info.NewResourceVectorMap())),
 				},
 			},
 			args: args{
@@ -465,7 +466,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 						},
 					},
 					Spec: v1.PodSpec{},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				tasks: []*pod_info.PodInfo{
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -476,7 +477,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
@@ -488,7 +489,7 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			})),
+			}, nil, resource_info.NewResourceVectorMap())),
 		},
 	}
 	for _, tt := range tests {
@@ -533,7 +534,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name2",
@@ -543,7 +544,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -557,7 +558,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			args: args{},
@@ -570,7 +571,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			})),
+			}, nil, resource_info.NewResourceVectorMap())),
 		},
 		{
 			name: "return latest task from AddPotentialVictimsTasks",
@@ -586,7 +587,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						}), pod_info.NewTaskInfo(&v1.Pod{
+						}, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name2",
 								Namespace: "n1",
@@ -595,7 +596,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name2",
@@ -605,7 +606,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 								},
 							},
 							Spec: v1.PodSpec{},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -619,7 +620,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			args: args{
@@ -633,7 +634,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 							},
 						},
 						Spec: v1.PodSpec{},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
@@ -645,7 +646,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			}), pod_info.NewTaskInfo(&v1.Pod{
+			}, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name2",
 					Namespace: "n1",
@@ -654,7 +655,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			})),
+			}, nil, resource_info.NewResourceVectorMap())),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
 )
 
@@ -55,7 +56,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      "name2",
@@ -70,7 +71,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +87,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 							Status: v1.PodStatus{
 								Phase: v1.PodRunning,
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -105,7 +106,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "name2",
@@ -120,7 +121,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			args: args{
@@ -142,7 +143,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name2",
@@ -157,7 +158,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 			},
 		},
 		{
@@ -180,7 +181,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      "name2",
@@ -195,7 +196,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -211,7 +212,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 							Status: v1.PodStatus{
 								Phase: v1.PodRunning,
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -230,7 +231,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "name2",
@@ -245,7 +246,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			args: args{
@@ -274,7 +275,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      "name2",
@@ -289,7 +290,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -305,7 +306,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 							Status: v1.PodStatus{
 								Phase: v1.PodRunning,
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -324,7 +325,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 					pod_info.NewTaskInfo(&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "name2",
@@ -339,7 +340,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			args: args{
@@ -361,7 +362,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name2",
@@ -376,7 +377,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 			},
 		},
 		{
@@ -399,7 +400,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 							pod_info.NewTaskInfo(&v1.Pod{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      "name2",
@@ -414,7 +415,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 								Status: v1.PodStatus{
 									Phase: v1.PodRunning,
 								},
-							}),
+							}, nil, resource_info.NewResourceVectorMap()),
 						),
 						"pg2": podgroup_info.NewPodGroupInfo("pg2", pod_info.NewTaskInfo(&v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -430,7 +431,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 							Status: v1.PodStatus{
 								Phase: v1.PodRunning,
 							},
-						})),
+						}, nil, resource_info.NewResourceVectorMap())),
 					}},
 				},
 				pendingTasksAsJob: podgroup_info.NewPodGroupInfo("123"),
@@ -449,7 +450,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
 			args: args{
@@ -468,7 +469,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 				},
 				nodeNames: []string{"node1"},
 			},
@@ -487,7 +488,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "name2",
@@ -502,7 +503,7 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 					Status: v1.PodStatus{
 						Phase: v1.PodRunning,
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 			},
 		},
 	}

--- a/pkg/scheduler/api/cluster_info.go
+++ b/pkg/scheduler/api/cluster_info.go
@@ -32,6 +32,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/storagecapacity_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/storageclaim_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/storageclass_info"
@@ -57,6 +58,9 @@ type ClusterInfo struct {
 	Topologies                  []*kaiv1alpha1.Topology
 
 	MinNodeGPUMemory int64
+
+	// Shared resource vector index map for this scheduling cycle
+	ResourceVectorMap *resource_info.ResourceVectorMap
 }
 
 func NewClusterInfo() *ClusterInfo {

--- a/pkg/scheduler/api/node_info/node_info_benchmark_test.go
+++ b/pkg/scheduler/api/node_info/node_info_benchmark_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_affinity"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils"
 )
 
@@ -213,7 +214,7 @@ func createTaskBestEffort() *pod_info.PodInfo {
 			Phase: v1.PodPending,
 		},
 	}
-	return pod_info.NewTaskInfo(pod)
+	return pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 }
 
 func createTaskWithGPU() *pod_info.PodInfo {
@@ -237,7 +238,7 @@ func createTaskWithGPU() *pod_info.PodInfo {
 			Phase: v1.PodPending,
 		},
 	}
-	return pod_info.NewTaskInfo(pod)
+	return pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 }
 
 func createTaskFractionalGPU() *pod_info.PodInfo {
@@ -264,7 +265,7 @@ func createTaskFractionalGPU() *pod_info.PodInfo {
 			Phase: v1.PodPending,
 		},
 	}
-	return pod_info.NewTaskInfo(pod)
+	return pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 }
 
 func createTaskMIG() *pod_info.PodInfo {
@@ -288,7 +289,7 @@ func createTaskMIG() *pod_info.PodInfo {
 			Phase: v1.PodPending,
 		},
 	}
-	return pod_info.NewTaskInfo(pod)
+	return pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 }
 
 func createTaskGPUMemory() *pod_info.PodInfo {
@@ -316,7 +317,7 @@ func createTaskGPUMemory() *pod_info.PodInfo {
 			Phase: v1.PodPending,
 		},
 	}
-	return pod_info.NewTaskInfo(pod)
+	return pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 }
 
 func createTaskWithCustomResources(numResources int) *pod_info.PodInfo {
@@ -347,7 +348,7 @@ func createTaskWithCustomResources(numResources int) *pod_info.PodInfo {
 			Phase: v1.PodPending,
 		},
 	}
-	return pod_info.NewTaskInfo(pod)
+	return pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 }
 
 func getCustomResourceNames(count int) []string {
@@ -373,5 +374,9 @@ func buildNodeInfoFromK8sNode(k8sNode *v1.Node, ctrl *gomock.Controller) *node_i
 	mockPodAffinity := pod_affinity.NewMockNodePodAffinityInfo(ctrl)
 	mockPodAffinity.EXPECT().AddPod(gomock.Any()).Times(0)
 	mockPodAffinity.EXPECT().RemovePod(gomock.Any()).Times(0)
-	return node_info.NewNodeInfo(k8sNode, mockPodAffinity)
+	vectorMap := resource_info.NewResourceVectorMap()
+	for resourceName := range k8sNode.Status.Allocatable {
+		vectorMap.AddResource(string(resourceName))
+	}
+	return node_info.NewNodeInfo(k8sNode, mockPodAffinity, vectorMap)
 }

--- a/pkg/scheduler/api/pod_info/pod_info_benchmark_test.go
+++ b/pkg/scheduler/api/pod_info/pod_info_benchmark_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 func BenchmarkPodInfoClone_Minimal(b *testing.B) {
@@ -71,7 +72,7 @@ func createMinimalPodInfo() *PodInfo {
 		},
 	}
 
-	podInfo := NewTaskInfo(pod)
+	podInfo := NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 	return podInfo
 }
 
@@ -104,7 +105,7 @@ func createPodInfoWithGPU() *PodInfo {
 		},
 	}
 
-	podInfo := NewTaskInfo(pod)
+	podInfo := NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 	podInfo.ResourceRequestType = RequestTypeGpuMemory
 	return podInfo
 }
@@ -141,7 +142,7 @@ func createPodInfoWithMultipleGPUs() *PodInfo {
 		},
 	}
 
-	podInfo := NewTaskInfo(pod)
+	podInfo := NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 	podInfo.AcceptedResource = podInfo.ResReq.Clone()
 	return podInfo
 }

--- a/pkg/scheduler/api/pod_info/scheduling_constraints_signature_test.go
+++ b/pkg/scheduler/api/pod_info/scheduling_constraints_signature_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/storageclaim_info"
 )
 
@@ -108,7 +109,7 @@ func TestPodSchedulingConstraintsSignature(t *testing.T) {
 	pod.Spec.Priority = pointer.Int32(6)
 	pod.Spec.PriorityClassName = "priority-class-1"
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	storageClaimID := storageclaim_info.NewKey("test-namespace", "claim-1")
 	podInfo.storageClaims = map[storageclaim_info.Key]*storageclaim_info.StorageClaimInfo{
 		storageClaimID: {
@@ -128,11 +129,11 @@ func TestPodSchedulingConstraintsSignature(t *testing.T) {
 func TestPodSchedulingConstraintsSignature_NodeSelector(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.NodeSelector = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected node selector to affect signature, got same")
 }
@@ -140,11 +141,11 @@ func TestPodSchedulingConstraintsSignature_NodeSelector(t *testing.T) {
 func TestPodSchedulingConstraintsSignature_Affinity(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.Affinity = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected affinity to affect signature, got same")
 }
@@ -152,11 +153,11 @@ func TestPodSchedulingConstraintsSignature_Affinity(t *testing.T) {
 func TestPodSchedulingConstraintsSignature_Tolerations(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.Tolerations = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected tolerations to affect signature, got same")
 }
@@ -164,11 +165,11 @@ func TestPodSchedulingConstraintsSignature_Tolerations(t *testing.T) {
 func TestPodSchedulingConstraintsSignature_Priority(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.Priority = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected priority to affect signature, got same")
 }
@@ -176,11 +177,11 @@ func TestPodSchedulingConstraintsSignature_Priority(t *testing.T) {
 func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.TopologySpreadConstraints = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected topology spread constraints to affect signature, got same")
 }
@@ -188,11 +189,11 @@ func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints(t *testing.
 func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints_MinDomainsNil(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.TopologySpreadConstraints[0].MinDomains = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected topology spread constraints to affect signature, got same")
 }
@@ -200,11 +201,11 @@ func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints_MinDomainsN
 func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints_nodeAffinityPolicyNil(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.TopologySpreadConstraints[0].NodeAffinityPolicy = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected topology spread constraints to affect signature, got same")
 }
@@ -212,11 +213,11 @@ func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints_nodeAffinit
 func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints_nodeTaintsPolicyNil(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.TopologySpreadConstraints[0].NodeTaintsPolicy = nil
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected topology spread constraints to affect signature, got same")
 }
@@ -224,11 +225,11 @@ func TestPodSchedulingConstraintsSignature_TopologySpreadConstraints_nodeTaintsP
 func TestPodSchedulingConstraintsSignature_ContainerPorts(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.Containers[0].Ports[0].HostPort = rand.Int31()
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected container ports to affect signature, got same")
 }
@@ -236,11 +237,11 @@ func TestPodSchedulingConstraintsSignature_ContainerPorts(t *testing.T) {
 func TestPodSchedulingConstraintsSignature_InitContainerPorts(t *testing.T) {
 	pod := getRandomPod()
 
-	podInfo := NewTaskInfo(&pod)
+	podInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	key := podInfo.GetSchedulingConstraintsSignature()
 
 	pod.Spec.InitContainers[0].Ports[0].HostPort = rand.Int31()
-	newPodInfo := NewTaskInfo(&pod)
+	newPodInfo := NewTaskInfo(&pod, nil, resource_info.NewResourceVectorMap())
 	newKey := newPodInfo.GetSchedulingConstraintsSignature()
 	assert.NotEqualf(t, key, newKey, "Expected init container ports to affect signature, got same")
 }

--- a/pkg/scheduler/api/podgroup_info/allocation_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info_test.go
@@ -23,7 +23,7 @@ func simpleTask(name string, subGroupName string, status pod_status.PodStatus) *
 		common_info.BuildResourceList("1", "1G"),
 		nil, nil, nil,
 	)
-	info := pod_info.NewTaskInfo(pod)
+	info := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 	info.Status = status
 	info.SubGroupName = subGroupName
 	return info
@@ -611,7 +611,7 @@ func Test_getNumOfAllocatedTasks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pg := NewPodGroupInfo("u1")
 			for i, pod := range tt.args.pods {
-				pi := pod_info.NewTaskInfo(pod)
+				pi := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 				pg.AddTaskInfo(pi)
 
 				if tt.args.overridingStatus != nil {

--- a/pkg/scheduler/api/podgroup_info/job_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/job_info_test.go
@@ -33,11 +33,22 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/topology_info"
 )
 
 func jobInfoEqual(l, r *PodGroupInfo) bool {
-	if !reflect.DeepEqual(l, r) {
+	// Create shallow copies to avoid modifying the original objects
+	lCopy := *l
+	rCopy := *r
+
+	// Ignore vector fields for comparison (they're tested separately)
+	lCopy.AllocatedVector = nil
+	rCopy.AllocatedVector = nil
+	lCopy.VectorMap = nil
+	rCopy.VectorMap = nil
+
+	if !reflect.DeepEqual(lCopy, rCopy) {
 		return false
 	}
 
@@ -55,13 +66,13 @@ func TestAddTaskInfo(t *testing.T) {
 		commonconstants.PodGroupAnnotationForPod:    common_info.FakePogGroupId,
 	}
 	case01_pod1 := common_info.BuildPod(case01_ns, "p1", "", v1.PodPending, common_info.BuildResourceList("1000m", "1G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), podAnnotations)
-	case01_task1 := pod_info.NewTaskInfo(case01_pod1)
+	case01_task1 := pod_info.NewTaskInfo(case01_pod1, nil, resource_info.NewResourceVectorMap())
 	case01_pod2 := common_info.BuildPod(case01_ns, "p2", "n1", v1.PodRunning, common_info.BuildResourceList("2000m", "2G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), podAnnotations)
-	case01_task2 := pod_info.NewTaskInfo(case01_pod2)
+	case01_task2 := pod_info.NewTaskInfo(case01_pod2, nil, resource_info.NewResourceVectorMap())
 	case01_pod3 := common_info.BuildPod(case01_ns, "p3", "n1", v1.PodPending, common_info.BuildResourceList("1000m", "1G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), podAnnotations)
-	case01_task3 := pod_info.NewTaskInfo(case01_pod3)
+	case01_task3 := pod_info.NewTaskInfo(case01_pod3, nil, resource_info.NewResourceVectorMap())
 	case01_pod4 := common_info.BuildPod(case01_ns, "p4", "n1", v1.PodPending, common_info.BuildResourceList("1000m", "1G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), podAnnotations)
-	case01_task4 := pod_info.NewTaskInfo(case01_pod4)
+	case01_task4 := pod_info.NewTaskInfo(case01_pod4, nil, resource_info.NewResourceVectorMap())
 
 	subGroupSet := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
 	defaultSubGroup := subgroup_info.NewPodSet(DefaultSubGroup, 1, nil).WithPodInfos(pod_info.PodsMap{
@@ -110,7 +121,7 @@ func TestAddTaskInfo(t *testing.T) {
 		ps := NewPodGroupInfo(test.uid)
 
 		for _, pod := range test.pods {
-			pi := pod_info.NewTaskInfo(pod)
+			pi := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 			ps.AddTaskInfo(pi)
 		}
 
@@ -130,22 +141,22 @@ func TestDeleteTaskInfo(t *testing.T) {
 
 	case01_owner := common_info.BuildOwnerReference(string(case01_uid))
 	case01_pod1 := common_info.BuildPod(case01_ns, "p1", "", v1.PodPending, common_info.BuildResourceList("1000m", "1G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), pendingPodAnnotations)
-	case01_task1 := pod_info.NewTaskInfo(case01_pod1)
+	case01_task1 := pod_info.NewTaskInfo(case01_pod1, nil, resource_info.NewResourceVectorMap())
 	case01_pod2 := common_info.BuildPod(case01_ns, "p2", "n1", v1.PodRunning, common_info.BuildResourceList("2000m", "2G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), runningPodAnnotations)
-	case01_task2 := pod_info.NewTaskInfo(case01_pod2)
+	case01_task2 := pod_info.NewTaskInfo(case01_pod2, nil, resource_info.NewResourceVectorMap())
 	case01_pod3 := common_info.BuildPod(case01_ns, "p3", "n1", v1.PodRunning, common_info.BuildResourceList("3000m", "3G"), []metav1.OwnerReference{case01_owner}, make(map[string]string), runningPodAnnotations)
-	case01_task3 := pod_info.NewTaskInfo(case01_pod3)
+	case01_task3 := pod_info.NewTaskInfo(case01_pod3, nil, resource_info.NewResourceVectorMap())
 	// case2
 	case02_uid := common_info.PodGroupID("owner2")
 	case02_ns := "c2"
 
 	case02_owner := common_info.BuildOwnerReference(string(case02_uid))
 	case02_pod1 := common_info.BuildPod(case02_ns, "p1", "", v1.PodPending, common_info.BuildResourceList("1000m", "1G"), []metav1.OwnerReference{case02_owner}, make(map[string]string), pendingPodAnnotations)
-	case02_task1 := pod_info.NewTaskInfo(case02_pod1)
+	case02_task1 := pod_info.NewTaskInfo(case02_pod1, nil, resource_info.NewResourceVectorMap())
 	case02_pod2 := common_info.BuildPod(case02_ns, "p2", "n1", v1.PodPending, common_info.BuildResourceList("2000m", "2G"), []metav1.OwnerReference{case02_owner}, make(map[string]string), pendingPodAnnotations)
-	case02_task2 := pod_info.NewTaskInfo(case02_pod2)
+	case02_task2 := pod_info.NewTaskInfo(case02_pod2, nil, resource_info.NewResourceVectorMap())
 	case02_pod3 := common_info.BuildPod(case02_ns, "p3", "n1", v1.PodRunning, common_info.BuildResourceList("3000m", "3G"), []metav1.OwnerReference{case02_owner}, make(map[string]string), runningPodAnnotations)
-	case02_task3 := pod_info.NewTaskInfo(case02_pod3)
+	case02_task3 := pod_info.NewTaskInfo(case02_pod3, nil, resource_info.NewResourceVectorMap())
 
 	tests := []struct {
 		name     string
@@ -224,12 +235,12 @@ func TestDeleteTaskInfo(t *testing.T) {
 		ps := NewPodGroupInfo(test.uid)
 
 		for _, pod := range test.pods {
-			pi := pod_info.NewTaskInfo(pod)
+			pi := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 			ps.AddTaskInfo(pi)
 		}
 
 		for _, pod := range test.rmPods {
-			pi := pod_info.NewTaskInfo(pod)
+			pi := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 			//nolint:golint,errcheck
 			ps.resetTaskState(pi)
 		}
@@ -264,7 +275,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}})),
+						}}, nil, resource_info.NewResourceVectorMap())),
 			expected: 1,
 		},
 		{
@@ -279,7 +290,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodSucceeded,
-						}})),
+						}}, nil, resource_info.NewResourceVectorMap())),
 			expected: 0,
 		},
 		{
@@ -294,7 +305,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -304,7 +315,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -314,7 +325,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodFailed,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 			),
 			expected: 2,
 		},
@@ -330,7 +341,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -340,7 +351,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -350,7 +361,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodFailed,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -368,7 +379,7 @@ func TestPodGroupInfo_GetNumAliveTasks(t *testing.T) {
 								},
 							},
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 			),
 			expected: 3,
 		},
@@ -402,7 +413,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}})),
+						}}, nil, resource_info.NewResourceVectorMap())),
 			minAvailable: ptr.To(int32(1)),
 			expected:     true,
 		},
@@ -427,6 +438,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 							},
 						},
 					},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 			),
 			minAvailable: ptr.To(int32(1)),
@@ -444,7 +456,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}})),
+						}}, nil, resource_info.NewResourceVectorMap())),
 			minAvailable: ptr.To(int32(2)),
 			expected:     false,
 		},
@@ -461,6 +473,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
 						}},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
@@ -472,6 +485,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
 						}},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
@@ -490,6 +504,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
 						}},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 			),
 			minAvailable: ptr.To(int32(2)),
@@ -508,6 +523,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
 						}},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
@@ -519,6 +535,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
 						}},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
@@ -537,6 +554,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
 						}},
+					nil, resource_info.NewResourceVectorMap(),
 				),
 			),
 			minAvailable: ptr.To(int32(3)),
@@ -559,6 +577,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 							"222": pod_info.NewTaskInfo(
 								&v1.Pod{
@@ -570,6 +589,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 					"sb-2": subgroup_info.NewPodSet("sb-2", 1, nil).
@@ -584,6 +604,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 				},
@@ -607,6 +628,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 							"222": pod_info.NewTaskInfo(
 								&v1.Pod{
@@ -618,6 +640,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 					"sb-2": subgroup_info.NewPodSet("sb-2", 1, nil).
@@ -632,6 +655,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodRunning,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 				},
@@ -655,6 +679,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 							"222": pod_info.NewTaskInfo(
 								&v1.Pod{
@@ -666,6 +691,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 							"333": pod_info.NewTaskInfo(
 								&v1.Pod{
@@ -677,6 +703,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 					"sb-2": subgroup_info.NewPodSet("sb-2", 1, nil).
@@ -691,6 +718,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 				},
@@ -714,6 +742,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 					"sb-2": subgroup_info.NewPodSet("sb-2", 1, nil).
@@ -728,6 +757,7 @@ func TestPodGroupInfo_IsReadyForScheduling(t *testing.T) {
 									Status: v1.PodStatus{
 										Phase: v1.PodPending,
 									}},
+								nil, resource_info.NewResourceVectorMap(),
 							),
 						}),
 				},
@@ -771,7 +801,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}})),
+						}}, nil, resource_info.NewResourceVectorMap())),
 			expected: 1,
 		},
 		{
@@ -786,7 +816,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
-						}})),
+						}}, nil, resource_info.NewResourceVectorMap())),
 			expected: 0,
 		},
 		{
@@ -801,7 +831,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -811,7 +841,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -821,7 +851,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodFailed,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 			),
 			expected: 1,
 		},
@@ -837,7 +867,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodPending,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -847,7 +877,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 						},
 						Status: v1.PodStatus{
 							Phase: v1.PodRunning,
-						}}),
+						}}, nil, resource_info.NewResourceVectorMap()),
 				pod_info.NewTaskInfo(
 					&v1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -865,7 +895,7 @@ func TestPodGroupInfo_GetNumPendingTasks(t *testing.T) {
 								},
 							},
 						},
-					}),
+					}, nil, resource_info.NewResourceVectorMap()),
 			),
 			expected: 1,
 		},
@@ -890,7 +920,7 @@ func TestPodGroupInfo_GetSchedulingConstraintsSignature(t *testing.T) {
 				Namespace: "ns",
 			},
 			Status: v1.PodStatus{Phase: v1.PodPending},
-		})
+		}, nil, resource_info.NewResourceVectorMap())
 	}
 
 	// Helper function to create a running (allocated) pod task
@@ -903,7 +933,7 @@ func TestPodGroupInfo_GetSchedulingConstraintsSignature(t *testing.T) {
 			},
 			Spec:   v1.PodSpec{NodeName: "node-1"},
 			Status: v1.PodStatus{Phase: v1.PodRunning},
-		})
+		}, nil, resource_info.NewResourceVectorMap())
 	}
 
 	tests := []struct {
@@ -1411,7 +1441,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 					},
 					Status: v1.PodStatus{Phase: v1.PodPending},
 				}
-				task := pod_info.NewTaskInfo(pod)
+				task := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 				pgi := NewPodGroupInfo("test-podgroup", task)
 				pgi.GetSubGroups()[DefaultSubGroup].SetMinAvailable(1)
 				return pgi
@@ -1437,8 +1467,8 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
 				}
-				task1 := pod_info.NewTaskInfo(pod1)
-				task2 := pod_info.NewTaskInfo(pod2)
+				task1 := pod_info.NewTaskInfo(pod1, nil, resource_info.NewResourceVectorMap())
+				task2 := pod_info.NewTaskInfo(pod2, nil, resource_info.NewResourceVectorMap())
 				pgi := NewPodGroupInfo("test-podgroup", task1, task2)
 				pgi.GetSubGroups()[DefaultSubGroup].SetMinAvailable(2)
 				return pgi
@@ -1456,7 +1486,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
 				}
-				task := pod_info.NewTaskInfo(pod)
+				task := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 				pgi := NewPodGroupInfo("test-podgroup", task)
 				pgi.GetSubGroups()[DefaultSubGroup].SetMinAvailable(2)
 				return pgi
@@ -1474,7 +1504,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
 				}
-				task := pod_info.NewTaskInfo(pod)
+				task := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 				pgi := NewPodGroupInfo("test-podgroup", task)
 				pgi.GetSubGroups()[DefaultSubGroup].SetMinAvailable(1)
 				return pgi
@@ -1502,7 +1532,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 						},
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				task2 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1514,7 +1544,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 						},
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				pgi.AddTaskInfo(task1)
 				pgi.AddTaskInfo(task2)
@@ -1545,7 +1575,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 						},
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				task2 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1557,7 +1587,7 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 						},
 					},
 					Status: v1.PodStatus{Phase: v1.PodRunning},
-				})
+				}, nil, resource_info.NewResourceVectorMap())
 
 				pgi.AddTaskInfo(task1)
 				pgi.AddTaskInfo(task2)

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -46,6 +46,7 @@ import (
 	fakeschedulingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/client/clientset/versioned/typed/scheduling/v1alpha2/fake"
 	schedulingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
 )
 
@@ -138,7 +139,7 @@ var _ = Describe("Cache", func() {
 					},
 				}
 
-				taskInfo := pod_info.NewTaskInfo(pod)
+				taskInfo := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 
 				err := cache.Bind(taskInfo, "node-1", map[string]string{})
 				Expect(err).To(HaveOccurred())

--- a/pkg/scheduler/cache/cluster_info/cluster_info_test.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info_test.go
@@ -481,11 +481,12 @@ func TestSnapshotNodes(t *testing.T) {
 			clusterPodAffinityInfo.EXPECT().AddNode(gomock.Any(), gomock.Any()).AnyTimes()
 
 			allPods, _ := clusterInfo.dataLister.ListPods()
-			nodes, _, err := clusterInfo.snapshotNodes(clusterPodAffinityInfo)
+			vectorMap := resource_info.NewResourceVectorMap()
+			nodes, _, err := clusterInfo.snapshotNodes(clusterPodAffinityInfo, vectorMap)
 			if err != nil {
 				assert.FailNow(t, fmt.Sprintf("SnapshotNode got error in test %s", t.Name()), err)
 			}
-			pods, err := clusterInfo.addTasksToNodes(allPods, existingPods, nodes, nil, nil)
+			pods, err := clusterInfo.addTasksToNodes(allPods, existingPods, nodes, nil, nil, vectorMap)
 
 			assert.Equal(t, len(test.resultNodes), len(nodes))
 			assert.Equal(t, test.resultPodsLen, len(pods))
@@ -1239,7 +1240,7 @@ func TestSnapshotPodGroups(t *testing.T) {
 		existingPods := map[common_info.PodID]*pod_info.PodInfo{}
 		podGroups, err := clusterInfo.snapshotPodGroups(
 			map[common_info.QueueID]*queue_info.QueueInfo{"queue-0": predefinedQueue},
-			existingPods)
+			existingPods, resource_info.NewResourceVectorMap())
 		if err != nil {
 			assert.FailNow(t, fmt.Sprintf("SnapshotNode got error in test %v", name), err)
 		}
@@ -1307,7 +1308,7 @@ func TestSnapshotPodGroups_QueueDoesNotExist_AddsJobFitError(t *testing.T) {
 	existingPods := map[common_info.PodID]*pod_info.PodInfo{}
 	podGroups, err := clusterInfo.snapshotPodGroups(
 		map[common_info.QueueID]*queue_info.QueueInfo{"queue-0": predefinedQueue},
-		existingPods)
+		existingPods, resource_info.NewResourceVectorMap())
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(podGroups), "Expected 1 podgroup even with missing queue")
@@ -2502,7 +2503,8 @@ func TestSnapshotNodesWithDRAGPUs(t *testing.T) {
 				clusterPodAffinityInfo: clusterPodAffinityInfo,
 			}
 
-			nodes, _, err := ci.snapshotNodes(clusterPodAffinityInfo)
+			vectorMap := resource_info.NewResourceVectorMap()
+			nodes, _, err := ci.snapshotNodes(clusterPodAffinityInfo, vectorMap)
 			assert.NoError(t, err)
 
 			for nodeName, expectedGPUs := range test.expectedDRAGPUs {

--- a/pkg/scheduler/cache/cluster_info/storage_test.go
+++ b/pkg/scheduler/cache/cluster_info/storage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/storagecapacity_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/storageclaim_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/constants/status"
@@ -83,7 +84,7 @@ func TestSetStorageObjects(t *testing.T) {
 		Status: v1.PodStatus{
 			Phase: status.Running,
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 
 	existingPods := map[common_info.PodID]*pod_info.PodInfo{
 		common_info.PodID("owner-pod-id"): podInfo,
@@ -184,7 +185,7 @@ func TestSetStorageObjectsMultiplePVCs(t *testing.T) {
 				Status: v1.PodStatus{
 					Phase: status.Running,
 				},
-			}),
+			}, nil, resource_info.NewResourceVectorMap()),
 	}
 
 	nodes := map[string]*node_info.NodeInfo{
@@ -290,7 +291,7 @@ func TestSetStorageObjects_ReleaseOwnedPVCs(t *testing.T) {
 				Status: v1.PodStatus{
 					Phase: status.Running,
 				},
-			}),
+			}, nil, resource_info.NewResourceVectorMap()),
 	}
 
 	nodes := map[string]*node_info.NodeInfo{

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
 )
 
@@ -546,7 +547,7 @@ func getPods(pods map[v1.PodPhase][]common_info.PodID) (podsInfos map[common_inf
 				},
 			}
 
-			podInfo := pod_info.NewTaskInfo(pod)
+			podInfo := pod_info.NewTaskInfo(pod, nil, resource_info.NewResourceVectorMap())
 
 			podsInfos[podInfo.UID] = podInfo
 			podsAsObjects = append(podsAsObjects, pod)

--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
@@ -606,7 +607,8 @@ func TestDefaultStatusUpdater_RecordJobStatusEvent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var podGroups []runtime.Object
-			jobInfos, _, _ := jobs_fake.BuildJobsAndTasksMaps([]*jobs_fake.TestJobBasic{&test.job})
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobInfos, _, _ := jobs_fake.BuildJobsAndTasksMaps([]*jobs_fake.TestJobBasic{&test.job}, vectorMap)
 			for _, job := range jobInfos {
 				podGroups = append(podGroups, job.PodGroup)
 			}

--- a/pkg/scheduler/cache/status_updater/pod_group_status_sync_test.go
+++ b/pkg/scheduler/cache/status_updater/pod_group_status_sync_test.go
@@ -25,6 +25,7 @@ import (
 	fakeschedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/client/clientset/versioned/typed/scheduling/v2alpha2/fake"
 	schedulingv2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/utils"
@@ -79,7 +80,8 @@ var _ = Describe("Status Updater - Pod Groups Syncing", func() {
 			})
 		}
 
-		jobInfos, _, _ := jobs_fake.BuildJobsAndTasksMaps(jobs)
+		vectorMap := resource_info.NewResourceVectorMap()
+		jobInfos, _, _ := jobs_fake.BuildJobsAndTasksMaps(jobs, vectorMap)
 		podGroupsOriginals = []*schedulingv2alpha2.PodGroup{}
 
 		for _, job := range jobInfos {

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -36,6 +36,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/k8s_internal"
@@ -451,6 +452,15 @@ func (ssn *Session) OverrideSchedulerName(name string) {
 
 func (ssn *Session) InternalK8sPlugins() *k8splugins.K8sPlugins {
 	return ssn.Cache.InternalK8sPlugins()
+}
+
+// ResourceVectorMap returns the shared vector index map for this scheduling cycle.
+// All vectors created during this cycle use the same map for consistent indexing.
+func (ssn *Session) ResourceVectorMap() *resource_info.ResourceVectorMap {
+	if ssn.ClusterInfo == nil {
+		return resource_info.NewResourceVectorMap()
+	}
+	return ssn.ClusterInfo.ResourceVectorMap
 }
 
 func sortNodesByScore(nodeScores map[float64][]*node_info.NodeInfo) []*node_info.NodeInfo {

--- a/pkg/scheduler/framework/statement_checkpoint_test.go
+++ b/pkg/scheduler/framework/statement_checkpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 
@@ -193,8 +194,9 @@ func TestStatement_Checkpoint(t *testing.T) {
 				},
 			},
 		}
-		jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(clusterTopology.Jobs)
-		nodesInfoMap := nodes_fake.BuildNodesInfoMap(clusterTopology.Nodes, tasksToNodeMap, nil)
+		vectorMap := resource_info.NewResourceVectorMap()
+		jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(clusterTopology.Jobs, vectorMap)
+		nodesInfoMap := nodes_fake.BuildNodesInfoMap(clusterTopology.Nodes, tasksToNodeMap, nil, vectorMap)
 		ssn := &Session{
 			ClusterInfo: &api.ClusterInfo{},
 		}

--- a/pkg/scheduler/framework/statement_test.go
+++ b/pkg/scheduler/framework/statement_test.go
@@ -107,8 +107,9 @@ func TestStatement_Evict_Unevict(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			ssn := &Session{
 				ClusterInfo: &api.ClusterInfo{},
 			}
@@ -259,8 +260,9 @@ func TestStatement_Evict(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			task := jobsInfoMap[tt.args.jobName].GetAllPodsMap()[tt.args.podName]
 
 			s := &Statement{
@@ -407,8 +409,9 @@ func TestStatement_Evict_Undo_Undo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			task := jobsInfoMap[tt.args.jobName].GetAllPodsMap()[tt.args.podName]
 
 			s := &Statement{
@@ -634,8 +637,9 @@ func TestStatement_Pipeline_Unpipeline(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			ssn := &Session{
 				ClusterInfo: &api.ClusterInfo{},
 			}
@@ -769,8 +773,9 @@ func TestStatement_Pipeline(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			pipelinedTask := jobsInfoMap[tt.args.jobName].GetAllPodsMap()[tt.args.podName]
 
 			s := &Statement{
@@ -897,8 +902,9 @@ func TestStatement_Pipeline_Undo_Undo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			pipelinedTask := jobsInfoMap[tt.args.jobName].GetAllPodsMap()[tt.args.podName]
 
 			s := &Statement{
@@ -1010,8 +1016,9 @@ func TestStatement_Allocate_Unallocate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			ssn := &Session{
 				ClusterInfo: &api.ClusterInfo{},
 			}
@@ -1121,8 +1128,9 @@ func TestStatement_Allocate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			allocatedTask := jobsInfoMap[tt.args.jobName].GetAllPodsMap()[tt.args.podName]
 
 			s := &Statement{
@@ -1226,8 +1234,9 @@ func TestStatement_Allocate_Undo_Undo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(tt.testMetadata.Jobs, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.testMetadata.Nodes, tasksToNodeMap, nil, vectorMap)
 			allocatedTask := jobsInfoMap[tt.args.jobName].GetAllPodsMap()[tt.args.podName]
 
 			s := &Statement{

--- a/pkg/scheduler/gpu_sharing/gpuSharing_test.go
+++ b/pkg/scheduler/gpu_sharing/gpuSharing_test.go
@@ -14,6 +14,7 @@ import (
 	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 func Test_getNodePreferableGpuForSharing(t *testing.T) {
@@ -38,21 +39,28 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 			name: "one whole gpu",
 			args: args{
 				fittingGPUsOnNode: []string{pod_info.WholeGpuIndicator},
-				node: node_info.NewNodeInfo(&v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "n1",
-						Annotations: map[string]string{},
-					},
-					Spec: v1.NodeSpec{},
-					Status: v1.NodeStatus{
-						Allocatable: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceCPU:    resource.MustParse("4"),
-							v1.ResourceMemory: resource.MustParse("10G"),
-							"nvidia.com/gpu":  resource.MustParse("1"),
-							v1.ResourcePods:   resource.MustParse("110"),
+				node: func() *node_info.NodeInfo {
+					n := &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "n1",
+							Annotations: map[string]string{},
 						},
-					},
-				}, nil),
+						Spec: v1.NodeSpec{},
+						Status: v1.NodeStatus{
+							Allocatable: map[v1.ResourceName]resource.Quantity{
+								v1.ResourceCPU:    resource.MustParse("4"),
+								v1.ResourceMemory: resource.MustParse("10G"),
+								"nvidia.com/gpu":  resource.MustParse("1"),
+								v1.ResourcePods:   resource.MustParse("110"),
+							},
+						},
+					}
+					vectorMap := resource_info.NewResourceVectorMap()
+					for resourceName := range n.Status.Allocatable {
+						vectorMap.AddResource(string(resourceName))
+					}
+					return node_info.NewNodeInfo(n, nil, vectorMap)
+				}(),
 				nodeSharingInfo: nil,
 				pod: pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +79,7 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				isPipelineOnly: false,
 			},
 			want: want{
@@ -84,21 +92,28 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 			name: "one fraction gpu - one gpu free on node",
 			args: args{
 				fittingGPUsOnNode: []string{pod_info.WholeGpuIndicator},
-				node: node_info.NewNodeInfo(&v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "n1",
-						Annotations: map[string]string{},
-					},
-					Spec: v1.NodeSpec{},
-					Status: v1.NodeStatus{
-						Allocatable: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceCPU:    resource.MustParse("4"),
-							v1.ResourceMemory: resource.MustParse("10G"),
-							"nvidia.com/gpu":  resource.MustParse("1"),
-							v1.ResourcePods:   resource.MustParse("110"),
+				node: func() *node_info.NodeInfo {
+					n := &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "n1",
+							Annotations: map[string]string{},
 						},
-					},
-				}, nil),
+						Spec: v1.NodeSpec{},
+						Status: v1.NodeStatus{
+							Allocatable: map[v1.ResourceName]resource.Quantity{
+								v1.ResourceCPU:    resource.MustParse("4"),
+								v1.ResourceMemory: resource.MustParse("10G"),
+								"nvidia.com/gpu":  resource.MustParse("1"),
+								v1.ResourcePods:   resource.MustParse("110"),
+							},
+						},
+					}
+					vectorMap := resource_info.NewResourceVectorMap()
+					for resourceName := range n.Status.Allocatable {
+						vectorMap.AddResource(string(resourceName))
+					}
+					return node_info.NewNodeInfo(n, nil, vectorMap)
+				}(),
 				nodeSharingInfo: nil,
 				pod: pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -115,7 +130,7 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				isPipelineOnly: false,
 			},
 			want: want{
@@ -128,21 +143,28 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 			name: "one fraction gpu - half gpu free on node",
 			args: args{
 				fittingGPUsOnNode: []string{"0", pod_info.WholeGpuIndicator},
-				node: node_info.NewNodeInfo(&v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "n1",
-						Annotations: map[string]string{},
-					},
-					Spec: v1.NodeSpec{},
-					Status: v1.NodeStatus{
-						Allocatable: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceCPU:    resource.MustParse("4"),
-							v1.ResourceMemory: resource.MustParse("10G"),
-							"nvidia.com/gpu":  resource.MustParse("2"),
-							v1.ResourcePods:   resource.MustParse("110"),
+				node: func() *node_info.NodeInfo {
+					n := &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "n1",
+							Annotations: map[string]string{},
 						},
-					},
-				}, nil),
+						Spec: v1.NodeSpec{},
+						Status: v1.NodeStatus{
+							Allocatable: map[v1.ResourceName]resource.Quantity{
+								v1.ResourceCPU:    resource.MustParse("4"),
+								v1.ResourceMemory: resource.MustParse("10G"),
+								"nvidia.com/gpu":  resource.MustParse("2"),
+								v1.ResourcePods:   resource.MustParse("110"),
+							},
+						},
+					}
+					vectorMap := resource_info.NewResourceVectorMap()
+					for resourceName := range n.Status.Allocatable {
+						vectorMap.AddResource(string(resourceName))
+					}
+					return node_info.NewNodeInfo(n, nil, vectorMap)
+				}(),
 				nodeSharingInfo: func() *node_info.GpuSharingNodeInfo {
 					sharingMaps := &node_info.GpuSharingNodeInfo{
 						ReleasingSharedGPUs:       make(map[string]bool),
@@ -171,7 +193,7 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				isPipelineOnly: false,
 			},
 			want: want{
@@ -184,21 +206,28 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 			name: "multi fraction gpu - one gpu free on node",
 			args: args{
 				fittingGPUsOnNode: []string{"0", pod_info.WholeGpuIndicator, pod_info.WholeGpuIndicator},
-				node: node_info.NewNodeInfo(&v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "n1",
-						Annotations: map[string]string{},
-					},
-					Spec: v1.NodeSpec{},
-					Status: v1.NodeStatus{
-						Allocatable: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceCPU:    resource.MustParse("4"),
-							v1.ResourceMemory: resource.MustParse("10G"),
-							"nvidia.com/gpu":  resource.MustParse("3"),
-							v1.ResourcePods:   resource.MustParse("110"),
+				node: func() *node_info.NodeInfo {
+					n := &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "n1",
+							Annotations: map[string]string{},
 						},
-					},
-				}, nil),
+						Spec: v1.NodeSpec{},
+						Status: v1.NodeStatus{
+							Allocatable: map[v1.ResourceName]resource.Quantity{
+								v1.ResourceCPU:    resource.MustParse("4"),
+								v1.ResourceMemory: resource.MustParse("10G"),
+								"nvidia.com/gpu":  resource.MustParse("3"),
+								v1.ResourcePods:   resource.MustParse("110"),
+							},
+						},
+					}
+					vectorMap := resource_info.NewResourceVectorMap()
+					for resourceName := range n.Status.Allocatable {
+						vectorMap.AddResource(string(resourceName))
+					}
+					return node_info.NewNodeInfo(n, nil, vectorMap)
+				}(),
 				nodeSharingInfo: func() *node_info.GpuSharingNodeInfo {
 					sharingMaps := &node_info.GpuSharingNodeInfo{
 						ReleasingSharedGPUs:       make(map[string]bool),
@@ -228,7 +257,7 @@ func Test_getNodePreferableGpuForSharing(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, nil, resource_info.NewResourceVectorMap()),
 				isPipelineOnly: false,
 			},
 			want: want{

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources.go
@@ -60,7 +60,7 @@ func (mnr *MaxNodeResourcesPredicate) PreFilter(_ context.Context, _ ksf.CycleSt
 	*k8sframework.PreFilterResult, *ksf.Status) {
 
 	draPodClaims := resource_info.GetDraPodClaims(pod, mnr.resourceClaimsMap, mnr.podsToClaimsMap)
-	podInfo := pod_info.NewTaskInfo(pod, draPodClaims...)
+	podInfo := pod_info.NewTaskInfo(pod, draPodClaims, resource_info.NewResourceVectorMap())
 
 	podGpuResources := podInfo.ResReq.GPUs() + float64(podInfo.ResReq.GetDraGpusCount())
 	if podGpuResources > mnr.maxResources.GPUs() {

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -385,12 +385,19 @@ func buildNodesFromResourceSlices(slices []*resourceapi.ResourceSlice, nodeBases
 	for nodeName, baseList := range nodeBases {
 		allocatable := resource_info.ResourceFromResourceList(baseList)
 		idle := allocatable.Clone()
+		vectorMap := resource_info.NewResourceVectorMap()
+		vectorMap.AddResourceList(baseList)
 		ni := &node_info.NodeInfo{
-			Name:        nodeName,
-			Allocatable: allocatable,
-			Idle:        idle,
-			Releasing:   resource_info.EmptyResource(),
-			Used:        resource_info.EmptyResource(),
+			Name:              nodeName,
+			Allocatable:       allocatable,
+			Idle:              idle,
+			Releasing:         resource_info.EmptyResource(),
+			Used:              resource_info.EmptyResource(),
+			VectorMap:         vectorMap,
+			AllocatableVector: allocatable.ToVector(vectorMap),
+			IdleVector:        idle.ToVector(vectorMap),
+			ReleasingVector:   resource_info.NewResourceVector(vectorMap),
+			UsedVector:        resource_info.NewResourceVector(vectorMap),
 		}
 		var draGPUCount int64
 		for _, slice := range slicesByNode[nodeName] {

--- a/pkg/scheduler/plugins/dynamicresources/dynamicresources_statement_test.go
+++ b/pkg/scheduler/plugins/dynamicresources/dynamicresources_statement_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/test_utils/dra_fake"
@@ -550,7 +551,7 @@ func TestStatementEvictUnevict_WithDRAClaims(t *testing.T) {
 
 			if test.bindRequest != nil {
 				bindRequestInfo := bindrequest_info.NewBindRequestInfo(test.bindRequest)
-				newTask := pod_info.NewTaskInfoWithBindRequest(task.Pod, bindRequestInfo, ssn.ClusterInfo.ResourceClaims...)
+				newTask := pod_info.NewTaskInfoWithBindRequest(task.Pod, bindRequestInfo, ssn.ClusterInfo.ResourceClaims, resource_info.NewResourceVectorMap())
 
 				for _, podSet := range job.PodSets {
 					if _, exists := podSet.GetPodInfos()[task.UID]; exists {

--- a/pkg/scheduler/plugins/gpupack/gpupack_test.go
+++ b/pkg/scheduler/plugins/gpupack/gpupack_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 const fakeNodeName = "node"
@@ -71,7 +72,7 @@ var _ = Describe("GpuPack scoring", func() {
 		},
 	}
 
-	task := pod_info.NewTaskInfo(&v1.Pod{})
+	task := pod_info.NewTaskInfo(&v1.Pod{}, nil, resource_info.NewResourceVectorMap())
 
 	for caseName, caseSpec := range cases {
 		caseName := caseName

--- a/pkg/scheduler/plugins/gpuspread/gpuspread_test.go
+++ b/pkg/scheduler/plugins/gpuspread/gpuspread_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 const fakeNodeName = "node"
@@ -71,7 +72,7 @@ var _ = Describe("GpuSpread scoring", func() {
 		},
 	}
 
-	task := pod_info.NewTaskInfo(&v1.Pod{})
+	task := pod_info.NewTaskInfo(&v1.Pod{}, nil, resource_info.NewResourceVectorMap())
 
 	for caseName, caseSpec := range cases {
 		caseName := caseName

--- a/pkg/scheduler/plugins/nodeavailability/nodeavailability_test.go
+++ b/pkg/scheduler/plugins/nodeavailability/nodeavailability_test.go
@@ -88,7 +88,11 @@ func createFakeNode(nodeName string, idleGpu int) *node_info.NodeInfo {
 	node := nodes_fake.BuildNode(nodeName, nodeResource, nodeIdleResource)
 	clusterPodAffinityInfo := cache.NewK8sClusterPodAffinityInfo()
 	podAffinityInfo := cluster_info.NewK8sNodePodAffinityInfo(node, clusterPodAffinityInfo)
-	return node_info.NewNodeInfo(node, podAffinityInfo)
+	vectorMap := resource_info.NewResourceVectorMap()
+	for resourceName := range node.Status.Allocatable {
+		vectorMap.AddResource(string(resourceName))
+	}
+	return node_info.NewNodeInfo(node, podAffinityInfo, vectorMap)
 }
 
 func createResource(gpu float64) *resource_info.ResourceRequirements {

--- a/pkg/scheduler/plugins/nodeplacement/nodepack_test.go
+++ b/pkg/scheduler/plugins/nodeplacement/nodepack_test.go
@@ -213,7 +213,11 @@ func buildSingleTestParams(testMetadata testTopologyMetadata) (*framework.Sessio
 		node := nodes_fake.BuildNode(nodeName, nodeResource, nodeResource)
 		clusterPodAffinityInfo := cache.NewK8sClusterPodAffinityInfo()
 		podAffinityInfo := cluster_info.NewK8sNodePodAffinityInfo(node, clusterPodAffinityInfo)
-		nodeInfo := node_info.NewNodeInfo(node, podAffinityInfo)
+		vectorMap := resource_info.NewResourceVectorMap()
+		for resourceName := range node.Status.Allocatable {
+			vectorMap.AddResource(string(resourceName))
+		}
+		nodeInfo := node_info.NewNodeInfo(node, podAffinityInfo, vectorMap)
 		idleResources := resources_fake.BuildResourceList(nil, nil,
 			&nodeMetadata.nodeIdleGPUs, nil)
 		nodeInfo.Idle = resource_info.ResourceFromResourceList(*idleResources)
@@ -279,5 +283,5 @@ func createFakeTask(taskName string) *pod_info.PodInfo {
 				},
 			},
 		},
-	})
+	}, nil, resource_info.NewResourceVectorMap())
 }

--- a/pkg/scheduler/plugins/resourcetype/resourcetype_test.go
+++ b/pkg/scheduler/plugins/resourcetype/resourcetype_test.go
@@ -133,7 +133,11 @@ func createFakeNode(nodeName string, capacityGPU int, migProfiles map[v1.Resourc
 	node := nodes_fake.BuildNode(nodeName, nodeResource, nodeResource)
 	clusterPodAffinityInfo := cache.NewK8sClusterPodAffinityInfo()
 	podAffinityInfo := cluster_info.NewK8sNodePodAffinityInfo(node, clusterPodAffinityInfo)
-	return node_info.NewNodeInfo(node, podAffinityInfo)
+	vectorMap := resource_info.NewResourceVectorMap()
+	for resourceName := range node.Status.Allocatable {
+		vectorMap.AddResource(string(resourceName))
+	}
+	return node_info.NewNodeInfo(node, podAffinityInfo, vectorMap)
 }
 
 func createFakeNodeWithDRA(nodeName string, draGPUs int) *node_info.NodeInfo {
@@ -143,7 +147,11 @@ func createFakeNodeWithDRA(nodeName string, draGPUs int) *node_info.NodeInfo {
 	node := nodes_fake.BuildNode(nodeName, nodeResource, nodeResource)
 	clusterPodAffinityInfo := cache.NewK8sClusterPodAffinityInfo()
 	podAffinityInfo := cluster_info.NewK8sNodePodAffinityInfo(node, clusterPodAffinityInfo)
-	ni := node_info.NewNodeInfo(node, podAffinityInfo)
+	vectorMap := resource_info.NewResourceVectorMap()
+	for resourceName := range node.Status.Allocatable {
+		vectorMap.AddResource(string(resourceName))
+	}
+	ni := node_info.NewNodeInfo(node, podAffinityInfo, vectorMap)
 	ni.HasDRAGPUs = true
 	return ni
 }

--- a/pkg/scheduler/plugins/taskorder/task_order_test.go
+++ b/pkg/scheduler/plugins/taskorder/task_order_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 func TestTaskOrder(t *testing.T) {
@@ -30,23 +31,23 @@ func TestTaskOrder(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod), pod_info.NewTaskInfo(rPod)), 1)
+	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(rPod, nil, resource_info.NewResourceVectorMap())), 1)
 
 	lPod.Labels["kai.scheduler/task-priority"] = "2"
-	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod), pod_info.NewTaskInfo(rPod)), 0)
+	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(rPod, nil, resource_info.NewResourceVectorMap())), 0)
 
 	rPod.Labels["kai.scheduler/task-priority"] = "1"
 
-	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod), pod_info.NewTaskInfo(rPod)), -1)
+	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(rPod, nil, resource_info.NewResourceVectorMap())), -1)
 
 	lPod.Labels = map[string]string{}
-	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod), pod_info.NewTaskInfo(rPod)), 1)
+	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(rPod, nil, resource_info.NewResourceVectorMap())), 1)
 
 	lPod.Labels = rPod.Labels
 	rPod.Labels = map[string]string{}
-	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod), pod_info.NewTaskInfo(rPod)), -1)
+	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(rPod, nil, resource_info.NewResourceVectorMap())), -1)
 
 	lPod.Labels = map[string]string{}
-	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod), pod_info.NewTaskInfo(rPod)), 0)
+	assert.Equal(t, TaskOrderFn(pod_info.NewTaskInfo(lPod, nil, resource_info.NewResourceVectorMap()), pod_info.NewTaskInfo(rPod, nil, resource_info.NewResourceVectorMap())), 0)
 
 }

--- a/pkg/scheduler/plugins/topology/job_filtering_test.go
+++ b/pkg/scheduler/plugins/topology/job_filtering_test.go
@@ -564,8 +564,9 @@ func TestTopologyPlugin_subsetNodesFn(t *testing.T) {
 			// Setup test data
 			jobName := tt.job.Name
 			clusterPodGroups := append(tt.allocatedPodGroups, tt.job)
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(clusterPodGroups)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(clusterPodGroups, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.nodes, tasksToNodeMap, nil, vectorMap)
 			job := jobsInfoMap[common_info.PodGroupID(jobName)]
 
 			// Setup topology tree
@@ -1386,8 +1387,9 @@ func TestTopologyPlugin_calcTreeAllocatable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			jobName := tt.job.Name
 			clusterPodGroups := append(tt.allocatedPodGroups, tt.job)
-			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(clusterPodGroups)
-			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.nodes, tasksToNodeMap, nil)
+			vectorMap := resource_info.NewResourceVectorMap()
+			jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(clusterPodGroups, vectorMap)
+			nodesInfoMap := nodes_fake.BuildNodesInfoMap(tt.nodes, tasksToNodeMap, nil, vectorMap)
 			job := jobsInfoMap[common_info.PodGroupID(jobName)]
 
 			topologyTree := tt.setupTopologyTree()

--- a/pkg/scheduler/test_utils/test_utils_builder.go
+++ b/pkg/scheduler/test_utils/test_utils_builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/cache/cluster_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/conf"
@@ -266,10 +267,12 @@ func BuildSession(testMetadata TestTopologyBasic, controller *Controller) *frame
 	}
 
 	addDefaultDepartmentIfNeeded(&testMetadata)
-	jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(testMetadata.Jobs, getDRAObjects(testMetadata)...)
+
+	vectorMap := resource_info.NewResourceVectorMap()
+	jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(testMetadata.Jobs, vectorMap, getDRAObjects(testMetadata)...)
 
 	clusterPodAffinityInfo := cache.NewK8sClusterPodAffinityInfo()
-	nodesInfoMap := nodes_fake.BuildNodesInfoMap(testMetadata.Nodes, tasksToNodeMap, clusterPodAffinityInfo, getDRAObjects(testMetadata)...)
+	nodesInfoMap := nodes_fake.BuildNodesInfoMap(testMetadata.Nodes, tasksToNodeMap, clusterPodAffinityInfo, vectorMap, getDRAObjects(testMetadata)...)
 	queueInfoMap := BuildQueueInfoMap(testMetadata)
 
 	departmentInfoMap := BuildDepartmentInfoMap(testMetadata)


### PR DESCRIPTION
## Description

…Info and update test infrastructure

Add ResourceVector equivalents for all Resource fields:
- NodeInfo: AllocatableVector, IdleVector, UsedVector, ReleasingVector, VectorMap
- PodInfo: ResReqVector, VectorMap
- PodGroupInfo: AllocatedVector, VectorMap

Those fields are currently being updated but not read by any of the users of those classes.

Update snapshot pipeline to build unified ResourceVectorMap from all node and pod resources, and propagate it to all info objects.

Update test infrastructure to pass vectorMap consistently through all test utilities and test helpers.

## Checklist


- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Additional Notes

Performance might take a small hit until we remove the older resource fields.
