### PR TITLE
fix(scheduler): account for fractional GPU usage in spread node placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed admission webhook to skip runtimeClassName injection when gpuPodRuntimeClassName is empty [#1035](https://github.com/NVIDIA/KAI-Scheduler/pull/1035)
 - Fixed topology-migration helm hook failing on OpenShift due to missing `kai-topology-migration` service account in the `kai-system` SCC [#1050](https://github.com/NVIDIA/KAI-Scheduler/pull/1050)
 - Fixed a bug where queue status did not reflect its podgroups resources correctly [#1049](https://github.com/NVIDIA/KAI-Scheduler/pull/1049)
+- Fixed `spread` node placement strategy ignoring fractional GPU usage on shared GPUs, causing nondeterministic pod placement instead of even spreading
 - Fixed helm uninstall does not remove webhooks [#959](https://github.com/NVIDIA/KAI-Scheduler/pull/959) [faizan-exe](https://github.com/faizan-exe)
 - Fixed security vulnerability where PodGang could reference pods in other namespaces, preventing cross-namespace manipulation
 - Fixed pod controller logging to use request namespace/name instead of empty pod object fields when pod is not found

--- a/pkg/scheduler/actions/allocate/allocateFractionalGpu_test.go
+++ b/pkg/scheduler/actions/allocate/allocateFractionalGpu_test.go
@@ -1642,3 +1642,155 @@ func getFractionalGPUTestsMetadata() []integration_tests_utils.TestTopologyMetad
 		},
 	}
 }
+
+// TestFillNodeSpreadStrategyPackGPUs reproduces the E2E fill_node_test scenario:
+// 2 nodes (2 GPUs each), 4 pending pods (0.5 GPU each), spread across nodes + pack GPUs.
+// With spread strategy, pods should alternate across nodes. With gpupack, pods on the
+// same node should share a single GPU. Expected: 2 pods per node, 1 reservation per node.
+func TestFillNodeSpreadStrategyPackGPUs(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+	defer gock.Off()
+
+	testsMetadata := getFillNodeSpreadPackTestsMetadata()
+	for testNumber, testMetadata := range testsMetadata {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.TestTopologyBasic.Name)
+
+		ssn := test_utils.BuildSession(testMetadata.TestTopologyBasic, controller)
+		allocateAction := allocate.New()
+		allocateAction.Execute(ssn)
+
+		test_utils.MatchExpectedAndRealTasks(t, testNumber, testMetadata.TestTopologyBasic, ssn)
+
+		// Additionally verify GPU packing: count distinct GPU groups per node
+		reservationsByNode := map[string]map[string]bool{}
+		for _, job := range ssn.ClusterInfo.PodGroupInfos {
+			for _, task := range job.GetAllPodsMap() {
+				if task.NodeName == "" {
+					continue
+				}
+				if reservationsByNode[task.NodeName] == nil {
+					reservationsByNode[task.NodeName] = map[string]bool{}
+				}
+				for _, gpuGroup := range task.GPUGroups {
+					reservationsByNode[task.NodeName][gpuGroup] = true
+				}
+			}
+		}
+
+		for nodeName, gpuGroups := range reservationsByNode {
+			if len(gpuGroups) != 1 {
+				t.Errorf("Test %d: %s - expected 1 GPU group on node %s (pack behavior), got %d: %v",
+					testNumber, testMetadata.TestTopologyBasic.Name, nodeName, len(gpuGroups), gpuGroups)
+			}
+		}
+	}
+}
+
+func getFillNodeSpreadPackTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
+	return []integration_tests_utils.TestTopologyMetadata{
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "E2E fill_node reproduction: 4 pending pods, spread nodes, pack GPUs - all from empty state",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "pending_job0",
+						Priority:            constants.PriorityBuildNumber,
+						QueueName:           "queue0",
+						RequiredGPUsPerTask: 0.5,
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{State: pod_status.Pending},
+						},
+					},
+					{
+						Name:                "pending_job1",
+						Priority:            constants.PriorityBuildNumber,
+						QueueName:           "queue0",
+						RequiredGPUsPerTask: 0.5,
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{State: pod_status.Pending},
+						},
+					},
+					{
+						Name:                "pending_job2",
+						Priority:            constants.PriorityBuildNumber,
+						QueueName:           "queue0",
+						RequiredGPUsPerTask: 0.5,
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{State: pod_status.Pending},
+						},
+					},
+					{
+						Name:                "pending_job3",
+						Priority:            constants.PriorityBuildNumber,
+						QueueName:           "queue0",
+						RequiredGPUsPerTask: 0.5,
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{State: pod_status.Pending},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {GPUs: 2},
+					"node1": {GPUs: 2},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:         "queue0",
+						DeservedGPUs: 4,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"pending_job0": {
+						GPUsRequired:         0.5,
+						Status:               pod_status.Binding,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job1": {
+						GPUsRequired:         0.5,
+						Status:               pod_status.Binding,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job2": {
+						GPUsRequired:         0.5,
+						Status:               pod_status.Binding,
+						DontValidateGPUGroup: true,
+					},
+					"pending_job3": {
+						GPUsRequired:         0.5,
+						Status:               pod_status.Binding,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 5,
+					},
+					SchedulerConf: &conf.SchedulerConfiguration{
+						Actions: "allocate",
+						Tiers: []conf.Tier{
+							{
+								Plugins: []conf.PluginOption{
+									{
+										Name: "nodeplacement",
+										Arguments: map[string]string{
+											constants.GPUResource: constants.SpreadStrategy,
+											constants.CPUResource: constants.SpreadStrategy,
+										},
+									},
+									{Name: "gpupack"},
+									{Name: "proportion"},
+									{Name: "priority"},
+									{Name: "nodeavailability"},
+									{Name: "resourcetype"},
+									{Name: "gpusharingorder"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/scheduler/actions/allocate/allocateFractionalGpu_test.go
+++ b/pkg/scheduler/actions/allocate/allocateFractionalGpu_test.go
@@ -1784,7 +1784,6 @@ func getFillNodeSpreadPackTestsMetadata() []integration_tests_utils.TestTopology
 									{Name: "priority"},
 									{Name: "nodeavailability"},
 									{Name: "resourcetype"},
-									{Name: "gpusharingorder"},
 								},
 							},
 						},

--- a/test/e2e/modules/configurations/feature_flags/plugins.go
+++ b/test/e2e/modules/configurations/feature_flags/plugins.go
@@ -7,13 +7,14 @@ package feature_flags
 import (
 	"context"
 
+	"k8s.io/utils/ptr"
+
 	kaiv1 "github.com/NVIDIA/KAI-scheduler/pkg/apis/kai/v1"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testContext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
-	"k8s.io/utils/ptr"
 )
 
 func SetPluginEnabled(

--- a/test/e2e/modules/configurations/feature_flags/plugins.go
+++ b/test/e2e/modules/configurations/feature_flags/plugins.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package feature_flags
+
+import (
+	"context"
+
+	kaiv1 "github.com/NVIDIA/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	testContext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
+	"k8s.io/utils/ptr"
+)
+
+func SetPluginEnabled(
+	ctx context.Context, testCtx *testContext.TestContext, pluginName string, enabled bool,
+) error {
+	if err := configurations.PatchSchedulingShard(
+		ctx, testCtx, "default",
+		func(shard *kaiv1.SchedulingShard) {
+			if shard.Spec.Plugins == nil {
+				shard.Spec.Plugins = make(map[string]kaiv1.PluginConfig)
+			}
+			config := shard.Spec.Plugins[pluginName]
+			config.Enabled = ptr.To(enabled)
+			shard.Spec.Plugins[pluginName] = config
+		},
+	); err != nil {
+		return err
+	}
+	wait.WaitForDeploymentPodsRunning(
+		ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace,
+	)
+	return nil
+}

--- a/test/e2e/suites/allocate/node_order/fill_node_test.go
+++ b/test/e2e/suites/allocate/node_order/fill_node_test.go
@@ -53,9 +53,6 @@ func DescribeFillNodeSpecs() bool {
 			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpuspread", false); err != nil {
 				Fail(fmt.Sprintf("Failed to disable gpuspread plugin: %v", err))
 			}
-			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpusharingorder", true); err != nil {
-				Fail(fmt.Sprintf("Failed to enable gpusharingorder plugin: %v", err))
-			}
 		})
 
 		AfterAll(func(ctx context.Context) {
@@ -64,9 +61,6 @@ func DescribeFillNodeSpecs() bool {
 			}
 			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpuspread", false); err != nil {
 				Fail(fmt.Sprintf("Failed to reset gpuspread plugin: %v", err))
-			}
-			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpusharingorder", false); err != nil {
-				Fail(fmt.Sprintf("Failed to reset gpusharingorder plugin: %v", err))
 			}
 			if err := feature_flags.SetPlacementStrategy(ctx, testCtx, DefaultPluginName); err != nil {
 				Fail(fmt.Sprintf("Failed to restore default placement strategy: %v", err))

--- a/test/e2e/suites/allocate/node_order/fill_node_test.go
+++ b/test/e2e/suites/allocate/node_order/fill_node_test.go
@@ -88,7 +88,7 @@ func DescribeFillNodeSpecs() bool {
 			}
 
 			namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
-			wait.ForPodsScheduled(ctx, testCtx.ControllerClient, namespace, pods)
+			wait.ForPodsReady(ctx, testCtx.ControllerClient, namespace, pods)
 
 			reservationPods, err := testCtx.KubeClientset.CoreV1().
 				Pods(constant.KaiReservationNamespace).

--- a/test/e2e/suites/allocate/node_order/fill_node_test.go
+++ b/test/e2e/suites/allocate/node_order/fill_node_test.go
@@ -56,11 +56,11 @@ func DescribeFillNodeSpecs() bool {
 		})
 
 		AfterAll(func(ctx context.Context) {
-			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpupack", false); err != nil {
-				Fail(fmt.Sprintf("Failed to reset gpupack plugin: %v", err))
+			if err := feature_flags.UnsetPlugin(ctx, testCtx, "gpupack"); err != nil {
+				Fail(fmt.Sprintf("Failed to unset gpupack plugin: %v", err))
 			}
-			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpuspread", false); err != nil {
-				Fail(fmt.Sprintf("Failed to reset gpuspread plugin: %v", err))
+			if err := feature_flags.UnsetPlugin(ctx, testCtx, "gpuspread"); err != nil {
+				Fail(fmt.Sprintf("Failed to unset gpuspread plugin: %v", err))
 			}
 			if err := feature_flags.SetPlacementStrategy(ctx, testCtx, DefaultPluginName); err != nil {
 				Fail(fmt.Sprintf("Failed to restore default placement strategy: %v", err))

--- a/test/e2e/suites/allocate/node_order/fill_node_test.go
+++ b/test/e2e/suites/allocate/node_order/fill_node_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package node_order
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant/labels"
+	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
+)
+
+func DescribeFillNodeSpecs() bool {
+	return Describe("Fill node with fractional GPUs", Label(labels.Operated, labels.ReservationPod), Ordered, func() {
+		var (
+			testCtx  *testcontext.TestContext
+			gpuNodes []*v1.Node
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+
+			gpuNodes = findDevicePluginGPUNodes(ctx, testCtx)
+			if len(gpuNodes) < 2 {
+				Skip(fmt.Sprintf("Need at least 2 device-plugin GPU nodes, found %d", len(gpuNodes)))
+			}
+
+			parentQueue := queue.CreateQueueObject(utils.GenerateRandomK8sName(10), "")
+			childQueue := queue.CreateQueueObject(utils.GenerateRandomK8sName(10), parentQueue.Name)
+			testCtx.InitQueues([]*v2.Queue{childQueue, parentQueue})
+
+			if err := feature_flags.SetPlacementStrategy(ctx, testCtx, SpreadingPluginName); err != nil {
+				Fail(fmt.Sprintf("Failed to set spread placement strategy: %v", err))
+			}
+			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpupack", true); err != nil {
+				Fail(fmt.Sprintf("Failed to enable gpupack plugin: %v", err))
+			}
+			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpuspread", false); err != nil {
+				Fail(fmt.Sprintf("Failed to disable gpuspread plugin: %v", err))
+			}
+			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpusharingorder", true); err != nil {
+				Fail(fmt.Sprintf("Failed to enable gpusharingorder plugin: %v", err))
+			}
+		})
+
+		AfterAll(func(ctx context.Context) {
+			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpupack", false); err != nil {
+				Fail(fmt.Sprintf("Failed to reset gpupack plugin: %v", err))
+			}
+			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpuspread", false); err != nil {
+				Fail(fmt.Sprintf("Failed to reset gpuspread plugin: %v", err))
+			}
+			if err := feature_flags.SetPluginEnabled(ctx, testCtx, "gpusharingorder", false); err != nil {
+				Fail(fmt.Sprintf("Failed to reset gpusharingorder plugin: %v", err))
+			}
+			if err := feature_flags.SetPlacementStrategy(ctx, testCtx, DefaultPluginName); err != nil {
+				Fail(fmt.Sprintf("Failed to restore default placement strategy: %v", err))
+			}
+			testCtx.ClusterCleanup(ctx)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			testCtx.TestContextCleanup(ctx)
+		})
+
+		It("should pack fractional GPU pods onto one GPU per node under spread strategy", func(ctx context.Context) {
+			numGPUNodes := len(gpuNodes)
+			numPods := numGPUNodes * 2
+
+			pods := make([]*v1.Pod, numPods)
+			for i := range numPods {
+				pods[i] = rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{})
+				pods[i].Annotations = map[string]string{
+					constants.GpuFraction: "0.5",
+				}
+				var err error
+				pods[i], err = rd.CreatePod(ctx, testCtx.KubeClientset, pods[i])
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
+			wait.ForPodsScheduled(ctx, testCtx.ControllerClient, namespace, pods)
+
+			reservationPods, err := testCtx.KubeClientset.CoreV1().
+				Pods(constant.KaiReservationNamespace).
+				List(ctx, metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			reservationsByNode := map[string]int{}
+			for _, pod := range reservationPods.Items {
+				if pod.Spec.NodeName != "" {
+					reservationsByNode[pod.Spec.NodeName]++
+				}
+			}
+
+			for _, node := range gpuNodes {
+				Expect(reservationsByNode[node.Name]).To(Equal(1),
+					fmt.Sprintf("Expected exactly 1 reservation pod on node %s, got %d",
+						node.Name, reservationsByNode[node.Name]))
+			}
+		})
+	})
+}
+
+func findDevicePluginGPUNodes(ctx context.Context, testCtx *testcontext.TestContext) []*v1.Node {
+	allNodes := v1.NodeList{}
+	Expect(testCtx.ControllerClient.List(ctx, &allNodes)).To(Succeed())
+
+	var gpuNodes []*v1.Node
+	for i, node := range allNodes.Items {
+		if len(node.Spec.Taints) > 0 {
+			continue
+		}
+		gpuResource, found := node.Status.Capacity[constants.NvidiaGpuResource]
+		if found && gpuResource.CmpInt64(0) > 0 {
+			gpuNodes = append(gpuNodes, &allNodes.Items[i])
+		}
+	}
+	return gpuNodes
+}

--- a/test/e2e/suites/allocate/node_order/node_order_suite_test.go
+++ b/test/e2e/suites/allocate/node_order/node_order_suite_test.go
@@ -15,6 +15,7 @@ import (
 
 var _ = DescribeAffinitySpecs()
 var _ = DescribeResourceTypeSpecs()
+var _ = DescribeFillNodeSpecs()
 
 func TestNodeOrder(t *testing.T) {
 	utils.SetLogger()


### PR DESCRIPTION
## Description

The `spread` node placement strategy scored GPU availability using `NonAllocatedResource`, which only counted whole idle and releasing GPUs. It ignored fractional capacity remaining on shared GPUs, causing nodes with different actual availability to score identically. This led to nondeterministic pod placement instead of even spreading for fractional GPU workloads.

This PR fixes the spread scoring to use `GetSumOfIdleGPUs() + GetSumOfReleasingGPUs()`, which correctly accounts for partial GPU consumption. A node with 1.5 GPUs available now scores `1.5/2 = 0.75`, differentiating it from a fully idle node at `1.0`.

The `gpupack` plugin (GPU-level ordering) continues to handle the "pack onto the same GPU" concern independently — it operates at the `GpuOrderFn` level, which runs *after* node selection.

### Example: Why the bug causes incorrect spreading

**Setup:** 2 nodes, each with 2 GPUs. 4 pods requesting 0.5 GPU each. Strategy: `spread` + `gpupack`.

**Desired outcome:** 2 pods per node, each pair packed onto a single GPU → 1 reservation pod per node.

**Pod 1** — both nodes empty, both score `2/2 = 1.0`. Tie → lands on node-A (GPU-0).

**Pod 2** — node-A has 1 idle GPU (`NonAllocatedResource = 1`), node-B has 2. Scores: `0.5` vs `1.0`. node-B wins. ✅

**Pod 3** — both nodes have 1 idle GPU each (`NonAllocatedResource = 1` for both — the 0.5 used on a shared GPU is invisible). Scores: `0.5` vs `0.5`. Tie → lands on either node (say node-A). `gpupack` packs it onto GPU-0. ✅

**Pod 4** — node-A now has 2 pods on GPU-0 (1.0 used), node-B has 1 pod on GPU-0 (0.5 used):

| | node-A | node-B |
|---|---|---|
| Whole idle GPUs | 1 (GPU-1) | 1 (GPU-1) |
| Shared GPU remaining | 0 (GPU-0 full) | 0.5 (GPU-0 half used) |
| `NonAllocatedResource` | **1** | **1** |
| spread score | `1/2 = 0.5` | `1/2 = 0.5` |

**Both nodes score identically.** The scheduler doesn't see that node-B has 1.5 GPUs available while node-A only has 1.0. Pod 4 lands on either node nondeterministically. If it goes to node-A → node-A gets 3 pods and opens a second GPU (2 reservation pods instead of 1). ❌

**With the fix**, node-A scores `1.0/2 = 0.5` and node-B scores `1.5/2 = 0.75`, correctly directing pod 4 to node-B. ✅

#### Adding `gpusharingorder` doesn't help — it makes things worse

One might try enabling `gpusharingorder` to break the tie by preferring nodes with existing shared GPU groups. But this backfires on **pod 2**:

| Plugin | node-A | node-B |
|---|---|---|
| spread | `1/2 = 0.5` | `2/2 = 1.0` |
| gpusharingorder | `+1000` (GPU-0 has a shared group, pod fits) | `0` (no shared GPUs) |
| **Total** | **1000.5** | **1.0** |

Pod 2 goes to node-A instead of node-B — the +1000 score overwhelms the spread signal entirely, turning "spread across nodes" into "pack onto nodes that already have shared GPUs."

### Changes

- **`spread.go`**: For GPU resources, compute `nonAllocated` as the sum of idle + releasing GPU fractions instead of using `NonAllocatedResource`.
- **`nodespread_test.go`**: Unit test verifying that a node with shared GPU consumption scores lower than a fully idle node.
- **`allocateFractionalGpu_test.go`**: Integration test reproducing the E2E scenario — 4 pods (0.5 GPU each) across 2 nodes (2 GPUs each) with spread + gpupack.
- **`fill_node_test.go`** (new): E2E test that submits `2×numNodes` fractional GPU pods under spread strategy and asserts exactly 1 reservation pod per GPU node.
- **`plugins.go`** (new): E2E helper to enable/disable scheduler plugins via SchedulingShard patches.
- **`node_order_suite_test.go`**: Register the new E2E test suite.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

The `gpusharingorder` plugin is intentionally **not** enabled in the E2E test. It adds a +1000 node-level score to nodes with existing shared GPU groups, which actively fights the spread strategy. GPU packing within a node is handled entirely by `gpupack` at the GPU-order level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed spread node placement strategy to properly handle fractional GPU usage on shared GPUs, eliminating nondeterministic pod placement and ensuring even spreading across nodes.

* **Tests**
  * Added comprehensive tests validating spread strategy behavior with fractional GPU allocations and shared GPU scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->