### PR TITLE
fix: use testconfig instead of hardcoded KAI constants in e2e

### DIFF
--- a/test/e2e/modules/configurations/feature_flags/hierarchy_fairness_type.go
+++ b/test/e2e/modules/configurations/feature_flags/hierarchy_fairness_type.go
@@ -8,10 +8,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	"k8s.io/utils/ptr"
 )
@@ -26,6 +25,7 @@ func SetFullHierarchyFairness(
 	if err := configurations.SetShardArg(ctx, testCtx, "default", "full-hierarchy-fairness", targetValue); err != nil {
 		return err
 	}
-	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)
+	cfg := testconfig.GetConfig()
+	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, cfg.SchedulerDeploymentName, cfg.SystemPodsNamespace)
 	return nil
 }

--- a/test/e2e/modules/configurations/feature_flags/knative_grouping.go
+++ b/test/e2e/modules/configurations/feature_flags/knative_grouping.go
@@ -8,10 +8,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	"k8s.io/utils/ptr"
 )
@@ -28,6 +27,7 @@ func SetKnativeGangScheduling(ctx context.Context, testCtx *testcontext.TestCont
 	if err := configurations.SetShardArg(ctx, testCtx, "default", "knative-gang-schedule", targetValue); err != nil {
 		return err
 	}
-	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)
+	cfg := testconfig.GetConfig()
+	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, cfg.SchedulerDeploymentName, cfg.SystemPodsNamespace)
 	return nil
 }

--- a/test/e2e/modules/configurations/feature_flags/placement_strategy.go
+++ b/test/e2e/modules/configurations/feature_flags/placement_strategy.go
@@ -8,10 +8,9 @@ import (
 	"context"
 
 	kaiv1 "github.com/NVIDIA/KAI-scheduler/pkg/apis/kai/v1"
-	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testContext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	"k8s.io/utils/ptr"
 )
@@ -36,8 +35,9 @@ func SetPlacementStrategy(
 	); err != nil {
 		return err
 	}
+	cfg := testconfig.GetConfig()
 	wait.WaitForDeploymentPodsRunning(
-		ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace,
+		ctx, testCtx.ControllerClient, cfg.SchedulerDeploymentName, cfg.SystemPodsNamespace,
 	)
 	return nil
 }

--- a/test/e2e/modules/configurations/feature_flags/restrict_node_scheduling.go
+++ b/test/e2e/modules/configurations/feature_flags/restrict_node_scheduling.go
@@ -8,10 +8,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testContext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	"k8s.io/utils/ptr"
 )
@@ -26,6 +25,7 @@ func SetRestrictNodeScheduling(
 	if err := configurations.SetShardArg(ctx, testCtx, "default", "restrict-node-scheduling", targetValue); err != nil {
 		return err
 	}
-	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)
+	cfg := testconfig.GetConfig()
+	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, cfg.SchedulerDeploymentName, cfg.SystemPodsNamespace)
 	return nil
 }

--- a/test/e2e/modules/configurations/feature_flags/staleness_grace_period.go
+++ b/test/e2e/modules/configurations/feature_flags/staleness_grace_period.go
@@ -7,10 +7,9 @@ package feature_flags
 import (
 	"context"
 
-	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/configurations"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	"k8s.io/utils/ptr"
 )
@@ -25,6 +24,7 @@ func SetDefaultStalenessGracePeriod(
 	if err := configurations.SetShardArg(ctx, testCtx, "default", "default-staleness-grace-period", targetValue); err != nil {
 		return err
 	}
-	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName, constants.DefaultKAINamespace)
+	cfg := testconfig.GetConfig()
+	wait.WaitForDeploymentPodsRunning(ctx, testCtx.ControllerClient, cfg.SchedulerDeploymentName, cfg.SystemPodsNamespace)
 	return nil
 }

--- a/test/e2e/modules/configurations/scheduler.go
+++ b/test/e2e/modules/configurations/scheduler.go
@@ -10,8 +10,8 @@ import (
 
 	kaiv1 "github.com/NVIDIA/KAI-scheduler/pkg/apis/kai/v1"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	. "github.com/onsi/ginkgo/v2"
 	"k8s.io/utils/ptr"
@@ -24,10 +24,11 @@ func DisableScheduler(ctx context.Context, testCtx *testcontext.TestContext) {
 		Fail(fmt.Sprintf("Failed to patch kai-config: %v", err))
 	}
 
+	cfg := testconfig.GetConfig()
 	wait.ForPodsToBeDeleted(
 		ctx, testCtx.ControllerClient,
-		client.InNamespace(constant.SystemPodsNamespace),
-		client.MatchingLabels{constants.AppLabelName: constant.SchedulerDeploymentName},
+		client.InNamespace(cfg.SystemPodsNamespace),
+		client.MatchingLabels{constants.AppLabelName: cfg.SchedulerDeploymentName},
 	)
 }
 
@@ -36,5 +37,5 @@ func EnableScheduler(ctx context.Context, testCtx *testcontext.TestContext) {
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to patch kai-config: %v", err))
 	}
-	wait.ForRunningSystemComponentEvent(ctx, testCtx.ControllerClient, constant.SchedulerDeploymentName)
+	wait.ForRunningSystemComponentEvent(ctx, testCtx.ControllerClient, testconfig.GetConfig().SchedulerDeploymentName)
 }

--- a/test/e2e/modules/resources/rd/jobset/jobset.go
+++ b/test/e2e/modules/resources/rd/jobset/jobset.go
@@ -12,7 +12,6 @@ import (
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 )
 
@@ -40,7 +39,7 @@ func CreateUnequalCompletionJobSetObject(name, namespace, queueName string, para
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "worker",
@@ -106,7 +105,7 @@ func CreateObjectWithStartupPolicy(name, namespace, queueName, startupPolicyOrde
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "job1",
@@ -140,7 +139,7 @@ func CreateObjectWithStartupPolicy(name, namespace, queueName, startupPolicyOrde
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "job2",
@@ -199,11 +198,11 @@ func CreateObjectWithHighParallelism(name, namespace, queueName string) *jobsetv
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "worker",
-											Image: "ubuntu",
+											Image: testconfig.GetConfig().ContainerImage,
 											Command: []string{
 												"sleep",
 												"3600",
@@ -261,11 +260,11 @@ func CreateObjectWithMultipleReplicatedJobs(name, namespace, queueName string) *
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "coordinator",
-											Image: "ubuntu",
+											Image: testconfig.GetConfig().ContainerImage,
 											Command: []string{
 												"sleep",
 												"3600",
@@ -288,11 +287,11 @@ func CreateObjectWithMultipleReplicatedJobs(name, namespace, queueName string) *
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "worker",
-											Image: "ubuntu",
+											Image: testconfig.GetConfig().ContainerImage,
 											Command: []string{
 												"sleep",
 												"3600",
@@ -347,11 +346,11 @@ func CreateObjectWithDefaultParallelism(name, namespace, queueName string) *jobs
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy: corev1.RestartPolicyNever,
-									SchedulerName: constant.SchedulerName,
+									SchedulerName: testconfig.GetConfig().SchedulerName,
 									Containers: []corev1.Container{
 										{
 											Name:  "single",
-											Image: "ubuntu",
+											Image: testconfig.GetConfig().ContainerImage,
 											Command: []string{
 												"sleep",
 												"3600",

--- a/test/e2e/modules/resources/rd/mpi/mpi.go
+++ b/test/e2e/modules/resources/rd/mpi/mpi.go
@@ -77,20 +77,21 @@ func CreateV2beta1Object(namespace, queueName string) *v2beta1.MPIJob {
 }
 
 func getPodTemplate(queueName, matchLabelValue string) corev1.PodTemplateSpec {
+	cfg := testconfig.GetConfig()
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				constants.AppLabelName:               matchLabelValue,
-				testconfig.GetConfig().QueueLabelKey: queueName,
+				constants.AppLabelName: matchLabelValue,
+				cfg.QueueLabelKey:      queueName,
 			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:                 corev1.RestartPolicyNever,
-			SchedulerName:                 testconfig.GetConfig().SchedulerName,
+			SchedulerName:                 cfg.SchedulerName,
 			TerminationGracePeriodSeconds: pointer.Int64(0),
 			Containers: []corev1.Container{
 				{
-					Image: "ubuntu",
+					Image: cfg.ContainerImage,
 					Name:  "ubuntu-container",
 					Args: []string{
 						"sleep",

--- a/test/e2e/modules/resources/rd/pytorch/pytorch.go
+++ b/test/e2e/modules/resources/rd/pytorch/pytorch.go
@@ -70,20 +70,21 @@ func CreateWorkerOnlyObject(namespace, queueName string, replicas int32) *traini
 }
 
 func GetPodTemplate(queueName, matchLabelValue string) corev1.PodTemplateSpec {
+	cfg := testconfig.GetConfig()
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				constants.AppLabelName:               matchLabelValue,
-				testconfig.GetConfig().QueueLabelKey: queueName,
+				constants.AppLabelName: matchLabelValue,
+				cfg.QueueLabelKey:      queueName,
 			},
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:                 corev1.RestartPolicyNever,
-			SchedulerName:                 constant.SchedulerName,
+			SchedulerName:                 cfg.SchedulerName,
 			TerminationGracePeriodSeconds: pointer.Int64(0),
 			Containers: []corev1.Container{
 				{
-					Image: "ubuntu",
+					Image: cfg.ContainerImage,
 					Name:  "pytorch",
 					Args: []string{
 						"sleep",

--- a/test/e2e/modules/resources/rd/resource_claim.go
+++ b/test/e2e/modules/resources/rd/resource_claim.go
@@ -43,21 +43,22 @@ func CreateResourceClaim(namespace, queueName, deviceClassName string, deviceCou
 }
 
 func CreateResourceClaimTemplate(namespace, queueName, deviceClassName string, deviceCount int) *resourceapi.ResourceClaimTemplate {
+	cfg := testconfig.GetConfig()
 	return &resourceapi.ResourceClaimTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        utils.GenerateRandomK8sName(10),
 			Namespace:   namespace,
 			Annotations: map[string]string{},
 			Labels: map[string]string{
-				constants.AppLabelName:      "engine-e2e",
-				constants.DefaultQueueLabel: queueName,
+				constants.AppLabelName: "engine-e2e",
+				cfg.QueueLabelKey:      queueName,
 			},
 		},
 		Spec: resourceapi.ResourceClaimTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					constants.AppLabelName:      "engine-e2e",
-					constants.DefaultQueueLabel: queueName,
+					constants.AppLabelName: "engine-e2e",
+					cfg.QueueLabelKey:      queueName,
 				},
 			},
 			Spec: resourceapi.ResourceClaimSpec{

--- a/test/e2e/suites/allocate/resources/dra_test.go
+++ b/test/e2e/suites/allocate/resources/dra_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -280,8 +281,8 @@ var _ = Describe("Schedule pod with dynamic resource request", Ordered, func() {
 						Name:      podGroupName,
 						Namespace: namespace,
 						Labels: map[string]string{
-							constants.AppLabelName:      "engine-e2e",
-							constants.DefaultQueueLabel: testCtx.Queues[0].Name,
+							constants.AppLabelName:               "engine-e2e",
+							testconfig.GetConfig().QueueLabelKey: testCtx.Queues[0].Name,
 						},
 					},
 					Spec: v2alpha2.PodGroupSpec{

--- a/test/e2e/suites/integrations/third_party/knative/knative_test.go
+++ b/test/e2e/suites/integrations/third_party/knative/knative_test.go
@@ -22,9 +22,9 @@ import (
 
 	v2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
-	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/constant"
 	testcontext "github.com/NVIDIA/KAI-scheduler/test/e2e/modules/context"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/utils"
 	"github.com/NVIDIA/KAI-scheduler/test/e2e/modules/wait"
 
@@ -161,7 +161,7 @@ func setKnativeGangAndWait(ctx context.Context, testCtx *testcontext.TestContext
 		podGrouperPod := &v1.PodList{}
 		err := testCtx.ControllerClient.List(
 			ctx, podGrouperPod,
-			client.InNamespace(constant.SystemPodsNamespace), client.MatchingLabels{"app": "podgrouper"},
+			client.InNamespace(testconfig.GetConfig().SystemPodsNamespace), client.MatchingLabels{"app": "podgrouper"},
 		)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(len(podGrouperPod.Items)).To(Equal(1))


### PR DESCRIPTION
## Description

Several e2e test modules and specs used hardcoded KAI-specific constants (`constant.SchedulerName`, `constant.SystemPodsNamespace`, `constant.SchedulerDeploymentName`, `constants.DefaultKAINamespace`, `constants.DefaultQueueLabel`, and hardcoded `"ubuntu"` image) instead of reading from `testconfig.GetConfig()`.

This breaks downstream consumers like runai-engine that override these values via `testconfig.SetConfig()` — pods get created with the wrong scheduler name, looked up in the wrong namespace, or labeled with the wrong queue key.

### Files changed (12):

**Modules — resource definitions:**
- `rd/pytorch/pytorch.go` — `SchedulerName` and `ContainerImage` now from testconfig
- `rd/mpi/mpi.go` — `ContainerImage` now from testconfig
- `rd/jobset/jobset.go` — `SchedulerName` (7x) and `ContainerImage` (4x) now from testconfig
- `rd/resource_claim.go` — `QueueLabelKey` now from testconfig in `CreateResourceClaimTemplate`

**Modules — configurations:**
- `configurations/scheduler.go` — `SystemPodsNamespace` and `SchedulerDeploymentName` now from testconfig
- `feature_flags/hierarchy_fairness_type.go` — testconfig
- `feature_flags/staleness_grace_period.go` — testconfig
- `feature_flags/restrict_node_scheduling.go` — testconfig
- `feature_flags/placement_strategy.go` — testconfig
- `feature_flags/knative_grouping.go` — testconfig

**Suites:**
- `knative/knative_test.go` — `SystemPodsNamespace` now from testconfig
- `resources/dra_test.go` — `QueueLabelKey` now from testconfig

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None — this is a behavioral fix for consumers that override testconfig values.