### PR TITLE
fix(operator): add Reconciling/NotReady condition reasons for kstatus compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fixed a bug where queue status did not reflect its podgroups resources correctly [#1049](https://github.com/NVIDIA/KAI-Scheduler/pull/1049)
 - Fixed plugin server (snapshot and job-order endpoints) listening on all interfaces by binding to localhost only.
+- Fixed operator status conditions to be kstatus-compatible for Helm 4 `--wait` support: added `Ready` condition and fixed `Reconciling` condition to properly transition to false after reconciliation completes [#1060](https://github.com/NVIDIA/KAI-Scheduler/pull/1060)
 
 ## [v0.9.12] - 2026-01-21
 

--- a/pkg/apis/kai/v1/config_types.go
+++ b/pkg/apis/kai/v1/config_types.go
@@ -35,8 +35,10 @@ const (
 	Deployed              ConditionReason = "deployed"
 	Available             ConditionReason = "available"
 	Reconciled            ConditionReason = "reconciled"
+	Reconciling           ConditionReason = "reconciling"
 	DependenciesFulfilled ConditionReason = "dependencies_fulfilled"
 	Ready                 ConditionReason = "ready"
+	NotReady              ConditionReason = "not_ready"
 )
 
 // ConfigSpec defines the desired state of Config

--- a/pkg/operator/controller/status_reconciler/status_reconciler.go
+++ b/pkg/operator/controller/status_reconciler/status_reconciler.go
@@ -120,18 +120,21 @@ func (r *StatusReconciler) getDeployedCondition(ctx context.Context, gen int64) 
 }
 
 func (r *StatusReconciler) getReconcilingCondition(gen int64, isReconciling bool) metav1.Condition {
-	status := metav1.ConditionFalse
-	message := "Reconciliation completed"
 	if isReconciling {
-		status = metav1.ConditionTrue
-		message = "Reconciliation in progress"
+		return metav1.Condition{
+			Type:               string(kaiv1.ConditionTypeReconciling),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(kaiv1.Reconciling),
+			Message:            "Reconciliation in progress",
+			ObservedGeneration: gen,
+			LastTransitionTime: metav1.Now(),
+		}
 	}
-
 	return metav1.Condition{
 		Type:               string(kaiv1.ConditionTypeReconciling),
-		Status:             status,
+		Status:             metav1.ConditionFalse,
 		Reason:             string(kaiv1.Reconciled),
-		Message:            message,
+		Message:            "Reconciliation completed successfully",
 		ObservedGeneration: gen,
 		LastTransitionTime: metav1.Now(),
 	}
@@ -193,7 +196,7 @@ func (r *StatusReconciler) getReadyCondition(gen int64, isReady bool) metav1.Con
 	return metav1.Condition{
 		Type:               string(kaiv1.ConditionTypeReady),
 		Status:             metav1.ConditionFalse,
-		Reason:             string(kaiv1.Ready),
+		Reason:             string(kaiv1.NotReady),
 		Message:            "System is not ready",
 		ObservedGeneration: gen,
 		LastTransitionTime: metav1.Now(),

--- a/pkg/operator/controller/status_reconciler/status_reconciler_test.go
+++ b/pkg/operator/controller/status_reconciler/status_reconciler_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Status Controller", func() {
 				if condition.Type == string(kaiv1.ConditionTypeReconciling) &&
 					condition.Status == metav1.ConditionTrue &&
 					condition.ObservedGeneration == kaiConfig.Generation &&
-					condition.Reason == string(kaiv1.Reconciled) {
+					condition.Reason == string(kaiv1.Reconciling) {
 					found = true
 				}
 			}
@@ -116,6 +116,8 @@ var _ = Describe("Status Controller", func() {
 			isAvailable = isAvailable && !isAvailableErr
 			Expect(checkIsDeployed(object.GetConditions())).To(Equal(isDeployed))
 			Expect(checkIsAvailable(object.GetConditions())).To(Equal(isAvailable))
+			Expect(checkIsReady(object.GetConditions())).To(Equal(isAvailable))
+			Expect(checkIsReconciling(object.GetConditions())).To(BeFalse())
 		},
 			Entry("kai config - no errors, all set", func() objectWithConditions { return &KAIConfigWithStatusWrapper{Config: kaiConfig} }, false, true, false, true),
 			Entry("kai config - no errors, deployed not avaialbe", func() objectWithConditions { return &KAIConfigWithStatusWrapper{Config: kaiConfig} }, false, true, false, false),
@@ -146,6 +148,22 @@ func checkIsAvailable(conditions []metav1.Condition) bool {
 		return false
 	}
 	return isAvailableCondition.Status == metav1.ConditionTrue
+}
+
+func checkIsReady(conditions []metav1.Condition) bool {
+	isReadyCondition := getConditionByType(conditions, string(kaiv1.ConditionTypeReady))
+	if isReadyCondition == nil {
+		return false
+	}
+	return isReadyCondition.Status == metav1.ConditionTrue
+}
+
+func checkIsReconciling(conditions []metav1.Condition) bool {
+	isReconcilingCondition := getConditionByType(conditions, string(kaiv1.ConditionTypeReconciling))
+	if isReconcilingCondition == nil {
+		return false
+	}
+	return isReconcilingCondition.Status == metav1.ConditionTrue
 }
 
 func getConditionByType(conditions []metav1.Condition, conditionType string) *metav1.Condition {


### PR DESCRIPTION
## Description

Backport of #1060 to v0.9.

The core behavioral fix from #1060 (Reconciling condition toggling to false after reconciliation, and Ready condition) was already present on v0.9. This backport adds the remaining pieces that were missing:

### Changes

- Add `Reconciling` and `NotReady` condition reason constants
- Use `Reconciling` reason when reconciliation starts (previously used `Reconciled` for both states)
- Use `NotReady` reason when system is not ready (previously used `Ready` for both states)
- Add test assertions for `Ready` and `Reconciling` conditions in `ReconcileStatus` tests

### kstatus behavior after fix

| Phase | `Reconciling` | `Ready` | kstatus result |
|-------|--------------|---------|----------------|
| Start of reconcile | `True` (reason: `reconciling`) | (unchanged) | `InProgress` |
| End, system available | `False` (reason: `reconciled`) | `True` (reason: `ready`) | `Current` |
| End, system not available | `False` (reason: `reconciled`) | `False` (reason: `not_ready`) | `InProgress` |

## Related Issues

Fixes #1042

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)

## Breaking Changes

None.

## Additional Notes

- v0.6 and v0.4 do not need this backport as the operator component (`pkg/operator/`) does not exist on those branches.