### PR TITLE
fix(scheduler): Do not include resources with a count of 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
+
 ## [v0.13.0] - 2026-03-02
 ### Added
 - Added `global.nodeSelector` propagation from Helm values to Config CR, ensuring operator-created sub-component deployments (admission, binder, scheduler, pod-grouper, etc.) receive the configured nodeSelector [#1102](https://github.com/NVIDIA/KAI-Scheduler/pull/1102) [yuanchen8911](https://github.com/yuanchen8911)

--- a/pkg/scheduler/api/resource_info/resource_info.go
+++ b/pkg/scheduler/api/resource_info/resource_info.go
@@ -53,6 +53,9 @@ func NewResource(milliCPU float64, memory float64, gpus float64) *Resource {
 func ResourceFromResourceList(rList v1.ResourceList) *Resource {
 	r := EmptyResource()
 	for rName, rQuant := range rList {
+		if rQuant.IsZero() {
+			continue
+		}
 		switch rName {
 		case v1.ResourceCPU:
 			r.milliCpu += float64(rQuant.MilliValue())

--- a/pkg/scheduler/api/resource_info/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info/resource_info_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resource_info
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Resource internal logic", func() {
+	Context("ResourceFromResourceList", func() {
+		It("should skip resources with zero quantity", func() {
+			resourceList := v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("5G"),
+				GPUResourceName:   resource.MustParse("1"),
+				v1.ResourceName("nvidia.com/mig-1g.24gb"): resource.MustParse("0"),
+				v1.ResourceName("nvidia.com/mig-2g.48gb"): resource.MustParse("0"),
+				v1.ResourceName("rdma/ib0"):               resource.MustParse("0"),
+			}
+
+			resource := ResourceFromResourceList(resourceList)
+
+			Expect(resource.milliCpu).To(Equal(float64(1000)))
+			Expect(resource.memory).To(Equal(float64(5000000000)))
+			Expect(resource.gpus).To(Equal(float64(1)))
+
+			scalarResources := resource.ScalarResources()
+			_, hasMig1g := scalarResources[v1.ResourceName("nvidia.com/mig-1g.24gb")]
+			_, hasMig2g := scalarResources[v1.ResourceName("nvidia.com/mig-2g.48gb")]
+			_, hasRdma := scalarResources[v1.ResourceName("rdma/ib0")]
+
+			Expect(hasMig1g).To(BeFalse())
+			Expect(hasMig2g).To(BeFalse())
+			Expect(hasRdma).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
# Description
Backport of #1123 to `v0.13`.