### PR TITLE
ci: disable coverage report for PRs targeting non-main branches

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -76,7 +76,7 @@ jobs:
     name: Code Coverage Report
     runs-on: ubuntu-latest
     needs: [ validate-and-test, check-build-and-test-required ]
-    if: github.event_name != 'merge_group' && needs.check-build-and-test-required.outputs.code == 'true'
+    if: github.event_name != 'merge_group' && needs.check-build-and-test-required.outputs.code == 'true' && github.base_ref == 'main'
     steps:
       - uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682
         id: coverage_reporter

--- a/.github/workflows/post-coverage-comment.yaml
+++ b/.github/workflows/post-coverage-comment.yaml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - name: Download PR number artifact
+        id: download_pr_number
+        continue-on-error: true
         uses: actions/download-artifact@v7
         with:
           name: pr-number-for-comment
@@ -27,6 +29,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download coverage report artifact
+        id: download_coverage_report
+        continue-on-error: true
         uses: actions/download-artifact@v7
         with:
           name: coverage-report-for-comment
@@ -34,6 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post comment
+        if: steps.download_pr_number.outcome == 'success' && steps.download_coverage_report.outcome == 'success'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Description

Coverage baseline only exists for main, so skip the coverage report job for PRs to version branches. Handle missing artifacts gracefully in the post-coverage-comment workflow.

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)