### PR TITLE
fix(admission): remove nvidia as default gpuPodRuntimeClassName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
 - Fixed scheduling-constraints signature hashing for `Priority` and container `HostPort` by encoding full `int32` values, preventing byte-truncation collisions and flaky signature tests.
+- Changed default `gpuPodRuntimeClassName` from `nvidia` to empty string (disabled) so clusters without an `nvidia` RuntimeClass work out of the box [#1151](https://github.com/NVIDIA/KAI-Scheduler/issues/1151)
 
 ### Added
 - Added support for Ray subgroup topology-aware scheduling by specifying `kai.scheduler/topology`, `kai.scheduler/topology-required-placement`, and `kai.scheduler/topology-preferred-placement` annotations.

--- a/cmd/admission/app/options.go
+++ b/cmd/admission/app/options.go
@@ -4,8 +4,6 @@
 package app
 
 import (
-	"fmt"
-
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/spf13/pflag"
 
@@ -68,7 +66,7 @@ func InitOptions() *Options {
 		"Specifies if the GPU sharing is enabled")
 	fs.StringVar(&options.GPUPodRuntimeClassName,
 		"gpu-pod-runtime-class-name", constants.DefaultRuntimeClassName,
-		fmt.Sprintf("Runtime class to be set for GPU pods (defaults to %s) Set to empty string to disable", constants.DefaultRuntimeClassName))
+		"Runtime class to be set for GPU pods. Defaults to empty (disabled). Set to 'nvidia' or another runtime class name to enable injection")
 
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
 

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -128,7 +128,7 @@ admission:
     metricsPort: 8080
     probePort: 8081
   cdi: false
-  gpuPodRuntimeClassName: nvidia
+  gpuPodRuntimeClassName: ""
   affinity: {}
 
 nodescaleadjuster:

--- a/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go
+++ b/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go
@@ -30,14 +30,14 @@ func TestMutate(t *testing.T) {
 	}{
 		{
 			name:                   "pod without GPU requests",
-			gpuPodRuntimeClassName: constants.DefaultRuntimeClassName,
+			gpuPodRuntimeClassName: "nvidia",
 			incomingPod:            &v1.Pod{},
 			expectedOutboundPod:    &v1.Pod{},
 			expectedError:          nil,
 		},
 		{
 			name:                   "pod with a fractional GPU request",
-			gpuPodRuntimeClassName: constants.DefaultRuntimeClassName,
+			gpuPodRuntimeClassName: "nvidia",
 			incomingPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{constants.GpuFraction: "0.5"},
@@ -48,14 +48,14 @@ func TestMutate(t *testing.T) {
 					Annotations: map[string]string{constants.GpuFraction: "0.5"},
 				},
 				Spec: v1.PodSpec{
-					RuntimeClassName: ptr.To(constants.DefaultRuntimeClassName),
+					RuntimeClassName: ptr.To("nvidia"),
 				},
 			},
 			expectedError: nil,
 		},
 		{
 			name:                   "pod with a whole GPU request",
-			gpuPodRuntimeClassName: constants.DefaultRuntimeClassName,
+			gpuPodRuntimeClassName: "nvidia",
 			incomingPod: &v1.Pod{
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -69,7 +69,7 @@ func TestMutate(t *testing.T) {
 			},
 			expectedOutboundPod: &v1.Pod{
 				Spec: v1.PodSpec{
-					RuntimeClassName: ptr.To(constants.DefaultRuntimeClassName),
+					RuntimeClassName: ptr.To("nvidia"),
 					Containers: []v1.Container{
 						{
 							Resources: v1.ResourceRequirements{
@@ -110,7 +110,7 @@ func TestMutate(t *testing.T) {
 		},
 		{
 			name:                   "pod with GPU request and runtimeClassName set",
-			gpuPodRuntimeClassName: constants.DefaultRuntimeClassName,
+			gpuPodRuntimeClassName: "nvidia",
 			incomingPod: &v1.Pod{
 				Spec: v1.PodSpec{
 					RuntimeClassName: ptr.To("custom-runtime"),

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -21,7 +21,7 @@ const (
 	DefaultScaleAdjustName                = "kai-scale-adjust"
 	DefaultKAIConfigSingeltonInstanceName = "kai-config"
 	DefaultNodePoolLabelKey               = "kai.scheduler/node-pool"
-	DefaultRuntimeClassName               = "nvidia"
+	DefaultRuntimeClassName               = ""
 
 	DefaultCPUWorkerNodeLabelKey = "node-role.kubernetes.io/cpu-worker"
 	DefaultGPUWorkerNodeLabelKey = "node-role.kubernetes.io/gpu-worker"


### PR DESCRIPTION
## Summary

- Changes the default `gpuPodRuntimeClassName` from `nvidia` to an empty string (disabled)
- Not every cluster has an `nvidia` RuntimeClass defined, and the current default causes pod creation failures on those setups
- Users who require the nvidia runtime class can still explicitly configure it via `--set admission.gpuPodRuntimeClassName=nvidia`

## Motivation

As raised in #1151, there is currently no straightforward way to unset the `gpuPodRuntimeClassName` during helm install in v0.13.0. The root cause is that `nvidia` is hardcoded as the default value in both the Helm chart (`values.yaml`) and the Go constant (`DefaultRuntimeClassName`). This is problematic for clusters that either don't use NVIDIA GPUs or have GPU support configured through the cluster's default runtime rather than a dedicated RuntimeClass.

## Changes

- `pkg/common/constants/constants.go`: Changed `DefaultRuntimeClassName` from `"nvidia"` to `""`
- `deployments/kai-scheduler/values.yaml`: Changed `gpuPodRuntimeClassName` default from `nvidia` to `""`
- `cmd/admission/app/options.go`: Updated the CLI flag help text to reflect the new default behaviour
- `pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement_test.go`: Updated test cases to use hardcoded `"nvidia"` rather than the constant, so they still excercise the configured runtime class injection path
- `CHANGELOG.md`: Documented the change under Unreleased > Fixed

## Test plan

- [x] Verified `go build ./...` completes successfully
- [x] Ran unit tests for `runtimeenforcement`, `admission`, `operator/operands/admission`, `binder/binding/resourcereservation`, and `binder/controllers` — all pass
- [x] Ran `helm lint` and `helm template` — chart renders `gpuPodRuntimeClassName: ""` as expected
- [ ] CI should confirm full test suite passes