### PR TITLE
fix(admission): validate subgroup names are lowercase on PodGroup creation

### DIFF
--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -67,6 +68,12 @@ func (_ *PodGroup) ValidateDelete(ctx context.Context, obj runtime.Object) (admi
 func validateSubGroups(subGroups []SubGroup) error {
 	subGroupMap := map[string]*SubGroup{}
 	for _, subGroup := range subGroups {
+		if subGroup.Name != strings.ToLower(subGroup.Name) {
+			return fmt.Errorf("subgroup name %q must be lowercase", subGroup.Name)
+		}
+		if subGroup.Parent != nil && *subGroup.Parent != strings.ToLower(*subGroup.Parent) {
+			return fmt.Errorf("subgroup parent %q must be lowercase", *subGroup.Parent)
+		}
 		if subGroupMap[subGroup.Name] != nil {
 			return fmt.Errorf("duplicate subgroup name %s", subGroup.Name)
 		}

--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
@@ -19,29 +19,29 @@ func TestValidateSubGroups(t *testing.T) {
 		{
 			name: "Valid DAG single root",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "C", Parent: ptr.To("B"), MinMember: 1},
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "c", Parent: ptr.To("b"), MinMember: 1},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "Valid DAG multiple roots",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", MinMember: 1},
-				{Name: "C", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "D", Parent: ptr.To("B"), MinMember: 1},
+				{Name: "a", MinMember: 1},
+				{Name: "b", MinMember: 1},
+				{Name: "c", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "d", Parent: ptr.To("b"), MinMember: 1},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "Missing parent",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", Parent: ptr.To("X"), MinMember: 1}, // parent X does not exist
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("x"), MinMember: 1}, // parent x does not exist
 			},
-			wantErr: errors.New("parent X of B was not found"),
+			wantErr: errors.New("parent x of b was not found"),
 		},
 		{
 			name:      "Empty list",
@@ -51,46 +51,68 @@ func TestValidateSubGroups(t *testing.T) {
 		{
 			name: "Duplicate subgroup names",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "A", MinMember: 1}, // duplicate
+				{Name: "a", MinMember: 1},
+				{Name: "a", MinMember: 1}, // duplicate
 			},
-			wantErr: errors.New("duplicate subgroup name A"),
+			wantErr: errors.New("duplicate subgroup name a"),
 		},
 		{
-			name: "Cycle in graph (A -> B -> C -> A) - duplicate subgroup name",
+			name: "Cycle in graph (a -> b -> c -> a) - duplicate subgroup name",
 			subGroups: []SubGroup{
-				{Name: "A", MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "C", Parent: ptr.To("B"), MinMember: 1},
-				{Name: "A", Parent: ptr.To("C"), MinMember: 1}, // creates a cycle
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "c", Parent: ptr.To("b"), MinMember: 1},
+				{Name: "a", Parent: ptr.To("c"), MinMember: 1}, // creates a cycle
 			},
-			wantErr: errors.New("duplicate subgroup name A"), // duplicate is caught before cycle
+			wantErr: errors.New("duplicate subgroup name a"), // duplicate is caught before cycle
 		},
 		{
 			name: "Self-parent subgroup (cycle of length 1)",
 			subGroups: []SubGroup{
-				{Name: "A", Parent: ptr.To("A"), MinMember: 1},
+				{Name: "a", Parent: ptr.To("a"), MinMember: 1},
 			},
 			wantErr: errors.New("cycle detected in subgroups"),
 		},
 		{
-			name: "Cycle in graph (A -> B -> C -> A)",
+			name: "Cycle in graph (a -> b -> c -> a)",
 			subGroups: []SubGroup{
-				{Name: "A", Parent: ptr.To("C"), MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1},
-				{Name: "C", Parent: ptr.To("B"), MinMember: 1}, // creates a cycle
+				{Name: "a", Parent: ptr.To("c"), MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1},
+				{Name: "c", Parent: ptr.To("b"), MinMember: 1}, // creates a cycle
 			},
 			wantErr: errors.New("cycle detected in subgroups"),
 		},
 		{
 			name: "Multiple disjoint cycles",
 			subGroups: []SubGroup{
-				{Name: "A", Parent: ptr.To("B"), MinMember: 1},
-				{Name: "B", Parent: ptr.To("A"), MinMember: 1}, // cycle A <-> B
-				{Name: "C", Parent: ptr.To("D"), MinMember: 1},
-				{Name: "D", Parent: ptr.To("C"), MinMember: 1}, // cycle C <-> D
+				{Name: "a", Parent: ptr.To("b"), MinMember: 1},
+				{Name: "b", Parent: ptr.To("a"), MinMember: 1}, // cycle a <-> b
+				{Name: "c", Parent: ptr.To("d"), MinMember: 1},
+				{Name: "d", Parent: ptr.To("c"), MinMember: 1}, // cycle c <-> d
 			},
 			wantErr: errors.New("cycle detected in subgroups"),
+		},
+		{
+			name: "Uppercase subgroup name rejected",
+			subGroups: []SubGroup{
+				{Name: "Workers", MinMember: 1},
+			},
+			wantErr: errors.New(`subgroup name "Workers" must be lowercase`),
+		},
+		{
+			name: "Mixed-case subgroup name rejected",
+			subGroups: []SubGroup{
+				{Name: "myGroup", MinMember: 1},
+			},
+			wantErr: errors.New(`subgroup name "myGroup" must be lowercase`),
+		},
+		{
+			name: "Uppercase parent reference rejected",
+			subGroups: []SubGroup{
+				{Name: "a", MinMember: 1},
+				{Name: "b", Parent: ptr.To("A"), MinMember: 1},
+			},
+			wantErr: errors.New(`subgroup parent "A" must be lowercase`),
 		},
 	}
 


### PR DESCRIPTION
Closes #948.

## Problem

The scheduler internally lowercases subgroup parent names via `formatParentName()` in `pkg/scheduler/api/podgroup_info/subgroup_info/factory.go`, but this constraint was never validated at admission time. A user creating a PodGroup with mixed-case subgroup names (e.g. `Workers`) would have their resources accepted by the API but then silently hit parent-lookup failures during scheduling, which is quite confusing to diagnose.

## Solution

Added lowercase validation in the PodGroup validating webhook (`validateSubGroups`) that rejects:
- Subgroup names containing uppercase characters
- Parent references containing uppercase characters

Both `ValidateCreate` and `ValidateUpdate` paths are covered since they share the same validation function. This ensures the constraint is properly recognised and enforced before the resource reaches the scheduler.

## Changes

- `pkg/apis/scheduling/v2alpha2/podgroup_webhook.go` — added `strings.ToLower` checks for `SubGroup.Name` and `SubGroup.Parent` in `validateSubGroups()`
- `pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go` — updated existing test fixtures to use lowercase names (matching the new constraint), added three new test cases:
  - Uppercase subgroup name rejected
  - Mixed-case subgroup name rejceted
  - Uppercase parent reference rejected

## Test plan

- [x] All existing `TestValidateSubGroups` cases pass with lowercase fixture names
- [x] New validation cases cover uppercase name, mixed-case name, and uppercase parent