### PR TITLE
fix: allow device-plugin GPU requests on dual-mode nodes

### DIFF
--- a/pkg/scheduler/api/node_info/node_info.go
+++ b/pkg/scheduler/api/node_info/node_info.go
@@ -98,6 +98,9 @@ type NodeInfo struct {
 
 	// HasDRAGPUs indicates GPUs were added via DRA ResourceSlices. Temporary fix - remove when device-plugin pods are supported on DRA nodes.
 	HasDRAGPUs bool
+	// HasDevicePluginGPUs indicates the node has GPUs advertised via the device-plugin (nvidia.com/gpu in allocatable).
+	// Used together with HasDRAGPUs to identify dual-mode nodes that support both device-plugin and DRA GPU requests.
+	HasDevicePluginGPUs bool
 
 	PodAffinityInfo pod_affinity.NodePodAffinityInfo
 
@@ -324,8 +327,9 @@ func (ni *NodeInfo) PredicateByNodeResourcesType(task *pod_info.PodInfo) error {
 	}
 
 	// Temporary fix: Reject device-plugin GPU requests on DRA-only nodes.
-	// Remove when device-plugin pods are supported on DRA nodes.
-	if task.ResReq.GPUs() > 0 && ni.HasDRAGPUs {
+	// Allow device-plugin requests on dual-mode nodes (both device-plugin and DRA GPUs).
+	// Remove when device-plugin pods are fully supported on DRA nodes.
+	if task.ResReq.GPUs() > 0 && ni.HasDRAGPUs && !ni.HasDevicePluginGPUs {
 		log.InfraLogger.V(4).Infof("Task %s/%s rejected on node %s: device-plugin GPU request on DRA-only node",
 			task.Namespace, task.Name, ni.Name)
 		return common_info.NewFitError(task.Name, task.Namespace, ni.Name,

--- a/pkg/scheduler/api/node_info/node_info_test.go
+++ b/pkg/scheduler/api/node_info/node_info_test.go
@@ -1353,6 +1353,20 @@ func TestPredicateByNodeResourcesType_DRA(t *testing.T) {
 			expectError: false,
 			errorMsg:    "",
 		},
+		"Device-plugin GPU request on dual-mode node (both device-plugin and DRA)": {
+			nodeInfo: &NodeInfo{
+				Name:                "dual-mode-node",
+				HasDRAGPUs:          true,
+				HasDevicePluginGPUs: true,
+				Allocatable:         common_info.BuildResourceWithGpu("1000m", "1G", "4", "110"),
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "dual-mode-node", Labels: map[string]string{}},
+				},
+			},
+			task:        createPod("default", "gpu-pod", podCreationOptions{GPUs: 1}),
+			expectError: false,
+			errorMsg:    "",
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/scheduler/cache/cluster_info/cluster_info.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info.go
@@ -283,9 +283,16 @@ func (c *ClusterInfo) populateDRAGPUs(nodes map[string]*node_info.NodeInfo) {
 		if draGPUCount > 0 {
 			log.InfraLogger.V(6).Infof("Node %s has %d DRA GPUs from ResourceSlices", nodeName, draGPUCount)
 			if nodeInfo.Allocatable.GPUs() > 0 {
-				log.InfraLogger.Warningf("Node %s has both device-plugin GPUs and DRA GPUs", nodeName)
+				// Dual-mode node: same physical GPUs are advertised by both device-plugin
+				// and DRA. Skip AddDRAGPUs to avoid double-counting the GPU capacity.
+				// Device-plugin accounting is already correct; just record both modes.
+				log.InfraLogger.Warningf("Node %s has both device-plugin GPUs (%v) and DRA GPUs (%d); using device-plugin accounting",
+					nodeName, nodeInfo.Allocatable.GPUs(), draGPUCount)
+				nodeInfo.HasDevicePluginGPUs = true
+			} else {
+				// DRA-only node: add DRA GPUs to the allocatable pool.
+				nodeInfo.AddDRAGPUs(float64(draGPUCount))
 			}
-			nodeInfo.AddDRAGPUs(float64(draGPUCount))
 			nodeInfo.HasDRAGPUs = true
 		}
 	}

--- a/pkg/scheduler/cache/cluster_info/cluster_info_test.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info_test.go
@@ -2410,10 +2410,11 @@ func newPodOnNode(pod *corev1.Pod, nodeName string) *corev1.Pod {
 
 func TestSnapshotNodesWithDRAGPUs(t *testing.T) {
 	tests := map[string]struct {
-		nodes           []*corev1.Node
-		resourceSlices  []*resourceapi.ResourceSlice
-		expectedDRAGPUs map[string]float64
-		hasDRAGPUs      map[string]bool
+		nodes               []*corev1.Node
+		resourceSlices      []*resourceapi.ResourceSlice
+		expectedDRAGPUs     map[string]float64
+		hasDRAGPUs          map[string]bool
+		hasDevicePluginGPUs map[string]bool
 	}{
 		"Single node with DRA GPUs": {
 			nodes: []*corev1.Node{
@@ -2456,6 +2457,26 @@ func TestSnapshotNodesWithDRAGPUs(t *testing.T) {
 			resourceSlices:  []*resourceapi.ResourceSlice{},
 			expectedDRAGPUs: map[string]float64{"node-1": 0},
 			hasDRAGPUs:      map[string]bool{"node-1": false},
+		},
+		"Dual-mode node with device-plugin and DRA GPUs": {
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			resourceSlices: []*resourceapi.ResourceSlice{
+				createTestResourceSlice("slice-1", "node-1", "nvidia.com/gpu", 8),
+			},
+			// Device-plugin GPUs should NOT be double-counted with DRA GPUs.
+			// The same physical GPUs are advertised by both; use device-plugin accounting only.
+			expectedDRAGPUs:     map[string]float64{"node-1": 8},
+			hasDRAGPUs:          map[string]bool{"node-1": true},
+			hasDevicePluginGPUs: map[string]bool{"node-1": true},
 		},
 		"Two device classes on same node": {
 			nodes: []*corev1.Node{
@@ -2515,6 +2536,10 @@ func TestSnapshotNodesWithDRAGPUs(t *testing.T) {
 				assert.Equal(t, expectedGPUs, actualGPUs, "GPUs mismatch for node %s", nodeName)
 				expectedFlag := test.hasDRAGPUs[nodeName]
 				assert.Equal(t, expectedFlag, nodeInfo.HasDRAGPUs, "HasDRAGPUs mismatch for node %s", nodeName)
+				if test.hasDevicePluginGPUs != nil {
+					expectedDP := test.hasDevicePluginGPUs[nodeName]
+					assert.Equal(t, expectedDP, nodeInfo.HasDevicePluginGPUs, "HasDevicePluginGPUs mismatch for node %s", nodeName)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Nodes running both the NVIDIA device-plugin (`nvidia.com/gpu` in allocatable) and the DRA GPU driver (ResourceSlices with `gpu.nvidia.com` driver) are incorrectly classified as DRA-only. This causes `PredicateByNodeResourcesType` to reject all device-plugin GPU pod requests with "device-plugin GPU requests cannot be scheduled on DRA-only nodes", even though the node can serve them via the device-plugin.

Additionally, `AddDRAGPUs` was called unconditionally on these dual-mode nodes, double-counting the same physical GPUs (device-plugin + DRA) in the allocatable pool, which could lead to GPU overcommitment.

This is common on clusters that deploy both `gpu-operator` (device-plugin) and `nvidia-dra-driver` simultaneously, such as EKS clusters with NVIDIA GPU Operator v25.10+ and DRA driver v25.12+.

## Changes

- Add `HasDevicePluginGPUs` field to `NodeInfo` to track whether a node advertises GPUs via the device-plugin
- Skip `AddDRAGPUs` on dual-mode nodes to prevent double-counting (same physical GPUs are advertised by both device-plugin and DRA)
- Update `PredicateByNodeResourcesType` to allow device-plugin GPU requests on dual-mode nodes (`HasDRAGPUs && HasDevicePluginGPUs`)
- Add predicate test for dual-mode node scheduling
- Add cluster snapshot test for dual-mode GPU accounting

## Assumptions

This change assumes that on dual-mode nodes, DRA ResourceSlices and device-plugin `nvidia.com/gpu` represent the **same physical GPUs**. If a future configuration exposes distinct GPU pools via each mechanism, the accounting policy would need revisiting.

## Test plan

- [x] `TestPredicateByNodeResourcesType_DRA`: DRA-only still blocked, device-plugin-only still allowed, dual-mode now allowed
- [x] `TestSnapshotNodesWithDRAGPUs`: dual-mode node reports 8 GPUs (not 16), `HasDevicePluginGPUs=true`
- [ ] Manual validation on EKS cluster with gpu-operator + nvidia-dra-driver (8x H100 node with both `nvidia.com/gpu: 8` and DRA ResourceSlices)