### PR TITLE
fix(ci): use set version for benchstat

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -37,7 +37,7 @@ jobs:
           cache: true
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260209182753-b57e4e371b65
 
       - name: Download envtest binaries
         run: |


### PR DESCRIPTION
## Description

Fix the benchmark action by setting benchstat to a specific version
The latest version requires go1.25 - until we upgrade we can use this version.