### PR TITLE
ci: Run fossa ci check only on successful build

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -36,23 +36,6 @@ jobs:
               - '!**/*.md'
               - '!docs/**'
 
-  fossa-validate:
-    name: FOSSA license check
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    env:
-      # push-only token, intentional; see https://github.com/fossa-contrib/fossa-action?tab=readme-ov-file#push-only-api-token
-      FOSSA_API_KEY: 577e3d21c48454822ae8ea496209a505 # This is a push-only token that is safe to be exposed.
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run FOSSA analysis and validate status
-        uses: fossa-contrib/fossa-action@v3.0.1
-        with:
-          fossa-api-key: ${{ env.FOSSA_API_KEY }}
-          skip-test: false
-
   validate-and-test:
     needs: [ check-build-and-test-required ]
     if: needs.check-build-and-test-required.outputs.code == 'true'
@@ -326,3 +309,22 @@ jobs:
           UPGRADE_CHART_PATH: /mnt/images/kai-scheduler-${{ needs.build.outputs.package_version }}.tgz
         run: |
           ginkgo -r --keep-going --trace -vv --label-filter 'upgrade' --output-dir=. --json-report=e2e-upgrade-report.json ./test/e2e/suites/upgrade
+
+  fossa-validate:
+    needs: [ build, check-build-and-test-required ]
+    if: needs.check-build-and-test-required.outputs.code == 'true'
+    name: FOSSA license check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      # push-only token, intentional; see https://github.com/fossa-contrib/fossa-action?tab=readme-ov-file#push-only-api-token
+      FOSSA_API_KEY: 577e3d21c48454822ae8ea496209a505 # This is a push-only token that is safe to be exposed.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run FOSSA analysis and validate status
+        uses: fossa-contrib/fossa-action@v3.0.1
+        with:
+          fossa-api-key: ${{ env.FOSSA_API_KEY }}
+          skip-test: false


### PR DESCRIPTION
## Description

Run fossa ci check only on successful build

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
