### PR TITLE
fix(chart): auto-enable leader election when operator.replicaCount > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Users that have VPA installed on their cluster can now utilize it for proper vertical autoscaling
 - Added FOSSA scanning for the repository context. Scans will also be performed for submitted PRs. The results can be found [here](https://app.fossa.com/projects/custom%2B162%2Fgit%40github.com%3Akai-scheduler%2FKAI-Scheduler.git). [#1178](https://github.com/kai-scheduler/KAI-Scheduler/pull/1178) - [davidLif](https://github.com/davidLif) 
 - Added support for Ray subgroup topology-aware scheduling by specifying `kai.scheduler/topology`, `kai.scheduler/topology-required-placement`, and `kai.scheduler/topology-preferred-placement` annotations.
-- Allow subgroups to have a 0 value for "minAvailable". This means that all pods in this subgroup are "elastic extra pods". [#1216](https://github.com/NVIDIA/KAI-Scheduler/pull/1216) [davidLif](https://github.com/davidLif) 
+- Allow subgroups to have a 0 value for "minAvailable". This means that all pods in this subgroup are "elastic extra pods". [#1216](https://github.com/NVIDIA/KAI-Scheduler/pull/1216) [davidLif](https://github.com/davidLif)
+
+### Changed
+- Auto-enable leader election when `operator.replicaCount` > 1 to prevent concurrent reconciliation [#1218](https://github.com/kai-scheduler/KAI-Scheduler/issues/1218)
+- Update go version to v1.26.1, With appropriate upgrades to the base docker images, linter, and controller generator. [#1222](https://github.com/kai-scheduler/KAI-Scheduler/pull/1222) - [davidLif](https://github.com/davidLif)
 
 ### Fixed
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
@@ -19,9 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed scheduling-constraints signature hashing for `Priority` and container `HostPort` by encoding full `int32` values, preventing byte-truncation collisions and flaky signature tests.
 - Fixed rollback in scheduling simulations with DRA [#1168](https://github.com/NVIDIA/KAI-Scheduler/pull/1168) [itsomri](https://github.com/itsomri)
 - Fixed a potential state corruption in DRA scheduling simulations [#1219](https://github.com/kai-scheduler/KAI-Scheduler/pull/1219) [itsomri](https://github.com/itsomri)
-
-### Changed
-- Update go version to v1.26.1, With appropriate upgrades to the base docker images, linter, and controller generator. [#1222](https://github.com/kai-scheduler/KAI-Scheduler/pull/1222) - [davidLif](https://github.com/davidLif) 
 
 ## [v0.13.0] - 2026-03-02
 ### Added

--- a/deployments/kai-scheduler/templates/services/operator.yaml
+++ b/deployments/kai-scheduler/templates/services/operator.yaml
@@ -30,7 +30,7 @@ spec:
         args:
           - --metrics-bind-address={{ .Values.operator.metricsBindAddress | default ":8080" }}
           - --health-probe-bind-address={{ .Values.operator.probeBindAddress | default ":8081" }}
-          - --leader-elect={{ .Values.global.leaderElection | default false }}
+          - --leader-elect={{ or .Values.global.leaderElection (gt (int .Values.operator.replicaCount) 1) }}
           - --qps={{ .Values.operator.qps | default 50 }}
           - --burst={{ .Values.operator.burst | default 300 }}
           - --namespace={{ .Release.Namespace }}

--- a/deployments/kai-scheduler/tests/leader_election_test.yaml
+++ b/deployments/kai-scheduler/tests/leader_election_test.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test leader election auto-enable
+templates:
+  - services/operator.yaml
+tests:
+  - it: should disable leader election by default (single replica)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=false"
+
+  - it: should enable leader election when global.leaderElection is true
+    set:
+      global.leaderElection: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"
+
+  - it: should auto-enable leader election when replicaCount > 1
+    set:
+      operator.replicaCount: 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"
+
+  - it: should keep leader election enabled when both leaderElection and replicaCount > 1
+    set:
+      global.leaderElection: true
+      operator.replicaCount: 2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--leader-elect=true"


### PR DESCRIPTION
## Description

When `operator.replicaCount` is set to a value greater than 1, leader election is now automatically enabled regardless of the `global.leaderElection` value. This prevents a silent misconfiguration where multiple operator replicas concurrently reconcile resources, causing race conditions and resource flapping.

## Related Issues

Fixes #1218

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. Single-replica deployments are unaffected. Multi-replica deployments that previously ran without leader election (a misconfiguration) will now correctly enable it.

## Additional Notes

- The fix uses Helm template functions to auto-enable leader election: `{{ or .Values.global.leaderElection (gt (int .Values.operator.replicaCount) 1) }}`
- Added 4 helm unit tests covering: default (single replica), explicit enable, auto-enable with replicaCount > 1, and combined scenario