### PR TITLE
fix: split concurrency log, lower severity for conflict

### DIFF
--- a/pkg/scheduler/cache/status_updater/concurrency.go
+++ b/pkg/scheduler/cache/status_updater/concurrency.go
@@ -105,15 +105,17 @@ func (su *defaultStatusUpdater) updatePodGroup(
 	if statusErr != nil || patchErr != nil {
 
 		if statusErr != nil {
-			log.StatusUpdaterLogger.V(1).Errorf("Failed to update pod group status %s/%s: %v",
-				podGroup.Namespace, podGroup.Name, statusErr)
 			if apierrors.IsConflict(statusErr) {
 				// Don't retry this update if the resource version is outdated - The status update cannot be updated with the given object.
 				// If a pod group status update is required (e.g. a scheduling condition) a new status update with an updated object
 				//  will be enqueued in the next scheduling cycle.
+				log.StatusUpdaterLogger.V(5).Infof("Conflict updating pod group status %s/%s, will retry in next cycle: %v",
+					podGroup.Namespace, podGroup.Name, statusErr)
 				su.inFlightPodGroups.Delete(key)
 				return
 			}
+			log.StatusUpdaterLogger.V(1).Errorf("Failed to update pod group status %s/%s: %v",
+				podGroup.Namespace, podGroup.Name, statusErr)
 		}
 		if patchErr != nil {
 			log.StatusUpdaterLogger.V(1).Errorf("Failed to patch pod group %s/%s: %v",


### PR DESCRIPTION
Signed-off-by: SiorMeir <msior@nvidia.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for status update conflicts to enable faster recovery cycles through early returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->