### PR TITLE
fix(scheduler): gate ResourceSliceTracker behind DRA feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed scheduling-constraints signature hashing for `Priority` and container `HostPort` by encoding full `int32` values, preventing byte-truncation collisions and flaky signature tests.
 - Fixed rollback in scheduling simulations with DRA [#1168](https://github.com/NVIDIA/KAI-Scheduler/pull/1168) [itsomri](https://github.com/itsomri)
 - Fixed a potential state corruption in DRA scheduling simulations [#1219](https://github.com/kai-scheduler/KAI-Scheduler/pull/1219) [itsomri](https://github.com/itsomri)
+- Fixed scheduler not starting on k8s clusters with DRA disabled, due to the ResourceSliceTracker not syncing. #1241 [cypres](https://github.com/cypres)
 
 ## [v0.13.0] - 2026-03-02
 ### Added

--- a/pkg/scheduler/k8s_internal/plugins/plugins.go
+++ b/pkg/scheduler/k8s_internal/plugins/plugins.go
@@ -6,9 +6,11 @@ package plugins
 import (
 	"context"
 
+	featureutil "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
 	k8splfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -48,11 +50,13 @@ func InitializeInternalPlugins(
 	initiatedPlugins.FrameworkHandle = k8sFrameworkHandle
 	initiatedPlugins.InformerFactory = informerFactory
 
-	tracker, err := k8s_utils.StartResourceSliceTracker(informerFactory, client)
-	if err != nil {
-		log.InfraLogger.Errorf("Failed to start resource slice tracker: %v", err)
+	if featureutil.DefaultMutableFeatureGate.Enabled(features.DynamicResourceAllocation) {
+		tracker, err := k8s_utils.StartResourceSliceTracker(informerFactory, client)
+		if err != nil {
+			log.InfraLogger.Errorf("Failed to start resource slice tracker: %v", err)
+		}
+		initiatedPlugins.ResourceSliceTracker = tracker
 	}
-	initiatedPlugins.ResourceSliceTracker = tracker
 
 	features := k8s_utils.GetK8sFeatures()
 	initiatedPlugins.Features = features

--- a/pkg/scheduler/k8s_internal/plugins/plugins_test.go
+++ b/pkg/scheduler/k8s_internal/plugins/plugins_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	featuregate "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// These tests verify that DRA informers are only registered when the DynamicResourceAllocation
+// feature gate is enabled. Unconditional registration caused WaitForCacheSync to block forever
+// on clusters without the resource.k8s.io API group, preventing the scheduler from starting.
+var _ = Describe("InitializeInternalPlugins", func() {
+	Context("DRA feature gate disabled", func() {
+		It("should not create ResourceSliceTracker", func() {
+			featuregate.SetFeatureGateDuringTest(GinkgoT(), utilfeature.DefaultMutableFeatureGate,
+				features.DynamicResourceAllocation, false)
+
+			fakeClient := fake.NewSimpleClientset()
+			factory := informers.NewSharedInformerFactory(fakeClient, 0)
+
+			result := InitializeInternalPlugins(fakeClient, factory, nil)
+
+			Expect(result.ResourceSliceTracker).To(BeNil())
+		})
+	})
+})

--- a/pkg/scheduler/k8s_internal/plugins/suite_test.go
+++ b/pkg/scheduler/k8s_internal/plugins/suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlugins(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugins Suite")
+}


### PR DESCRIPTION
## Description

This PR fixes a problem where KAI-Scheduler was not scheduling workloads on Clusters without DRA, like a Kubernetes 1.31 cluster that we observed the behavior on.

  - StartResourceSliceTracker in plugins.go was registering DRA informers unconditionally
  - On clusters where resource.k8s.io API group doesn't exist, those informers never synced
  - WaitForCacheSync blocked forever, preventing the scheduling loop from ever starting
  - The fix gates it behind DynamicResourceAllocation feature flag, consistent with how kubernetes_lister.go already handled it

## Related Issues

Fixes #

Split off from #1229

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [X] Self-reviewed
- [X] Added/updated tests (if needed)
- [X] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
