### PR TITLE
ci: Skip dco checkout for dependabot PRs

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -9,7 +9,9 @@ on:
     types: [checks_requested]
 
 jobs:
-  check:
+  dco-check:
+    name: DCO
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
# Description
Backport of #1272 to `v0.9`.