### PR TITLE
ci: auto-pass DCO check for dependabot on merge_group events

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   dco-check:
     name: DCO
-    if: github.actor != 'dependabot[bot]' || (github.event_name != 'pull_request' && github.event_name != 'merge_group')
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

The DCO check was not skipping for `dependabot[bot]` commits when triggered via the GitHub merge queue (`merge_group` event). Since the workflow only triggers on `pull_request` and `merge_group`, a simple `github.actor != 'dependabot[bot]'` condition covers both cases.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.