### PR TITLE
ci: auto-pass DCO check for dependabot on merge_group events

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   dco-check:
     name: DCO
-    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
# Description
Backport of #1280 to `v0.9`.