### PR TITLE
fix(operator): stop webhook reconcile loop on AKS caused by injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed a potential state corruption in DRA scheduling simulations [#1219](https://github.com/kai-scheduler/KAI-Scheduler/pull/1219) [itsomri](https://github.com/itsomri)
 - Fixed operator reconcile loop caused by status-only updates triggering re-reconciliation. #1229 [cypres](https://github.com/cypres)
 - Fixed scheduler not starting on k8s clusters with DRA disabled, due to the ResourceSliceTracker not syncing. #1241 [cypres](https://github.com/cypres)
+- Fixed webhook reconcile loop on AKS, by retaining the cloud-provider-injected namespaceSelector rules during reconciliation. #1292 [cypres](https://github.com/cypres)
 
 ## [v0.13.0] - 2026-03-02
 ### Added

--- a/pkg/operator/operands/known_types/fieldInherit.go
+++ b/pkg/operator/operands/known_types/fieldInherit.go
@@ -3,7 +3,10 @@
 
 package known_types
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 type FieldInherit func(current, desired client.Object)
 
@@ -17,4 +20,25 @@ func mergeAnnotations(desiredAnnotations, currentAnnotations map[string]string) 
 		}
 	}
 	return desiredAnnotations
+}
+
+// mergeNamespaceSelector merges matchExpressions from current into desired, preserving any
+// entries in current whose key is not already present in desired (e.g. cloud-provider-injected rules).
+func mergeNamespaceSelector(desired, current *metav1.LabelSelector) *metav1.LabelSelector {
+	if current == nil {
+		return desired
+	}
+	if desired == nil {
+		return current
+	}
+	desiredKeys := map[string]bool{}
+	for _, expr := range desired.MatchExpressions {
+		desiredKeys[expr.Key] = true
+	}
+	for _, expr := range current.MatchExpressions {
+		if !desiredKeys[expr.Key] {
+			desired.MatchExpressions = append(desired.MatchExpressions, expr)
+		}
+	}
+	return desired
 }

--- a/pkg/operator/operands/known_types/known_types_test.go
+++ b/pkg/operator/operands/known_types/known_types_test.go
@@ -8,12 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestKnownTypes(t *testing.T) {
@@ -118,6 +118,86 @@ var _ = Describe("VPAFieldInherit", func() {
 		Expect(desired.GetAnnotations()).To(HaveKeyWithValue("user-set", "keep"))
 		Expect(desired.GetAnnotations()).To(HaveKeyWithValue("server-added", "val"))
 		Expect(desired.Status.Recommendation).ToNot(BeNil())
+	})
+})
+
+var _ = Describe("MutatingWebhookConfigurationFieldInherit", func() {
+	It("should preserve cloud-provider-injected namespaceSelector matchExpressions", func() {
+		aksExpressions := []metav1.LabelSelectorRequirement{
+			{Key: "control-plane", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"true"}},
+			{Key: "kubernetes.azure.com/managedby", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"aks"}},
+		}
+		desiredExpression := metav1.LabelSelectorRequirement{
+			Key: "kai-injection", Operator: metav1.LabelSelectorOpIn, Values: []string{"enabled"},
+		}
+
+		current := &admissionv1.MutatingWebhookConfiguration{
+			Webhooks: []admissionv1.MutatingWebhook{
+				{
+					Name: "test-webhook",
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: append([]metav1.LabelSelectorRequirement{desiredExpression}, aksExpressions...),
+					},
+				},
+			},
+		}
+		desired := &admissionv1.MutatingWebhookConfiguration{
+			Webhooks: []admissionv1.MutatingWebhook{
+				{
+					Name: "test-webhook",
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{desiredExpression},
+					},
+				},
+			},
+		}
+
+		MutatingWebhookConfigurationFieldInherit(current, desired)
+
+		exprs := desired.Webhooks[0].NamespaceSelector.MatchExpressions
+		Expect(exprs).To(ContainElement(desiredExpression))
+		Expect(exprs).To(ContainElement(aksExpressions[0]))
+		Expect(exprs).To(ContainElement(aksExpressions[1]))
+	})
+
+	It("should not duplicate namespaceSelector keys already present in desired", func() {
+		expr := metav1.LabelSelectorRequirement{
+			Key: "control-plane", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"true"},
+		}
+		current := &admissionv1.MutatingWebhookConfiguration{
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "wh", NamespaceSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{expr}}},
+			},
+		}
+		desired := &admissionv1.MutatingWebhookConfiguration{
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "wh", NamespaceSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{expr}}},
+			},
+		}
+
+		MutatingWebhookConfigurationFieldInherit(current, desired)
+
+		Expect(desired.Webhooks[0].NamespaceSelector.MatchExpressions).To(HaveLen(1))
+	})
+
+	It("should inherit TimeoutSeconds and MatchPolicy from current when not set in desired", func() {
+		timeout := int32(10)
+		policy := admissionv1.Equivalent
+		current := &admissionv1.MutatingWebhookConfiguration{
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "wh", TimeoutSeconds: &timeout, MatchPolicy: &policy},
+			},
+		}
+		desired := &admissionv1.MutatingWebhookConfiguration{
+			Webhooks: []admissionv1.MutatingWebhook{
+				{Name: "wh"},
+			},
+		}
+
+		MutatingWebhookConfigurationFieldInherit(current, desired)
+
+		Expect(desired.Webhooks[0].TimeoutSeconds).To(Equal(&timeout))
+		Expect(desired.Webhooks[0].MatchPolicy).To(Equal(&policy))
 	})
 })
 

--- a/pkg/operator/operands/known_types/mutationwebhookconfiguration.go
+++ b/pkg/operator/operands/known_types/mutationwebhookconfiguration.go
@@ -65,8 +65,15 @@ func MutatingWebhookConfigurationFieldInherit(current, desired client.Object) {
 	desiredT.Annotations = mergeAnnotations(desiredT.Annotations, currentT.Annotations)
 	if len(currentT.Webhooks) == len(desiredT.Webhooks) {
 		for webhookIndex, currentWebhook := range currentT.Webhooks {
-			if desiredT.Webhooks[webhookIndex].NamespaceSelector == nil {
-				desiredT.Webhooks[webhookIndex].NamespaceSelector = currentWebhook.NamespaceSelector
+			desiredT.Webhooks[webhookIndex].NamespaceSelector = mergeNamespaceSelector(
+				desiredT.Webhooks[webhookIndex].NamespaceSelector,
+				currentWebhook.NamespaceSelector,
+			)
+			if desiredT.Webhooks[webhookIndex].TimeoutSeconds == nil {
+				desiredT.Webhooks[webhookIndex].TimeoutSeconds = currentWebhook.TimeoutSeconds
+			}
+			if desiredT.Webhooks[webhookIndex].MatchPolicy == nil {
+				desiredT.Webhooks[webhookIndex].MatchPolicy = currentWebhook.MatchPolicy
 			}
 		}
 	}

--- a/pkg/operator/operands/known_types/validatingwebhookconfiguration.go
+++ b/pkg/operator/operands/known_types/validatingwebhookconfiguration.go
@@ -65,8 +65,15 @@ func ValidatingWebhookConfigurationFieldInherit(current, desired client.Object) 
 	desiredT.Annotations = mergeAnnotations(desiredT.Annotations, currentT.Annotations)
 	if len(currentT.Webhooks) == len(desiredT.Webhooks) {
 		for webhookIndex, currentWebhook := range currentT.Webhooks {
-			if desiredT.Webhooks[webhookIndex].NamespaceSelector == nil {
-				desiredT.Webhooks[webhookIndex].NamespaceSelector = currentWebhook.NamespaceSelector
+			desiredT.Webhooks[webhookIndex].NamespaceSelector = mergeNamespaceSelector(
+				desiredT.Webhooks[webhookIndex].NamespaceSelector,
+				currentWebhook.NamespaceSelector,
+			)
+			if desiredT.Webhooks[webhookIndex].TimeoutSeconds == nil {
+				desiredT.Webhooks[webhookIndex].TimeoutSeconds = currentWebhook.TimeoutSeconds
+			}
+			if desiredT.Webhooks[webhookIndex].MatchPolicy == nil {
+				desiredT.Webhooks[webhookIndex].MatchPolicy = currentWebhook.MatchPolicy
 			}
 		}
 	}


### PR DESCRIPTION
## Description

AKS automatically injects matchExpressions into webhook NamespaceSelectors (e.g. control-plane NotIn and kubernetes.azure.com/managedby NotIn aks). The previous FieldInherit only copied NamespaceSelector when desired was nil, so these injected entries were stripped every reconcile, triggering another update indefinitely.

Replace nil-only copy with mergeNamespaceSelector that preserves entries from current whose keys are not already present in desired. Also inherit TimeoutSeconds and MatchPolicy from current when not set in desired, to avoid spurious diffs from Kubernetes server-side defaults.

This is example of the diff between cycles in the reconcile loop
```diff
--- a.yaml	2026-03-20 16:30:19
+++ b.yaml	2026-03-20 16:30:22
@@ -2,7 +2,7 @@
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: "2026-03-20T23:14:28Z"
-  generation: 14477
+  generation: 14510
   labels:
     app: admission
   name: mutating-kai-admission
@@ -12,7 +12,7 @@
     kind: Config
     name: kai-config
     uid: 0dd63430-0cbf-4a27-bd76-c6f22e7e52b9
-  resourceVersion: "752830367"
+  resourceVersion: "752830457"
   uid: 890414ab-e783-4434-86fd-7b308be032f5
 webhooks:
 - admissionReviewVersions:
@@ -37,6 +37,14 @@
       values:
       - kube-system
       - kai-scheduler
+    - key: control-plane
+      operator: NotIn
+      values:
+      - "true"
+    - key: kubernetes.azure.com/managedby
+      operator: NotIn
+      values:
+      - aks
   objectSelector: {}
   reinvocationPolicy: IfNeeded
   rules:
```

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [X] Self-reviewed
- [X] Added/updated tests (if needed)
- [X] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

As described in the [AKS documentation](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-), you can break the loop by having the admissions enforcer ignore these webhooks
```
kubectl label mutatingwebhookconfigurations.admissionregistration.k8s.io/mutating-kai-admission admissions.enforcer/disabled=true
kubectl label validatingwebhookconfigurations.admissionregistration.k8s.io/validating-kai-admission admissions.enforcer/disabled=true
```