### PR TITLE
ci: Skip DCO check in merge queue commits, due to github shenanigans

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -9,9 +9,9 @@ on:
     types: [checks_requested]
 
 jobs:
-  dco-check:
+  dco-pull-request:
     name: DCO
-    if: github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,3 +27,12 @@ jobs:
         run: |
           pip3 install -U dco-check
           dco-check --verbose
+
+  dco-merge-queue:
+    name: DCO
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip DCO for merge queue
+        run: |
+          echo "DCO was already validated before entering merge queue"


### PR DESCRIPTION
## Description

Skip DCO check in merge queue commits, due to github shenanigans

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
