### PR TITLE
docs: Small min subgroup design validation update

### DIFF
--- a/docs/developer/designs/min-subgroups/README.md
+++ b/docs/developer/designs/min-subgroups/README.md
@@ -213,8 +213,8 @@ The following validations will be enforced via a Validating Webhook:
 
 ### Mutual Exclusivity
 1. **PodGroup Level**: `minMember` and `minSubGroup` are mutually exclusive
-   - If `minSubGroup` is specified, `minMember` must be 0 or unset
-   - If `minMember` is specified and > 0, `minSubGroup` must be nil
+   - If `minSubGroup` is specified, `minMember` must be -1
+   - If `minMember` is specified and >= 0, `minSubGroup` must be nil
 
 2. **SubGroup Level**: `minMember` and `minSubGroup` are mutually exclusive for each SubGroup
    - Same rules as PodGroup level


### PR DESCRIPTION
## Description

As we allow currently for minMember: 0 (full elastic podgroup), I recommend setting the minMember to -1 when not in use

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
