### PR TITLE
fix: generate-kind-config.sh for macos

### DIFF
--- a/hack/generate-kind-config.sh
+++ b/hack/generate-kind-config.sh
@@ -31,7 +31,7 @@ if [[ -z "$K8S_VERSION" || -z "$OUTPUT" ]]; then
   exit 1
 fi
 
-K8S_MINOR=$(echo "$K8S_VERSION" | grep -oP '(?<=v1\.)\d+')
+K8S_MINOR=$(echo "$K8S_VERSION" | sed -nE 's/^v1\.([0-9]+).*$/\1/p')
 
 if [[ -z "$K8S_MINOR" ]]; then
   echo "Error: could not parse minor version from --k8s-version '$K8S_VERSION'" >&2


### PR DESCRIPTION
## Description

Fix an unsupported grep argument on macos

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
