### PR TITLE
ci: Enable only security updates for existing releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
     target-branch: "v0.12"
     schedule:
       interval: "weekly"
+    # Enable only security updates for existing releases 
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
+    open-pull-requests-limit: 0 
     groups:
       kubernetes:
         patterns:
@@ -36,6 +39,9 @@ updates:
     target-branch: "v0.9"
     schedule:
       interval: "weekly"
+    # Enable only security updates for existing releases 
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
+    open-pull-requests-limit: 0 
     groups:
       kubernetes:
         patterns:
@@ -46,6 +52,9 @@ updates:
     target-branch: "v0.6"
     schedule:
       interval: "weekly"
+    # Enable only security updates for existing releases 
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
+    open-pull-requests-limit: 0 
     groups:
       kubernetes:
         patterns:
@@ -56,6 +65,9 @@ updates:
     target-branch: "v0.4"
     schedule:
       interval: "weekly"
+    # Enable only security updates for existing releases 
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
+    open-pull-requests-limit: 0 
     groups:
       kubernetes:
         patterns:


### PR DESCRIPTION
## Description

Enable only security updates for existing releases
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
