### PR TITLE
fix: Add resourceclaims/binding RBAC for DRA granular status authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed `windowSize` field in `SchedulingShard` CR to support Prometheus duration format (e.g. `1w`, `7d`). Previously, using `windowSize: 1w` as shown in the documentation caused the kai-operator to crash-loop with `time: unknown unit "w" in duration "1w"`.
 - Race condition where `SyncForGpuGroup` could prematurely delete reservation pods when the informer cache had not yet propagated GPU group labels on recently-bound fraction pods. The binder now checks for active BindRequests referencing the GPU group before deleting a reservation pod.
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)
+- Added `resourceclaims/binding` RBAC permission to the binder ClusterRole for compatibility with Kubernetes v1.36+, where the `DRAResourceClaimGranularStatusAuthorization` feature gate requires explicit permission on the `resourceclaims/binding` subresource to modify `status.allocation` and `status.reservedFor` on ResourceClaims. [#1372](https://github.com/kai-scheduler/KAI-Scheduler/pull/1372) [praveen0raj](https://github.com/praveen0raj)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/deployments/kai-scheduler/templates/rbac/binder.yaml
+++ b/deployments/kai-scheduler/templates/rbac/binder.yaml
@@ -96,6 +96,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/binding
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - scheduling.run.ai
   resources:
   - bindrequests

--- a/pkg/binder/controllers/bindrequest_controller.go
+++ b/pkg/binder/controllers/bindrequest_controller.go
@@ -76,6 +76,7 @@ func NewBindRequestReconciler(
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses;resourceslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims/status,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims/binding,verbs=update;patch
 // +kubebuilder:rbac:groups=scheduling.run.ai,resources=bindrequests,verbs=get;list;watch;patch;update;delete
 // +kubebuilder:rbac:groups=scheduling.run.ai,resources=bindrequests/finalizers,verbs=patch;update
 // +kubebuilder:rbac:groups=scheduling.run.ai,resources=bindrequests/status,verbs=get;list;watch;patch;update


### PR DESCRIPTION
## Summary

- Add `resourceclaims/binding` with `update` and `patch` verbs to the binder ClusterRole
- Updated both the kubebuilder RBAC marker in source code and the auto-generated manifest

## Why

Starting in Kubernetes v1.36, modifying `status.allocation` and `status.reservedFor` on a ResourceClaim requires additional permission on the synthetic `resourceclaims/binding` subresource. Without this change, KAI-Scheduler's binder will get 403 Forbidden when binding claims to nodes.

The existing `resourceclaims/status` permission is still required and kept as-is.

## Files changed

- `pkg/binder/controllers/bindrequest_controller.go` — added `+kubebuilder:rbac` marker
- `deployments/kai-scheduler/templates/rbac/binder.yaml` — added generated RBAC rule

## References

- kubernetes/kubernetes#138149
- kubernetes/kubernetes#134947
- https://github.com/kubernetes/website/pull/55070

## Test plan

- [x] Deploy ClusterRole without fix → `kubectl auth can-i update resourceclaims/binding` returns `no`
- [x] Deploy ClusterRole with fix → `kubectl auth can-i update resourceclaims/binding` returns `yes`
- [x] Existing `resourceclaims/status` permission unchanged