### PR TITLE
fix(binder): check active BindRequests before deleting reservation pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update go version to v1.25.6, with appropriate upgrades to the base docker images, linter, and controller generator. [#1282](https://github.com/kai-scheduler/KAI-Scheduler/pull/1283) [davidLif](https://github.com/davidLif)
 
 ### Fixed
+- Race condition where `SyncForGpuGroup` could prematurely delete reservation pods when the informer cache had not yet propagated GPU group labels on recently-bound fraction pods. The binder now checks for active BindRequests referencing the GPU group before deleting a reservation pod.
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
 - Added `resourceclaims/binding` RBAC permission to the binder ClusterRole for compatibility with Kubernetes v1.36+, where the `DRAResourceClaimGranularStatusAuthorization` feature gate requires explicit permission on the `resourceclaims/binding` subresource to modify `status.allocation` and `status.reservedFor` on ResourceClaims. [#1372](https://github.com/kai-scheduler/KAI-Scheduler/pull/1372) [praveen0raj](https://github.com/praveen0raj)
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
+	schedulingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/binder/binding/resourcereservation/group_mutex"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/resources"
@@ -194,9 +195,20 @@ func (rsc *service) syncForPods(ctx context.Context, pods []*v1.Pod, gpuGroupToS
 
 	for gpuGroup, reservationPod := range reservationPods {
 		if _, found := fractionPods[gpuGroup]; !found {
+			hasActive, err := rsc.hasActiveBindRequestsForGpuGroup(ctx, gpuGroup)
+			if err != nil {
+				logger.Error(err, "Failed to check active BindRequests for gpu group",
+					"gpuGroup", gpuGroup)
+				return err
+			}
+			if hasActive {
+				logger.Info("Skipping reservation pod deletion, active BindRequests exist",
+					"gpuGroup", gpuGroup)
+				continue
+			}
 			logger.Info("Did not find fraction pod for gpu group, deleting reservation pod",
 				"gpuGroup", gpuGroup)
-			err := rsc.deleteReservationPod(ctx, reservationPod)
+			err = rsc.deleteReservationPod(ctx, reservationPod)
 			if err != nil {
 				return err
 			}
@@ -206,6 +218,26 @@ func (rsc *service) syncForPods(ctx context.Context, pods []*v1.Pod, gpuGroupToS
 	return nil
 }
 
+// hasActiveBindRequestsForGpuGroup checks if any non-terminal BindRequests reference
+// the given GPU group. This prevents premature reservation pod deletion when the
+// informer cache has not yet propagated GPU group labels on recently-bound fraction pods.
+func (rsc *service) hasActiveBindRequestsForGpuGroup(ctx context.Context, gpuGroup string) (bool, error) {
+	bindRequestList := &schedulingv1alpha2.BindRequestList{}
+	if err := rsc.kubeClient.List(ctx, bindRequestList); err != nil {
+		return false, fmt.Errorf("failed to list BindRequests: %w", err)
+	}
+
+	for _, br := range bindRequestList.Items {
+		if br.Status.Phase == schedulingv1alpha2.BindRequestPhaseSucceeded ||
+			br.Status.Phase == schedulingv1alpha2.BindRequestPhaseFailed {
+			continue
+		}
+		if slices.Contains(br.Spec.SelectedGPUGroups, gpuGroup) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 func (rsc *service) ReserveGpuDevice(ctx context.Context, pod *v1.Pod, nodeName string, gpuGroup string) (string, error) {
 	logger := log.FromContext(ctx)
 

--- a/pkg/binder/binding/resourcereservation/resource_reservation_test.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	schedulingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 )
 
@@ -31,6 +32,13 @@ const (
 	resourceReservationAppLabelValue  = resourceReservationNameSpace
 	scalingPodsNamespace              = "kai-scale-adjust"
 )
+
+var testScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1.AddToScheme(s)
+	_ = schedulingv1alpha2.AddToScheme(s)
+	return s
+}()
 
 func TestResourceReservation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -314,8 +322,7 @@ var _ = Describe("ResourceReservationService", func() {
 				if testData.reservationPod != nil {
 					podsInCluster = append(podsInCluster, testData.reservationPod)
 				}
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(podsInCluster...).
-					WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(podsInCluster...).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -382,7 +389,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testName := testName
 			testData := testData
 			It(testName, func() {
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(testData.podsInCluster...).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(testData.podsInCluster...).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -595,8 +602,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testName := testName
 			testData := testData
 			It(testName, func() {
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(testData.podsInCluster...).
-					WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(testData.podsInCluster...).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -854,8 +860,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testName := testName
 			testData := testData
 			It(testName, func() {
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(testData.podsInCluster...).
-					WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(testData.podsInCluster...).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -882,7 +887,7 @@ var _ = Describe("ResourceReservationService", func() {
 				appLabelValue:       "kai-reservation",
 				serviceAccountName:  "kai-sa",
 				reservationPodImage: "nvidia/kai-reservation:latest",
-				kubeClient:          fake.NewClientBuilder().Build(),
+				kubeClient:          fake.NewClientBuilder().WithScheme(testScheme).Build(),
 				runtimeClassName:    customRuntime,
 			}
 
@@ -1061,7 +1066,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testData := testData
 			It(testName, func() {
 				podsInCluster := []runtime.Object{testData.pod}
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(podsInCluster...).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(podsInCluster...).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -1091,7 +1096,7 @@ var _ = Describe("ResourceReservationService", func() {
 				appLabelValue:       "kai-reservation",
 				serviceAccountName:  "kai-sa",
 				reservationPodImage: "test-image:latest",
-				kubeClient:          fake.NewClientBuilder().Build(),
+				kubeClient:          fake.NewClientBuilder().WithScheme(testScheme).Build(),
 				runtimeClassName:    "nvidia",
 				podResources: &v1.ResourceRequirements{
 					Requests: v1.ResourceList{
@@ -1131,7 +1136,7 @@ var _ = Describe("ResourceReservationService", func() {
 				appLabelValue:       "kai-reservation",
 				serviceAccountName:  "kai-sa",
 				reservationPodImage: "test-image:latest",
-				kubeClient:          fake.NewClientBuilder().Build(),
+				kubeClient:          fake.NewClientBuilder().WithScheme(testScheme).Build(),
 				runtimeClassName:    "nvidia",
 				podResources:        nil,
 				scalingPodNamespace: scalingPodsNamespace,
@@ -1167,7 +1172,7 @@ var _ = Describe("ResourceReservationService", func() {
 				appLabelValue:       "kai-reservation",
 				serviceAccountName:  "kai-sa",
 				reservationPodImage: "test-image:latest",
-				kubeClient:          fake.NewClientBuilder().Build(),
+				kubeClient:          fake.NewClientBuilder().WithScheme(testScheme).Build(),
 				runtimeClassName:    "nvidia",
 				podResources: &v1.ResourceRequirements{
 					Requests: v1.ResourceList{
@@ -1205,7 +1210,7 @@ var _ = Describe("ResourceReservationService", func() {
 				appLabelValue:       "kai-reservation",
 				serviceAccountName:  "kai-sa",
 				reservationPodImage: "test-image:latest",
-				kubeClient:          fake.NewClientBuilder().Build(),
+				kubeClient:          fake.NewClientBuilder().WithScheme(testScheme).Build(),
 				runtimeClassName:    "nvidia",
 				podResources: &v1.ResourceRequirements{
 					Requests: v1.ResourceList{
@@ -1278,3 +1283,199 @@ func exampleMockWatchPod(gpuIndex string, delay time.Duration) watch.Interface {
 		},
 	}
 }
+
+// FakeWatchPodClosed simulates a watch that closes its channel immediately
+type FakeWatchPodClosed struct {
+	channel chan watch.Event
+}
+
+func (w *FakeWatchPodClosed) Stop() {
+	// No-op
+}
+
+func (w *FakeWatchPodClosed) ResultChan() <-chan watch.Event {
+	if w.channel == nil {
+		w.channel = make(chan watch.Event)
+		close(w.channel) // Close immediately to simulate channel close
+	}
+	return w.channel
+}
+
+var _ = Describe("Race condition: reservation pod deleted during concurrent binding", func() {
+	const (
+		nodeName = "node-1"
+		gpuGroup = "gpu-group"
+	)
+	var (
+		groupLabels = map[string]string{
+			constants.GPUGroup: gpuGroup,
+		}
+		reservationPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-reservation-node-1-abcde",
+				Namespace: resourceReservationNameSpace,
+				Labels:    groupLabels,
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		}
+	)
+
+	Context("SyncForGpuGroup with stale cache - no fraction pods visible", func() {
+		It("should preserve reservation pod when an active BindRequest exists for the gpu group", func() {
+			activeBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-1",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhasePending,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), activeBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(1),
+				"Reservation pod should be preserved when an active BindRequest exists")
+		})
+
+		It("should delete reservation pod when no active BindRequests exist", func() {
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(reservationPod.DeepCopy()).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(0),
+				"Reservation pod should be deleted when no active BindRequests exist")
+		})
+
+		It("should delete reservation pod when only succeeded BindRequests exist", func() {
+			succeededBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-done",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhaseSucceeded,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), succeededBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(0),
+				"Reservation pod should be deleted when only terminal BindRequests exist")
+		})
+
+		It("should delete reservation pod when only failed BindRequests exist", func() {
+			failedBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-failed",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhaseFailed,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), failedBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(0),
+				"Reservation pod should be deleted when only terminal BindRequests exist")
+		})
+
+		It("should preserve reservation pod when BindRequest for different group is active but one for this group is active too", func() {
+			activeBindRequestOtherGroup := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-other",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "other-pod",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{"other-group"},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhasePending,
+				},
+			}
+			activeBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-1",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhasePending,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), activeBindRequestOtherGroup, activeBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(1),
+				"Reservation pod should be preserved when an active BindRequest exists")
+		})
+	})
+})

--- a/pkg/binder/controllers/integration_tests/reservation_race_test.go
+++ b/pkg/binder/controllers/integration_tests/reservation_race_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package integration_tests
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	scheudlingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	"github.com/NVIDIA/KAI-scheduler/pkg/binder/common"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// This test reproduces a race condition where the binder's resource reservation
+// sync logic prematurely deletes GPU reservation pods during concurrent binding.
+//
+// The race:
+//  1. Pod 1 binds to a GPU group, creating a reservation pod and getting a GPU
+//     group label. The label is written to the API server but may not have
+//     propagated to the informer cache yet.
+//  2. A concurrent sync (triggered by Pod 2 binding, BindRequest deletion, or
+//     pod completion) calls SyncForGpuGroup, which lists pods by GPU group label
+//     from the cache. Due to cache lag, it doesn't see Pod 1's label.
+//  3. The sync sees the reservation pod but no fraction pods → deletes the
+//     reservation pod.
+//
+// This test creates the preconditions (reservation pod + active BindRequest but
+// no labeled fraction pod) and calls SyncForGpuGroup to demonstrate that the
+// reservation pod is deleted.
+var _ = Describe("Reservation pod race condition", Ordered, func() {
+	const (
+		fracNamespaceName = "frac-test-ns"
+		fracNodeName      = "frac-test-node"
+		gpuGroup          = "node1-gpu0-group"
+	)
+
+	BeforeAll(func() {
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: fracNamespaceName},
+		}
+		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fracNodeName},
+		}
+		Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+
+		reservationNs := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: resourceReservationNameSpace},
+		}
+		err := k8sClient.Create(context.Background(), reservationNs)
+		if err != nil {
+			// Namespace may already exist from suite setup
+			Expect(client.IgnoreAlreadyExists(err)).To(Succeed())
+		}
+	})
+
+	// This test verifies that SyncForGpuGroup preserves reservation pods when
+	// active BindRequests exist for the GPU group, even if no fraction pods are
+	// visible (simulating cache lag).
+	It("should preserve reservation pod when sync runs with active BindRequest and no visible fraction pods", func() {
+		ctx := context.Background()
+
+		// Step 1: Create a reservation pod (as if ReserveGpuDevice just created it)
+		reservationPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("gpu-reservation-%s-test1", fracNodeName),
+				Namespace: resourceReservationNameSpace,
+				Labels: map[string]string{
+					constants.AppLabelName: resourceReservationAppLabelValue,
+					constants.GPUGroup:     gpuGroup,
+				},
+			},
+			Spec: v1.PodSpec{
+				NodeName:           fracNodeName,
+				ServiceAccountName: resourceReservationServiceAccount,
+				Containers: []v1.Container{
+					{
+						Name:  "resource-reservation",
+						Image: "test-image",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, reservationPod)).To(Succeed())
+
+		// Step 2: Create a fraction pod WITHOUT the GPU group label.
+		// This simulates the state after ReserveGpuDevice created the
+		// reservation pod but the label patch on the fraction pod hasn't
+		// propagated to the cache yet.
+		fractionPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fraction-pod-1",
+				Namespace: fracNamespaceName,
+				// NOTE: No GPU group label - simulates cache lag
+			},
+			Spec: v1.PodSpec{
+				// NOTE: No NodeName - pod not yet bound, simulates in-flight binding
+				SchedulerName: "kai-scheduler",
+				Containers: []v1.Container{
+					{
+						Name:  "worker",
+						Image: "test-image",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fractionPod)).To(Succeed())
+
+		// Step 3: Create an active BindRequest for this GPU group.
+		// This represents the in-flight binding that is about to label the pod.
+		bindReq := &scheudlingv1alpha2.BindRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frac-bind-request-1",
+				Namespace: fracNamespaceName,
+			},
+			Spec: scheudlingv1alpha2.BindRequestSpec{
+				PodName:              fractionPod.Name,
+				SelectedNode:         fracNodeName,
+				ReceivedResourceType: common.ReceivedTypeFraction,
+				SelectedGPUGroups:    []string{gpuGroup},
+				ReceivedGPU:          &scheudlingv1alpha2.ReceivedGPU{Count: 1, Portion: "0.5"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bindReq)).To(Succeed())
+
+		// Step 4: Call SyncForGpuGroup - this simulates what happens when
+		// a concurrent binding triggers a sync.
+		err := rrs.SyncForGpuGroup(ctx, gpuGroup)
+		Expect(err).To(Succeed())
+
+		// Step 5: Check if the reservation pod survived.
+		// After fix: reservation pod should be preserved because an active
+		// BindRequest exists for this GPU group.
+		resultPod := &v1.Pod{}
+		err = k8sClient.Get(ctx, client.ObjectKeyFromObject(reservationPod), resultPod)
+		Expect(err).NotTo(HaveOccurred(),
+			"Reservation pod should be preserved when an active BindRequest exists")
+
+		// Cleanup
+		_ = k8sClient.Delete(ctx, fractionPod)
+		_ = k8sClient.Delete(ctx, bindReq)
+		_ = k8sClient.Delete(ctx, reservationPod)
+	})
+
+	AfterAll(func() {
+		ctx := context.Background()
+		_ = k8sClient.DeleteAllOf(ctx, &v1.Pod{}, client.InNamespace(fracNamespaceName))
+		_ = k8sClient.DeleteAllOf(ctx, &v1.Pod{}, client.InNamespace(resourceReservationNameSpace))
+		_ = k8sClient.DeleteAllOf(ctx, &scheudlingv1alpha2.BindRequest{}, client.InNamespace(fracNamespaceName))
+		_ = k8sClient.Delete(ctx, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fracNodeName}})
+	})
+})

--- a/pkg/binder/controllers/integration_tests/suite_test.go
+++ b/pkg/binder/controllers/integration_tests/suite_test.go
@@ -53,6 +53,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var k8sManager ctrl.Manager
+var rrs resourcereservation.Interface
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -116,7 +117,7 @@ var _ = BeforeSuite(func() {
 	clientWithWatch, err := client.NewWithWatch(cfg, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
 
-	rrs := resourcereservation.NewService(false, clientWithWatch, "", 40*time.Second,
+	rrs = resourcereservation.NewService(false, clientWithWatch, "", 40*time.Second,
 		resourceReservationNameSpace, resourceReservationServiceAccount, resourceReservationAppLabelValue, scalingPodsNamespace, constants.DefaultRuntimeClassName,
 		nil) // nil podResources to use defaults
 	podBinder := binding.NewBinder(k8sManager.GetClient(), rrs, binderPlugins)

--- a/pkg/env-tests/reservation_race_scale_test.go
+++ b/pkg/env-tests/reservation_race_scale_test.go
@@ -1,0 +1,328 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package env_tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/xyproto/randomstring"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaiv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	schedulingv2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+	"github.com/NVIDIA/KAI-scheduler/pkg/env-tests/binder"
+	"github.com/NVIDIA/KAI-scheduler/pkg/env-tests/utils"
+)
+
+// This test reproduces a race condition in the binder's resource reservation
+// sync logic at scale (4 nodes × 8 GPUs = 32 GPU groups). The full binder
+// controller runs autonomously; the test only creates Kubernetes objects and
+// observes outcomes.
+//
+// The race:
+//  1. A fraction pod binds, creating a reservation pod. The binder patches the
+//     fraction pod with a GPU group label, but the informer cache may lag.
+//  2. A concurrent SyncForGpuGroup (triggered by another BindRequest reconcile
+//     or deletion) lists pods by GPU group label from the cache.
+//  3. Due to cache lag, the sync sees the reservation pod but no fraction pods
+//     for that group → deletes the reservation pod prematurely.
+//
+// The test pre-creates reservation pods (as if ReserveGpuDevice placed them)
+// and fraction BindRequests. Because envtest has no GPU device plugin, the
+// BindRequest reconciliation will fail to fully bind the fractional pods (no
+// GPU index annotation on reservation pods). However, the reconciler still
+// calls SyncForNode at the start of each reconcile, which triggers the
+// problematic reservation pod cleanup path.
+var _ = Describe("Reservation pod race at scale", Ordered, func() {
+	const (
+		numNodes    = 4
+		gpusPerNode = 8
+
+		gpuIndexAnnotationKey  = "run.ai/reserve_for_gpu_index"
+		gpuIndexHeartbeatKey   = "run.ai/test-annotator-heartbeat"
+		annotatorPollInterval  = 100 * time.Millisecond
+		annotatorGPUIndexValue = "0"
+	)
+
+	var (
+		testNamespace  *corev1.Namespace
+		testDepartment *schedulingv2.Queue
+		testQueue      *schedulingv2.Queue
+		nodes          []*corev1.Node
+
+		backgroundCtx context.Context
+		cancel        context.CancelFunc
+	)
+
+	type gpuGroupState struct {
+		gpuGroup       string
+		nodeName       string
+		reservationPod *corev1.Pod
+		fractionPod    *corev1.Pod
+		bindRequest    *kaiv1alpha2.BindRequest
+	}
+
+	var groups []gpuGroupState
+
+	startReservationPodAnnotator := func(ctx context.Context, c client.Client) {
+		ticker := time.NewTicker(annotatorPollInterval)
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					var reservationPods corev1.PodList
+					err := c.List(ctx, &reservationPods,
+						client.InNamespace(constants.DefaultResourceReservationName),
+						client.HasLabels{constants.GPUGroup},
+					)
+					if err != nil {
+						GinkgoWriter.Printf("reservation pod annotator list error: %v\n", err)
+						continue
+					}
+
+					for i := range reservationPods.Items {
+						pod := reservationPods.Items[i]
+						updated := pod.DeepCopy()
+						if updated.Annotations == nil {
+							updated.Annotations = map[string]string{}
+						}
+
+						needsPatch := false
+						if updated.Annotations[gpuIndexAnnotationKey] == "" {
+							updated.Annotations[gpuIndexAnnotationKey] = annotatorGPUIndexValue
+							needsPatch = true
+						} else {
+							updated.Annotations[gpuIndexHeartbeatKey] = time.Now().UTC().Format(time.RFC3339Nano)
+							needsPatch = true
+						}
+
+						if needsPatch {
+							if err := c.Patch(ctx, updated, client.MergeFrom(&pod)); err != nil {
+								GinkgoWriter.Printf("reservation pod annotator patch error: %v\n", err)
+							}
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	BeforeEach(func(ctx context.Context) {
+		testNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-" + randomstring.HumanFriendlyEnglishString(10),
+			},
+		}
+		Expect(ctrlClient.Create(ctx, testNamespace)).To(Succeed())
+
+		testDepartment = utils.CreateQueueObject("test-department", "")
+		Expect(ctrlClient.Create(ctx, testDepartment)).To(Succeed())
+
+		testQueue = utils.CreateQueueObject("test-queue", testDepartment.Name)
+		Expect(ctrlClient.Create(ctx, testQueue)).To(Succeed())
+
+		nodes = make([]*corev1.Node, numNodes)
+		for i := range numNodes {
+			nodeCfg := utils.DefaultNodeConfig(fmt.Sprintf("scale-node-%d", i))
+			nodeCfg.GPUs = gpusPerNode
+			nodes[i] = utils.CreateNodeObject(ctx, ctrlClient, nodeCfg)
+			Expect(ctrlClient.Create(ctx, nodes[i])).To(Succeed())
+		}
+
+		// Ensure the reservation namespace exists
+		reservationNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: constants.DefaultResourceReservationName},
+		}
+		err := ctrlClient.Create(ctx, reservationNs)
+		if err != nil {
+			Expect(client.IgnoreAlreadyExists(err)).To(Succeed())
+		}
+
+		backgroundCtx, cancel = context.WithCancel(context.Background())
+
+		// Build GPU group state for all nodes × GPUs
+		groups = make([]gpuGroupState, 0, numNodes*gpusPerNode)
+		for nodeIdx := range numNodes {
+			for gpuIdx := range gpusPerNode {
+				gpuGroup := fmt.Sprintf("%s-gpu%d-group", nodes[nodeIdx].Name, gpuIdx)
+				groups = append(groups, gpuGroupState{
+					gpuGroup: gpuGroup,
+					nodeName: nodes[nodeIdx].Name,
+				})
+			}
+		}
+	})
+
+	AfterEach(func(ctx context.Context) {
+		cancel()
+
+		// Clean up reservation pods
+		_ = ctrlClient.DeleteAllOf(ctx, &corev1.Pod{},
+			client.InNamespace(constants.DefaultResourceReservationName))
+
+		// Clean up test resources
+		if testNamespace != nil {
+			err := utils.DeleteAllInNamespace(ctx, ctrlClient, testNamespace.Name,
+				&corev1.Pod{},
+				&corev1.ConfigMap{},
+				&kaiv1alpha2.BindRequest{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		for _, node := range nodes {
+			_ = ctrlClient.Delete(ctx, node)
+		}
+		if testQueue != nil {
+			_ = ctrlClient.Delete(ctx, testQueue)
+		}
+		if testDepartment != nil {
+			_ = ctrlClient.Delete(ctx, testDepartment)
+		}
+	})
+
+	// Pre-create reservation pods and fraction BindRequests, then let the
+	// binder controller run. The controller's SyncForNode (called at the start
+	// of each BindRequest reconcile) will discover reservation pods with no
+	// matching labeled fraction pods and delete them.
+	It("should preserve reservation pods when active BindRequests exist", func(ctx context.Context) {
+		// Step 1: Pre-create reservation pods for all 32 GPU groups.
+		// These simulate the state after ReserveGpuDevice created them.
+		for i := range groups {
+			g := &groups[i]
+			g.reservationPod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("gpu-reservation-%s-%d", g.nodeName, i),
+					Namespace: constants.DefaultResourceReservationName,
+					Labels: map[string]string{
+						constants.AppLabelName: constants.DefaultResourceReservationName,
+						constants.GPUGroup:     g.gpuGroup,
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:           g.nodeName,
+					ServiceAccountName: constants.DefaultResourceReservationName,
+					Containers: []corev1.Container{
+						{Name: "resource-reservation", Image: "test-image"},
+					},
+				},
+			}
+			Expect(ctrlClient.Create(ctx, g.reservationPod)).To(Succeed())
+		}
+
+		// Step 2: Create fraction pods WITHOUT GPU group labels.
+		// This simulates the window where ReserveGpuDevice has created the
+		// reservation pod but hasn't yet labeled the fraction pod.
+		for i := range groups {
+			g := &groups[i]
+			g.fractionPod = utils.CreatePodObject(
+				testNamespace.Name,
+				fmt.Sprintf("fraction-pod-%d", i),
+				corev1.ResourceRequirements{},
+			)
+			if g.fractionPod.Annotations == nil {
+				g.fractionPod.Annotations = map[string]string{}
+			}
+			g.fractionPod.Annotations[constants.GpuSharingConfigMapAnnotation] =
+				fmt.Sprintf("%s-shared-gpu", g.fractionPod.Name)
+			Expect(ctrlClient.Create(ctx, g.fractionPod)).To(Succeed())
+
+			configMapPrefix := g.fractionPod.Annotations[constants.GpuSharingConfigMapAnnotation]
+			capabilitiesConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-0", configMapPrefix),
+					Namespace: testNamespace.Name,
+				},
+				Data: map[string]string{},
+			}
+			Expect(ctrlClient.Create(ctx, capabilitiesConfigMap)).To(Succeed())
+
+			directEnvConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-0-evar", configMapPrefix),
+					Namespace: testNamespace.Name,
+				},
+				Data: map[string]string{},
+			}
+			Expect(ctrlClient.Create(ctx, directEnvConfigMap)).To(Succeed())
+		}
+
+		// Step 3: Create BindRequests for all fraction pods.
+		// The binder will reconcile these, calling SyncForNode which
+		// triggers the reservation pod cleanup logic.
+		for i := range groups {
+			g := &groups[i]
+			g.bindRequest = &kaiv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("scale-bind-%d", i),
+					Namespace: testNamespace.Name,
+				},
+				Spec: kaiv1alpha2.BindRequestSpec{
+					PodName:              g.fractionPod.Name,
+					SelectedNode:         g.nodeName,
+					ReceivedResourceType: "Fraction",
+					SelectedGPUGroups:    []string{g.gpuGroup},
+					ReceivedGPU: &kaiv1alpha2.ReceivedGPU{
+						Count:   1,
+						Portion: "0.5",
+					},
+				},
+			}
+			Expect(ctrlClient.Create(ctx, g.bindRequest)).To(Succeed())
+		}
+
+		startReservationPodAnnotator(backgroundCtx, ctrlClient)
+		err := binder.RunBinder(cfg, backgroundCtx)
+		Expect(err).NotTo(HaveOccurred())
+		time.Sleep(1 * time.Second)
+
+		// Step 5: Check how many reservation pods survived.
+		var reservationPods corev1.PodList
+		Expect(ctrlClient.List(ctx, &reservationPods,
+			client.InNamespace(constants.DefaultResourceReservationName),
+			client.HasLabels{constants.GPUGroup},
+		)).To(Succeed())
+
+		survivedCount := len(reservationPods.Items)
+		totalGroups := len(groups)
+
+		GinkgoWriter.Printf("\n=== Scale Race Results ===\n")
+		GinkgoWriter.Printf("Total GPU groups: %d\n", totalGroups)
+		GinkgoWriter.Printf("Reservation pods survived: %d\n", survivedCount)
+		GinkgoWriter.Printf("Reservation pods deleted:  %d\n", totalGroups-survivedCount)
+
+		if survivedCount < totalGroups {
+			deletedGroups := []string{}
+			survivingGroups := map[string]bool{}
+			for _, pod := range reservationPods.Items {
+				survivingGroups[pod.Labels[constants.GPUGroup]] = true
+			}
+			for _, g := range groups {
+				if !survivingGroups[g.gpuGroup] {
+					deletedGroups = append(deletedGroups, g.gpuGroup)
+				}
+			}
+			GinkgoWriter.Printf("Deleted groups: %v\n", deletedGroups)
+		}
+
+		// Without the fix: SyncForNode sees reservation pods but no labeled
+		// fraction pods (cache lag simulation) → deletes reservation pods.
+		// With the fix: hasActiveBindRequestsForGpuGroup prevents deletion.
+		Expect(survivedCount).To(Equal(totalGroups),
+			"Expected all %d reservation pods to survive, but %d were deleted. "+
+				"This indicates the race condition where SyncForGpuGroup deletes "+
+				"reservation pods despite active BindRequests.",
+			totalGroups, totalGroups-survivedCount)
+	})
+})


### PR DESCRIPTION
## Description

Backport of #1104 to `v0.12`.

Fixes a race condition where the binder's `syncForGpuGroup` could prematurely delete GPU reservation pods when the informer cache had not yet propagated the `runai-gpu-group` label on recently-bound fraction pods. The fix adds a check for active (non-terminal) BindRequests referencing the GPU group before deleting a reservation pod.

**Backport notes:** Import paths adjusted from `github.com/kai-scheduler/KAI-scheduler` to `github.com/NVIDIA/KAI-scheduler` to match the module name used in v0.12.

## Related Issues

Fixes #1103

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.