### PR TITLE
fix(binder): check active BindRequests before deleting reservation pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [v0.6.18] - 2026-03-24
 
 ### Fixed
+- Race condition where `SyncForGpuGroup` could prematurely delete reservation pods when the informer cache had not yet propagated GPU group labels on recently-bound fraction pods. The binder now checks for active BindRequests referencing the GPU group before deleting a reservation pod.
 
 - fixed podGroup status update loop on conflict[#1313](https://github.com/kai-scheduler/KAI-Scheduler/pull/1313)
 

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
+	schedulingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/binder/binding/resourcereservation/group_mutex"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/resources"
@@ -187,9 +188,20 @@ func (rsc *service) syncForPods(ctx context.Context, pods []*v1.Pod, gpuGroupToS
 
 	for gpuGroup, reservationPod := range reservationPods {
 		if _, found := fractionPods[gpuGroup]; !found {
+			hasActive, err := rsc.hasActiveBindRequestsForGpuGroup(ctx, gpuGroup)
+			if err != nil {
+				logger.Error(err, "Failed to check active BindRequests for gpu group",
+					"gpuGroup", gpuGroup)
+				return err
+			}
+			if hasActive {
+				logger.Info("Skipping reservation pod deletion, active BindRequests exist",
+					"gpuGroup", gpuGroup)
+				continue
+			}
 			logger.Info("Did not find fraction pod for gpu group, deleting reservation pod",
 				"gpuGroup", gpuGroup)
-			err := rsc.deleteReservationPod(ctx, reservationPod)
+			err = rsc.deleteReservationPod(ctx, reservationPod)
 			if err != nil {
 				return err
 			}
@@ -199,6 +211,26 @@ func (rsc *service) syncForPods(ctx context.Context, pods []*v1.Pod, gpuGroupToS
 	return nil
 }
 
+// hasActiveBindRequestsForGpuGroup checks if any non-terminal BindRequests reference
+// the given GPU group. This prevents premature reservation pod deletion when the
+// informer cache has not yet propagated GPU group labels on recently-bound fraction pods.
+func (rsc *service) hasActiveBindRequestsForGpuGroup(ctx context.Context, gpuGroup string) (bool, error) {
+	bindRequestList := &schedulingv1alpha2.BindRequestList{}
+	if err := rsc.kubeClient.List(ctx, bindRequestList); err != nil {
+		return false, fmt.Errorf("failed to list BindRequests: %w", err)
+	}
+
+	for _, br := range bindRequestList.Items {
+		if br.Status.Phase == schedulingv1alpha2.BindRequestPhaseSucceeded ||
+			br.Status.Phase == schedulingv1alpha2.BindRequestPhaseFailed {
+			continue
+		}
+		if slices.Contains(br.Spec.SelectedGPUGroups, gpuGroup) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 func (rsc *service) ReserveGpuDevice(ctx context.Context, pod *v1.Pod, nodeName string, gpuGroup string) (string, error) {
 	rsc.gpuGroupMutex.LockMutexForGroup(gpuGroup)
 	defer rsc.gpuGroupMutex.ReleaseMutex(gpuGroup)

--- a/pkg/binder/binding/resourcereservation/resource_reservation_test.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	schedulingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 )
 
@@ -30,6 +31,13 @@ const (
 	resourceReservationAppLabelValue  = resourceReservationNameSpace
 	scalingPodsNamespace              = "kai-scale-adjust"
 )
+
+var testScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1.AddToScheme(s)
+	_ = schedulingv1alpha2.AddToScheme(s)
+	return s
+}()
 
 func TestResourceReservation(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -311,8 +319,7 @@ var _ = Describe("ResourceReservationService", func() {
 				if testData.reservationPod != nil {
 					podsInCluster = append(podsInCluster, testData.reservationPod)
 				}
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(podsInCluster...).
-					WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(podsInCluster...).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -379,7 +386,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testName := testName
 			testData := testData
 			It(testName, func() {
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(testData.podsInCluster...).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(testData.podsInCluster...).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -592,8 +599,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testName := testName
 			testData := testData
 			It(testName, func() {
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(testData.podsInCluster...).
-					WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(testData.podsInCluster...).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -851,8 +857,7 @@ var _ = Describe("ResourceReservationService", func() {
 			testName := testName
 			testData := testData
 			It(testName, func() {
-				clientWithObjs := fake.NewClientBuilder().WithRuntimeObjects(testData.podsInCluster...).
-					WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+				clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(testData.podsInCluster...).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
 				fakeClient := interceptor.NewClient(clientWithObjs, testData.clientInterceptFuncs)
 				rsc := initializeTestService(fakeClient)
 
@@ -911,3 +916,199 @@ func exampleMockWatchPod(gpuIndex string, delay time.Duration) watch.Interface {
 		},
 	}
 }
+
+// FakeWatchPodClosed simulates a watch that closes its channel immediately
+type FakeWatchPodClosed struct {
+	channel chan watch.Event
+}
+
+func (w *FakeWatchPodClosed) Stop() {
+	// No-op
+}
+
+func (w *FakeWatchPodClosed) ResultChan() <-chan watch.Event {
+	if w.channel == nil {
+		w.channel = make(chan watch.Event)
+		close(w.channel) // Close immediately to simulate channel close
+	}
+	return w.channel
+}
+
+var _ = Describe("Race condition: reservation pod deleted during concurrent binding", func() {
+	const (
+		nodeName = "node-1"
+		gpuGroup = "gpu-group"
+	)
+	var (
+		groupLabels = map[string]string{
+			constants.GPUGroup: gpuGroup,
+		}
+		reservationPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-reservation-node-1-abcde",
+				Namespace: resourceReservationNameSpace,
+				Labels:    groupLabels,
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		}
+	)
+
+	Context("SyncForGpuGroup with stale cache - no fraction pods visible", func() {
+		It("should preserve reservation pod when an active BindRequest exists for the gpu group", func() {
+			activeBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-1",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhasePending,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), activeBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(1),
+				"Reservation pod should be preserved when an active BindRequest exists")
+		})
+
+		It("should delete reservation pod when no active BindRequests exist", func() {
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(reservationPod.DeepCopy()).WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(0),
+				"Reservation pod should be deleted when no active BindRequests exist")
+		})
+
+		It("should delete reservation pod when only succeeded BindRequests exist", func() {
+			succeededBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-done",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhaseSucceeded,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), succeededBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(0),
+				"Reservation pod should be deleted when only terminal BindRequests exist")
+		})
+
+		It("should delete reservation pod when only failed BindRequests exist", func() {
+			failedBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-failed",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhaseFailed,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), failedBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(0),
+				"Reservation pod should be deleted when only terminal BindRequests exist")
+		})
+
+		It("should preserve reservation pod when BindRequest for different group is active but one for this group is active too", func() {
+			activeBindRequestOtherGroup := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-other",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "other-pod",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{"other-group"},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhasePending,
+				},
+			}
+			activeBindRequest := &schedulingv1alpha2.BindRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bind-request-1",
+					Namespace: "team-a",
+				},
+				Spec: schedulingv1alpha2.BindRequestSpec{
+					PodName:           "fraction-pod-1",
+					SelectedNode:      nodeName,
+					SelectedGPUGroups: []string{gpuGroup},
+				},
+				Status: schedulingv1alpha2.BindRequestStatus{
+					Phase: schedulingv1alpha2.BindRequestPhasePending,
+				},
+			}
+
+			clientWithObjs := fake.NewClientBuilder().WithScheme(testScheme).
+				WithRuntimeObjects(reservationPod.DeepCopy(), activeBindRequestOtherGroup, activeBindRequest).
+				WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+			rsc := initializeTestService(clientWithObjs)
+
+			err := rsc.SyncForGpuGroup(context.TODO(), gpuGroup)
+			Expect(err).To(Succeed())
+
+			pods := &v1.PodList{}
+			err = clientWithObjs.List(context.Background(), pods)
+			Expect(err).To(Succeed())
+			Expect(len(pods.Items)).To(Equal(1),
+				"Reservation pod should be preserved when an active BindRequest exists")
+		})
+	})
+})

--- a/pkg/binder/controllers/integration_tests/reservation_race_test.go
+++ b/pkg/binder/controllers/integration_tests/reservation_race_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package integration_tests
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	scheudlingv1alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	"github.com/NVIDIA/KAI-scheduler/pkg/binder/common"
+	"github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// This test reproduces a race condition where the binder's resource reservation
+// sync logic prematurely deletes GPU reservation pods during concurrent binding.
+//
+// The race:
+//  1. Pod 1 binds to a GPU group, creating a reservation pod and getting a GPU
+//     group label. The label is written to the API server but may not have
+//     propagated to the informer cache yet.
+//  2. A concurrent sync (triggered by Pod 2 binding, BindRequest deletion, or
+//     pod completion) calls SyncForGpuGroup, which lists pods by GPU group label
+//     from the cache. Due to cache lag, it doesn't see Pod 1's label.
+//  3. The sync sees the reservation pod but no fraction pods → deletes the
+//     reservation pod.
+//
+// This test creates the preconditions (reservation pod + active BindRequest but
+// no labeled fraction pod) and calls SyncForGpuGroup to demonstrate that the
+// reservation pod is deleted.
+var _ = Describe("Reservation pod race condition", Ordered, func() {
+	const (
+		fracNamespaceName = "frac-test-ns"
+		fracNodeName      = "frac-test-node"
+		gpuGroup          = "node1-gpu0-group"
+	)
+
+	BeforeAll(func() {
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: fracNamespaceName},
+		}
+		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fracNodeName},
+		}
+		Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+
+		reservationNs := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: resourceReservationNameSpace},
+		}
+		err := k8sClient.Create(context.Background(), reservationNs)
+		if err != nil {
+			// Namespace may already exist from suite setup
+			Expect(client.IgnoreAlreadyExists(err)).To(Succeed())
+		}
+	})
+
+	// This test verifies that SyncForGpuGroup preserves reservation pods when
+	// active BindRequests exist for the GPU group, even if no fraction pods are
+	// visible (simulating cache lag).
+	It("should preserve reservation pod when sync runs with active BindRequest and no visible fraction pods", func() {
+		ctx := context.Background()
+
+		// Step 1: Create a reservation pod (as if ReserveGpuDevice just created it)
+		reservationPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("gpu-reservation-%s-test1", fracNodeName),
+				Namespace: resourceReservationNameSpace,
+				Labels: map[string]string{
+					constants.AppLabelName: resourceReservationAppLabelValue,
+					constants.GPUGroup:     gpuGroup,
+				},
+			},
+			Spec: v1.PodSpec{
+				NodeName:           fracNodeName,
+				ServiceAccountName: resourceReservationServiceAccount,
+				Containers: []v1.Container{
+					{
+						Name:  "resource-reservation",
+						Image: "test-image",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, reservationPod)).To(Succeed())
+
+		// Step 2: Create a fraction pod WITHOUT the GPU group label.
+		// This simulates the state after ReserveGpuDevice created the
+		// reservation pod but the label patch on the fraction pod hasn't
+		// propagated to the cache yet.
+		fractionPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fraction-pod-1",
+				Namespace: fracNamespaceName,
+				// NOTE: No GPU group label - simulates cache lag
+			},
+			Spec: v1.PodSpec{
+				// NOTE: No NodeName - pod not yet bound, simulates in-flight binding
+				SchedulerName: "kai-scheduler",
+				Containers: []v1.Container{
+					{
+						Name:  "worker",
+						Image: "test-image",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, fractionPod)).To(Succeed())
+
+		// Step 3: Create an active BindRequest for this GPU group.
+		// This represents the in-flight binding that is about to label the pod.
+		bindReq := &scheudlingv1alpha2.BindRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "frac-bind-request-1",
+				Namespace: fracNamespaceName,
+			},
+			Spec: scheudlingv1alpha2.BindRequestSpec{
+				PodName:              fractionPod.Name,
+				SelectedNode:         fracNodeName,
+				ReceivedResourceType: common.ReceivedTypeFraction,
+				SelectedGPUGroups:    []string{gpuGroup},
+				ReceivedGPU:          &scheudlingv1alpha2.ReceivedGPU{Count: 1, Portion: "0.5"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bindReq)).To(Succeed())
+
+		// Step 4: Call SyncForGpuGroup - this simulates what happens when
+		// a concurrent binding triggers a sync.
+		err := rrs.SyncForGpuGroup(ctx, gpuGroup)
+		Expect(err).To(Succeed())
+
+		// Step 5: Check if the reservation pod survived.
+		// After fix: reservation pod should be preserved because an active
+		// BindRequest exists for this GPU group.
+		resultPod := &v1.Pod{}
+		err = k8sClient.Get(ctx, client.ObjectKeyFromObject(reservationPod), resultPod)
+		Expect(err).NotTo(HaveOccurred(),
+			"Reservation pod should be preserved when an active BindRequest exists")
+
+		// Cleanup
+		_ = k8sClient.Delete(ctx, fractionPod)
+		_ = k8sClient.Delete(ctx, bindReq)
+		_ = k8sClient.Delete(ctx, reservationPod)
+	})
+
+	AfterAll(func() {
+		ctx := context.Background()
+		_ = k8sClient.DeleteAllOf(ctx, &v1.Pod{}, client.InNamespace(fracNamespaceName))
+		_ = k8sClient.DeleteAllOf(ctx, &v1.Pod{}, client.InNamespace(resourceReservationNameSpace))
+		_ = k8sClient.DeleteAllOf(ctx, &scheudlingv1alpha2.BindRequest{}, client.InNamespace(fracNamespaceName))
+		_ = k8sClient.Delete(ctx, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fracNodeName}})
+	})
+})

--- a/pkg/binder/controllers/integration_tests/suite_test.go
+++ b/pkg/binder/controllers/integration_tests/suite_test.go
@@ -53,6 +53,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var k8sManager ctrl.Manager
+var rrs resourcereservation.Interface
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -116,7 +117,7 @@ var _ = BeforeSuite(func() {
 	gpuSharingPlugin := gpusharing.New(clientWithWatch, options.GpuCdiEnabled, options.GPUSharingEnabled)
 	binderPlugins.RegisterPlugin(gpuSharingPlugin)
 
-	rrs := resourcereservation.NewService(false, clientWithWatch, "", 40*time.Second,
+	rrs = resourcereservation.NewService(false, clientWithWatch, "", 40*time.Second,
 		resourceReservationNameSpace, resourceReservationServiceAccount, resourceReservationAppLabelValue, scalingPodsNamespace)
 	podBinder := binding.NewBinder(k8sManager.GetClient(), rrs, binderPlugins)
 


### PR DESCRIPTION
## Description

Backport of #1104 to `v0.6`.

Fixes a race condition where the binder's `syncForGpuGroup` could prematurely delete GPU reservation pods when the informer cache had not yet propagated the `runai-gpu-group` label on recently-bound fraction pods. The fix adds a check for active (non-terminal) BindRequests referencing the GPU group before deleting a reservation pod.

**Backport notes:**
- Import paths adjusted from `github.com/kai-scheduler/KAI-scheduler` to `github.com/NVIDIA/KAI-scheduler` to match the module name used in v0.6.
- `runtimeClassName` and `podResources` parameters were not yet present in `NewService` at v0.6 — call sites kept with original 8-argument list.
- `podResources` tests were excluded from the backport.
- `reservation_race_scale_test.go` (the env-test stress test) was excluded because `pkg/env-tests/binder` and `pkg/env-tests/utils` do not exist in v0.6.

## Related Issues

Fixes #1103

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.