### PR TITLE
fix(scheduler): account for device count in multi-device GPU memory quota check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
+- Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)
 
 ## [v0.9.15] - 2026-03-09
 

--- a/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions/allocate"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/actions/integration_tests/integration_tests_utils"
@@ -409,6 +410,58 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 					CacheRequirements: &test_utils.CacheMocking{
 						NumberOfCacheBinds:      0,
 						NumberOfPipelineActions: 1,
+					},
+				},
+			},
+		},
+		{
+			// A task requesting 2 GPU-memory devices (2×60 MiB) needs 1.2 GPU-fraction units
+			// (2 × 60/100). With DeservedGPUs=1 the job must stay pending.
+			//
+			// IsJobOverQueueCapacity always passes (ResReqVector[GPU]=0 for memory requests).
+			// IsTaskAllocationOnNodeOverCapacity is the only gate, via GetRequiredInitQuota.
+			//
+			// Bug: GetRequiredInitQuota returns per-device fraction (0.6) instead of total
+			// (1.2 = 2 × 0.6), so the check sees 0+0.6=0.6 < 1 → wrongly schedulable.
+			// The node has 2 GPUs so the physical fit check would also pass (each device gets
+			// its own GPU), meaning only the quota check can block this job.
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "2-device GPU memory job blocked by non-preemptible quota",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                                "pending_job",
+						RequiredGpuMemory:                   60,
+						RequiredMultiFractionDevicesPerTask: ptr.To(uint64(2)),
+						Priority:                            constants.PriorityBuildNumber,
+						QueueName:                           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {
+						GPUs:      2,
+						GPUMemory: 100,
+					},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:         "queue0",
+						DeservedGPUs: 1,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"pending_job": {
+						GPUsAccepted: 0,
+						Status:       pod_status.Pending,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds: 0,
 					},
 				},
 			},

--- a/pkg/scheduler/api/node_info/node_info.go
+++ b/pkg/scheduler/api/node_info/node_info.go
@@ -689,7 +689,7 @@ func (ni *NodeInfo) GetRequiredInitQuota(pi *pod_info.PodInfo) *podgroup_info.Jo
 	if len(pi.ResReq.MigResources()) != 0 {
 		quota.GPU = pi.ResReq.GetSumGPUs()
 	} else {
-		quota.GPU = ni.getGpuMemoryFractionalOnNode(ni.GetResourceGpuMemory(pi.ResReq))
+		quota.GPU = float64(pi.ResReq.GetNumOfGpuDevices()) * ni.getGpuMemoryFractionalOnNode(ni.GetResourceGpuMemory(pi.ResReq))
 	}
 	quota.MilliCPU = pi.ResReq.Cpu()
 	quota.Memory = pi.ResReq.Memory()

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
@@ -1117,7 +1117,8 @@ var _ = Describe("Capacity Policy Check", func() {
 						},
 					},
 					node: &node_info.NodeInfo{
-						Name: "worker-node",
+						Name:                   "worker-node",
+						MemoryOfEveryGpuOnNode: 100,
 					},
 					expectedResult: false,
 				},
@@ -1181,7 +1182,8 @@ var _ = Describe("Capacity Policy Check", func() {
 						},
 					},
 					node: &node_info.NodeInfo{
-						Name: "worker-node",
+						Name:                   "worker-node",
+						MemoryOfEveryGpuOnNode: 100,
 					},
 					expectedResult: false,
 				},

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
@@ -6,7 +6,6 @@ package capacity_policy
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
@@ -1094,14 +1093,13 @@ var _ = Describe("Capacity Policy Check", func() {
 						},
 					},
 					job: &podgroup_info.PodGroupInfo{
-						Name:           "job-a",
-						Namespace:      "team-a",
-						Queue:          "queue",
-						Preemptibility: v2alpha2.NonPreemptible,
-						VectorMap:      testVectorMap,
-						JobFitErrors:   make([]common_info.JobFitError, 0),
-						PodSets: map[string]*subgroup_info.PodSet{
-							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+						Name:         "job-a",
+						Namespace:    "team-a",
+						Queue:        "queue",
+						Priority:     constants.PriorityBuildNumber,
+						JobFitErrors: make(v2alpha2.UnschedulableExplanations, 0),
+						SubGroups: map[string]*podgroup_info.SubGroupInfo{
+							podgroup_info.DefaultSubGroup: podgroup_info.NewSubGroupInfo(podgroup_info.DefaultSubGroup, 1).
 								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
 									"task-a": {
 										UID:       "task-a",
@@ -1114,13 +1112,13 @@ var _ = Describe("Capacity Policy Check", func() {
 											r.GpuResourceRequirement = *resource_info.NewGpuResourceRequirementWithMultiFraction(2, 0, 60)
 											return r
 										}(),
-										ResReqVector: resource_info.NewResourceRequirements(0, 0, 0).ToVector(testVectorMap),
-										VectorMap:    testVectorMap,
 									},
 								}),
 						},
 					},
-					node:           node_info.NewNodeInfo(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-node"}}, nil, testVectorMap),
+					node: &node_info.NodeInfo{
+						Name: "worker-node",
+					},
 					expectedResult: false,
 				},
 			}
@@ -1163,29 +1161,28 @@ var _ = Describe("Capacity Policy Check", func() {
 						},
 					},
 					job: &podgroup_info.PodGroupInfo{
-						Name:           "job-a",
-						Namespace:      "team-a",
-						Queue:          "queue",
-						Preemptibility: v2alpha2.NonPreemptible,
-						VectorMap:      testVectorMap,
-						JobFitErrors:   make([]common_info.JobFitError, 0),
-						PodSets: map[string]*subgroup_info.PodSet{
-							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+						Name:         "job-a",
+						Namespace:    "team-a",
+						Queue:        "queue",
+						Priority:     constants.PriorityBuildNumber,
+						JobFitErrors: make(v2alpha2.UnschedulableExplanations, 0),
+						SubGroups: map[string]*podgroup_info.SubGroupInfo{
+							podgroup_info.DefaultSubGroup: podgroup_info.NewSubGroupInfo(podgroup_info.DefaultSubGroup, 1).
 								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
 									"task-a": {
-										UID:          "task-a",
-										Job:          "job-a",
-										Name:         "task-a",
-										Namespace:    "team-a",
-										Status:       pod_status.Pending,
-										ResReq:       resource_info.NewResourceRequirementsWithGpus(2),
-										ResReqVector: resource_info.NewResourceRequirementsWithGpus(2).ToVector(testVectorMap),
-										VectorMap:    testVectorMap,
+										UID:       "task-a",
+										Job:       "job-a",
+										Name:      "task-a",
+										Namespace: "team-a",
+										Status:    pod_status.Pending,
+										ResReq:    resource_info.NewResourceRequirementsWithGpus(2),
 									},
 								}),
 						},
 					},
-					node:           node_info.NewNodeInfo(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-node"}}, nil, testVectorMap),
+					node: &node_info.NodeInfo{
+						Name: "worker-node",
+					},
 					expectedResult: false,
 				},
 			}

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
@@ -6,6 +6,7 @@ package capacity_policy
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
@@ -1063,6 +1064,142 @@ var _ = Describe("Capacity Policy Check", func() {
 				})
 			}
 
+		})
+
+		Context("GPU memory multi-device quota enforcement", func() {
+			// 2-device GPU memory request: GetRequiredInitQuota returns per-device fraction (0.6)
+			// instead of total (1.2 = 2 × 0.6), because it never multiplies by GetNumOfGpuDevices().
+			// AllocatedNotPreemptible=0.4, Deserved=1:
+			//   correct:  1 < 0.4 + 1.2 = 1.6  → blocked
+			//   bug:      1 < 0.4 + 0.6 = 1.0  → schedulable (false, not strictly less)
+			tests := map[string]struct {
+				queues         map[common_info.QueueID]*rs.QueueAttributes
+				job            *podgroup_info.PodGroupInfo
+				node           *node_info.NodeInfo
+				expectedResult bool
+			}{
+				"2-device GPU memory task exceeds non-preemptible quota": {
+					queues: map[common_info.QueueID]*rs.QueueAttributes{
+						"queue": {
+							UID:         "queue",
+							Name:        "queue",
+							ParentQueue: "",
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed:              commonconstants.UnlimitedResourceQuantity,
+									AllocatedNotPreemptible: 0.4,
+									Deserved:                1,
+								},
+							},
+						},
+					},
+					job: &podgroup_info.PodGroupInfo{
+						Name:           "job-a",
+						Namespace:      "team-a",
+						Queue:          "queue",
+						Preemptibility: v2alpha2.NonPreemptible,
+						VectorMap:      testVectorMap,
+						JobFitErrors:   make([]common_info.JobFitError, 0),
+						PodSets: map[string]*subgroup_info.PodSet{
+							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
+									"task-a": {
+										UID:       "task-a",
+										Job:       "job-a",
+										Name:      "task-a",
+										Namespace: "team-a",
+										Status:    pod_status.Pending,
+										ResReq: func() *resource_info.ResourceRequirements {
+											r := resource_info.EmptyResourceRequirements()
+											r.GpuResourceRequirement = *resource_info.NewGpuResourceRequirementWithMultiFraction(2, 0, 60)
+											return r
+										}(),
+										ResReqVector: resource_info.NewResourceRequirements(0, 0, 0).ToVector(testVectorMap),
+										VectorMap:    testVectorMap,
+									},
+								}),
+						},
+					},
+					node:           node_info.NewNodeInfo(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-node"}}, nil, testVectorMap),
+					expectedResult: false,
+				},
+			}
+
+			for name, data := range tests {
+				testName := name
+				testData := data
+				It(testName, func() {
+					capacityPolicy := New(testData.queues)
+					result := capacityPolicy.IsTaskAllocationOnNodeOverCapacity(testData.job.GetAllPodsMap()["task-a"],
+						testData.job, testData.node)
+					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
+				})
+			}
+		})
+
+		Context("GPU limit enforcement for multi-GPU requests", func() {
+			tests := map[string]struct {
+				queues         map[common_info.QueueID]*rs.QueueAttributes
+				job            *podgroup_info.PodGroupInfo
+				node           *node_info.NodeInfo
+				expectedResult bool
+			}{
+				// A 2-GPU task must be blocked when MaxAllowed=1.
+				// Bug: GetRequiredInitQuota returns the per-device fraction (1.0) instead of
+				// the total GPU count (2.0), so the check sees 0+1=1 which is NOT > 1 → schedulable.
+				"2-GPU task exceeds queue GPU limit of 1": {
+					queues: map[common_info.QueueID]*rs.QueueAttributes{
+						"queue": {
+							UID:         "queue",
+							Name:        "queue",
+							ParentQueue: "",
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 1,
+									Allocated:  0,
+									Deserved:   commonconstants.UnlimitedResourceQuantity,
+								},
+							},
+						},
+					},
+					job: &podgroup_info.PodGroupInfo{
+						Name:           "job-a",
+						Namespace:      "team-a",
+						Queue:          "queue",
+						Preemptibility: v2alpha2.NonPreemptible,
+						VectorMap:      testVectorMap,
+						JobFitErrors:   make([]common_info.JobFitError, 0),
+						PodSets: map[string]*subgroup_info.PodSet{
+							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
+									"task-a": {
+										UID:          "task-a",
+										Job:          "job-a",
+										Name:         "task-a",
+										Namespace:    "team-a",
+										Status:       pod_status.Pending,
+										ResReq:       resource_info.NewResourceRequirementsWithGpus(2),
+										ResReqVector: resource_info.NewResourceRequirementsWithGpus(2).ToVector(testVectorMap),
+										VectorMap:    testVectorMap,
+									},
+								}),
+						},
+					},
+					node:           node_info.NewNodeInfo(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-node"}}, nil, testVectorMap),
+					expectedResult: false,
+				},
+			}
+
+			for name, data := range tests {
+				testName := name
+				testData := data
+				It(testName, func() {
+					capacityPolicy := New(testData.queues)
+					result := capacityPolicy.IsTaskAllocationOnNodeOverCapacity(testData.job.GetAllPodsMap()["task-a"],
+						testData.job, testData.node)
+					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
+				})
+			}
 		})
 	})
 })

--- a/pkg/scheduler/test_utils/jobs_fake/jobs.go
+++ b/pkg/scheduler/test_utils/jobs_fake/jobs.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	enginev2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_status"
@@ -296,6 +297,10 @@ func createPodOfTask(job *TestJobBasic, taskIndex int,
 	if task.RequiredGPUs != nil {
 		numGPUsStr := strconv.FormatInt(*task.RequiredGPUs, 10)
 		podOfTask.Spec.Containers[0].Resources.Requests[resource_info.GPUResourceName] = resource.MustParse(numGPUsStr)
+	}
+
+	if job.RequiredMultiFractionDevicesPerTask != nil {
+		podOfTask.Annotations[commonconstants.GpuFractionsNumDevices] = strconv.FormatUint(*job.RequiredMultiFractionDevicesPerTask, 10)
 	}
 
 	if pod_status.IsActiveUsedStatus(task.State) {


### PR DESCRIPTION
## Description

Backport of #1370 to `v0.9`.

Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices.

## Related Issues

Fixes #1369

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Additional Notes

Cherry-picked from main with import path conflict resolved (NVIDIA → kai-scheduler module rename).