### PR TITLE
fix: Handle nil min member in subgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)
 - Added `resourceclaims/binding` RBAC permission to the binder ClusterRole for compatibility with Kubernetes v1.36+, where the `DRAResourceClaimGranularStatusAuthorization` feature gate requires explicit permission on the `resourceclaims/binding` subresource to modify `status.allocation` and `status.reservedFor` on ResourceClaims. [#1372](https://github.com/kai-scheduler/KAI-Scheduler/pull/1372) [praveen0raj](https://github.com/praveen0raj)
 - Allow users to override minMember for k8s batch Jobs and JobSets using the `kai.scheduler/batch-min-member` annotation [#1308](https://github.com/kai-scheduler/KAI-Scheduler/pull/1308) [itsomri](https://github.com/itsomri)
+- Fixed a bug where nil minMember caused subgroups creation to fail in scheduler [#1407](https://github.com/kai-scheduler/KAI-Scheduler/pull/1407) [itsomri](https://github.com/itsomri)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/factory.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/factory.go
@@ -79,10 +79,11 @@ func createSubGroupInfos(allSubGroups map[string]*v2alpha2.SubGroup, children ma
 		if hasChildren {
 			subGroupSets[name] = NewSubGroupSet(name, topologyConstrainInfo)
 		} else {
-			if subGroup.MinMember == nil {
-				return fmt.Errorf("subgroup <%s> minMember is required", name)
+			minMember := int32(0)
+			if subGroup.MinMember != nil {
+				minMember = *subGroup.MinMember
 			}
-			podSets[name] = NewPodSet(name, max(*subGroup.MinMember, MinimumSubGroupMinAvailable), topologyConstrainInfo)
+			podSets[name] = NewPodSet(name, max(minMember, MinimumSubGroupMinAvailable), topologyConstrainInfo)
 		}
 	}
 	return nil

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/factory.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/factory.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	RootSubGroupSetName         = ""
-	MinimumSubGroupMinAvailable = 1
+	MinimumSubGroupMinAvailable = 0
 )
 
 func FromPodGroup(podGroup *v2alpha2.PodGroup) (*SubGroupSet, error) {

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/factory_test.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/factory_test.go
@@ -359,8 +359,13 @@ func TestFromPodGroup_FullTree(t *testing.T) {
 					},
 				},
 			},
-			want:    nil,
-			wantErr: "minMember is required",
+			want: &wantGroup{
+				Name:   RootSubGroupSetName,
+				Groups: nil,
+				PodSets: []*wantPodSet{
+					{Name: "only-leaf", MinMember: 0},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR fixed subgroup creation when minMember is not set

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler failure when creating subgroups with missing minimum member values. Subgroups now default to a minimum member setting of 0, enabling more flexible configuration without requiring explicit minimum member specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->