### PR TITLE
feat: Allpodsmap caching v0.14

### DIFF
--- a/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
@@ -498,7 +498,14 @@ func TestPodSimpleScenario_GetVictimJobRepresentativeById(t *testing.T) {
 				tt.fields.session, tt.fields.pendingTasksAsJob, tt.fields.pendingTasksAsJob, tt.fields.potentialVictimsTasks,
 				tt.fields.recordedVictimsJobs)
 			s.AddPotentialVictimsTasks(tt.args.tasks)
-			if got := s.GetVictimJobRepresentativeById(tt.args.victimPodInfo); !reflect.DeepEqual(got, tt.want) {
+			got := s.GetVictimJobRepresentativeById(tt.args.victimPodInfo)
+			if got != nil {
+				_ = got.GetAllPodsMap()
+			}
+			if tt.want != nil {
+				tt.want.GetAllPodsMap()
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetVictimJobRepresentativeById() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/scheduler/actions/utils/job_order_by_queue_test.go
+++ b/pkg/scheduler/actions/utils/job_order_by_queue_test.go
@@ -755,6 +755,7 @@ func TestJobsOrderByQueues_RequeueJob(t *testing.T) {
 			jobsOrder.PushJob(jobToRequeue)
 
 			for _, expectedJob := range tt.expected.expectedJobsList {
+				_ = expectedJob.GetAllPodsMap()
 				actualJob := jobsOrder.PopNextJob()
 				assert.Equal(t, expectedJob, actualJob)
 			}

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -96,6 +96,7 @@ type PodGroupInfo struct {
 	schedulingConstraintsSignature common_info.SchedulingConstraintsSignature
 
 	// inner cache
+	allPodsMap                        *pod_info.PodsMap
 	tasksToAllocate                   []*pod_info.PodInfo
 	tasksToAllocateInitResource       *resource_info.Resource
 	tasksToAllocateInitResourceVector resource_info.ResourceVector
@@ -141,12 +142,21 @@ func NewPodGroupInfoWithVectorMap(uid common_info.PodGroupID, vectorMap *resourc
 }
 
 func (pgi *PodGroupInfo) GetAllPodsMap() pod_info.PodsMap {
-	allPods := pod_info.PodsMap{}
+	if pgi.allPodsMap != nil {
+		return *pgi.allPodsMap
+	}
+	totalPods := 0
+	for _, podSet := range pgi.PodSets {
+		totalPods += len(podSet.GetPodInfos())
+	}
+
+	allPods := make(pod_info.PodsMap, totalPods)
 	for _, subGroup := range pgi.PodSets {
 		for podId, podInfo := range subGroup.GetPodInfos() {
 			allPods[podId] = podInfo
 		}
 	}
+	pgi.allPodsMap = &allPods
 	return allPods
 }
 
@@ -213,6 +223,7 @@ func (pgi *PodGroupInfo) setSubGroups(podGroup *enginev2alpha2.PodGroup) error {
 			rootSubGroupSet.AddPodSet(defaultPodSet)
 		}
 	}
+	pgi.invalidateTasksCache()
 	return nil
 }
 
@@ -222,6 +233,9 @@ func (pgi *PodGroupInfo) addTaskIndex(ti *pod_info.PodInfo) {
 	}
 
 	pgi.PodStatusIndex[ti.Status][ti.UID] = ti
+	if pgi.allPodsMap != nil {
+		(*pgi.allPodsMap)[ti.UID] = ti
+	}
 	if pod_status.IsActiveAllocatedStatus(ti.Status) {
 		pgi.activeAllocatedCount = ptr.To(*pgi.activeAllocatedCount + 1)
 	}
@@ -265,6 +279,9 @@ func (pgi *PodGroupInfo) UpdateTaskStatus(task *pod_info.PodInfo, status pod_sta
 func (pgi *PodGroupInfo) deleteTaskIndex(ti *pod_info.PodInfo) {
 	if tasks, found := pgi.PodStatusIndex[ti.Status]; found {
 		delete(tasks, ti.UID)
+		if pgi.allPodsMap != nil {
+			delete(*pgi.allPodsMap, ti.UID)
+		}
 		if pod_status.IsActiveAllocatedStatus(ti.Status) {
 			pgi.activeAllocatedCount = ptr.To(*pgi.activeAllocatedCount - 1)
 		}
@@ -278,6 +295,7 @@ func (pgi *PodGroupInfo) deleteTaskIndex(ti *pod_info.PodInfo) {
 }
 
 func (pgi *PodGroupInfo) invalidateTasksCache() {
+	pgi.allPodsMap = nil
 	pgi.tasksToAllocate = nil
 	pgi.tasksToAllocateInitResource = nil
 	pgi.tasksToAllocateInitResourceVector = nil


### PR DESCRIPTION
## Description

This PR adds internal caching for PodGroupInfo.GetAllPodsMap to improve performance.

## Related Issues

Backports #1408

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
