### PR TITLE
fix: Call SetNode once per session v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Race condition where `SyncForGpuGroup` could prematurely delete reservation pods when the informer cache had not yet propagated GPU group labels on recently-bound fraction pods. The binder now checks for active BindRequests referencing the GPU group before deleting a reservation pod.
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)
 - Added `resourceclaims/binding` RBAC permission to the binder ClusterRole for compatibility with Kubernetes v1.36+, where the `DRAResourceClaimGranularStatusAuthorization` feature gate requires explicit permission on the `resourceclaims/binding` subresource to modify `status.allocation` and `status.reservedFor` on ResourceClaims. [#1372](https://github.com/kai-scheduler/KAI-Scheduler/pull/1372) [praveen0raj](https://github.com/praveen0raj)
+- Improved performance by evaluating SetNode once per session instead of on each predicate evaluation  [#1422](https://github.com/kai-scheduler/KAI-Scheduler/pull/1422) [itsomri](https://github.com/itsomri)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -125,6 +125,7 @@ func (pp *predicatesPlugin) initializeK8sNodeInfos(ssn *framework.Session) {
 	for _, nodeInfo := range ssn.ClusterInfo.Nodes {
 		podAffinityInfo, ok := nodeInfo.PodAffinityInfo.(*cluster_info.K8sNodePodAffinityInfo)
 		if !ok || podAffinityInfo == nil || podAffinityInfo.NodeInfo == nil {
+			log.InfraLogger.Warningf("Node %s has no pod affinity info", nodeInfo.Name)
 			continue
 		}
 

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -105,6 +105,7 @@ func (pp *predicatesPlugin) Name() string {
 
 func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 	k8sPredicates := predicates.NewSessionPredicates(ssn)
+	pp.initializeK8sNodeInfos(ssn)
 
 	pp.storageSchedulingEnabled = ssn.ScheduleCSIStorage()
 	pp.skipPredicates = SkipPredicates{}
@@ -118,6 +119,17 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 		return pp.evaluateTaskOnPredicates(task, job, node, k8sPredicates,
 			ssn.IsTaskAllocationOnNodeOverCapacityFn, ssn.IsRestrictNodeSchedulingEnabled, pp.skipPredicates)
 	})
+}
+
+func (pp *predicatesPlugin) initializeK8sNodeInfos(ssn *framework.Session) {
+	for _, nodeInfo := range ssn.ClusterInfo.Nodes {
+		podAffinityInfo, ok := nodeInfo.PodAffinityInfo.(*cluster_info.K8sNodePodAffinityInfo)
+		if !ok || podAffinityInfo == nil || podAffinityInfo.NodeInfo == nil {
+			continue
+		}
+
+		podAffinityInfo.NodeInfo.SetNode(nodeInfo.Node)
+	}
 }
 
 func evaluateTaskOnPrePredicate(task *pod_info.PodInfo, k8sPredicates k8s_internal.SessionPredicates,
@@ -188,7 +200,6 @@ func (pp *predicatesPlugin) evaluateTaskOnPredicates(
 	}()
 
 	k8sNodeInfo := node.PodAffinityInfo.(*cluster_info.K8sNodePodAffinityInfo).NodeInfo
-	k8sNodeInfo.SetNode(node.Node)
 
 	if result := isTaskAllocationOnNodeOverCapacityFn(task, job, node); !result.IsSchedulable {
 		return common_info.NewFitError(task.Name, task.Namespace, node.Name,


### PR DESCRIPTION
## Description

This PR improves performance by calling k8s' SetNode for NodeInfo once, instead of on every predicate evaluation.

## Related Issues

Backports #1421 

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
