### PR TITLE
feat(chart): expose enabled helm value for all kai-config components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Added `enabled` Helm values for `binder`, `podgrouper`, `podgroupcontroller`, `queuecontroller`, `admission`, and `scheduler` to allow disabling individual components from values.yaml. Previously these were hardcoded to `true` in the kai-config template.
 - Added `prometheus.enabled` and `prometheus.externalPrometheusUrl` Helm values to configure Prometheus from values.yaml [#907](https://github.com/NVIDIA/KAI-Scheduler/issues/907)
 - Added validation for `subgroup` name in podgroup [faizanexe](https://github.com/faizan-exe)
 - Added memory profile and run duration to snapshot tool [#1411](https://github.com/NVIDIA/KAI-Scheduler/issues/1411)

--- a/deployments/kai-scheduler/templates/kai-config.yaml
+++ b/deployments/kai-scheduler/templates/kai-config.yaml
@@ -53,7 +53,7 @@ spec:
 
   binder:
     service:
-      enabled: true
+      enabled: {{ .Values.binder.enabled }}
       image:
         name: {{ .Values.binder.image.name }}
         repository: {{ .Values.global.registry }}
@@ -96,7 +96,7 @@ spec:
 
   podGrouper:
     service:
-      enabled: true
+      enabled: {{ .Values.podgrouper.enabled }}
       image:
         name: {{ .Values.podgrouper.image.name }}
         repository: {{ .Values.global.registry }}
@@ -113,7 +113,7 @@ spec:
 
   podGroupController:
     service:
-      enabled: true
+      enabled: {{ .Values.podgroupcontroller.enabled }}
       image:
         name: {{ .Values.podgroupcontroller.image.name }}
         repository: {{ .Values.global.registry }}
@@ -130,7 +130,7 @@ spec:
 
   queueController:
     service:
-      enabled: true
+      enabled: {{ .Values.queuecontroller.enabled }}
       image:
         name: {{ .Values.queuecontroller.image.name }}
         repository: {{ .Values.global.registry }}
@@ -147,7 +147,7 @@ spec:
 
   admission:
     service:
-      enabled: true
+      enabled: {{ .Values.admission.enabled }}
       image:
         name: {{ .Values.admission.image.name }}
         repository: {{ .Values.global.registry }}
@@ -196,6 +196,7 @@ spec:
 
   scheduler:
     service:
+      enabled: {{ .Values.scheduler.enabled }}
       image:
         name: {{ .Values.scheduler.image.name }}
         repository: {{ .Values.global.registry }}

--- a/deployments/kai-scheduler/tests/enabled_test.yaml
+++ b/deployments/kai-scheduler/tests/enabled_test.yaml
@@ -1,0 +1,217 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test service enabled configuration
+templates:
+  - kai-config.yaml
+tests:
+  # ======================================
+  # Default Behavior Tests
+  # ======================================
+  - it: should enable all services by default
+    asserts:
+      - equal:
+          path: spec.binder.service.enabled
+          value: true
+      - equal:
+          path: spec.podGrouper.service.enabled
+          value: true
+      - equal:
+          path: spec.podGroupController.service.enabled
+          value: true
+      - equal:
+          path: spec.queueController.service.enabled
+          value: true
+      - equal:
+          path: spec.admission.service.enabled
+          value: true
+      - equal:
+          path: spec.scheduler.service.enabled
+          value: true
+
+  # ======================================
+  # Binder Enabled Tests
+  # ======================================
+  - it: should render binder enabled true when explicitly set
+    set:
+      binder.enabled: true
+    asserts:
+      - equal:
+          path: spec.binder.service.enabled
+          value: true
+
+  - it: should render binder enabled false when disabled
+    set:
+      binder.enabled: false
+    asserts:
+      - equal:
+          path: spec.binder.service.enabled
+          value: false
+
+  # ======================================
+  # PodGrouper Enabled Tests
+  # ======================================
+  - it: should render podGrouper enabled true when explicitly set
+    set:
+      podgrouper.enabled: true
+    asserts:
+      - equal:
+          path: spec.podGrouper.service.enabled
+          value: true
+
+  - it: should render podGrouper enabled false when disabled
+    set:
+      podgrouper.enabled: false
+    asserts:
+      - equal:
+          path: spec.podGrouper.service.enabled
+          value: false
+
+  # ======================================
+  # PodGroupController Enabled Tests
+  # ======================================
+  - it: should render podGroupController enabled true when explicitly set
+    set:
+      podgroupcontroller.enabled: true
+    asserts:
+      - equal:
+          path: spec.podGroupController.service.enabled
+          value: true
+
+  - it: should render podGroupController enabled false when disabled
+    set:
+      podgroupcontroller.enabled: false
+    asserts:
+      - equal:
+          path: spec.podGroupController.service.enabled
+          value: false
+
+  # ======================================
+  # QueueController Enabled Tests
+  # ======================================
+  - it: should render queueController enabled true when explicitly set
+    set:
+      queuecontroller.enabled: true
+    asserts:
+      - equal:
+          path: spec.queueController.service.enabled
+          value: true
+
+  - it: should render queueController enabled false when disabled
+    set:
+      queuecontroller.enabled: false
+    asserts:
+      - equal:
+          path: spec.queueController.service.enabled
+          value: false
+
+  # ======================================
+  # Admission Enabled Tests
+  # ======================================
+  - it: should render admission enabled true when explicitly set
+    set:
+      admission.enabled: true
+    asserts:
+      - equal:
+          path: spec.admission.service.enabled
+          value: true
+
+  - it: should render admission enabled false when disabled
+    set:
+      admission.enabled: false
+    asserts:
+      - equal:
+          path: spec.admission.service.enabled
+          value: false
+
+  # ======================================
+  # Scheduler Enabled Tests
+  # ======================================
+  - it: should render scheduler enabled true when explicitly set
+    set:
+      scheduler.enabled: true
+    asserts:
+      - equal:
+          path: spec.scheduler.service.enabled
+          value: true
+
+  - it: should render scheduler enabled false when disabled
+    set:
+      scheduler.enabled: false
+    asserts:
+      - equal:
+          path: spec.scheduler.service.enabled
+          value: false
+
+  # ======================================
+  # NodeScaleAdjuster Enabled Tests
+  # ======================================
+  - it: should render nodeScaleAdjuster disabled by default (clusterAutoscaling false)
+    asserts:
+      - equal:
+          path: spec.nodeScaleAdjuster.service.enabled
+          value: false
+
+  - it: should render nodeScaleAdjuster enabled when clusterAutoscaling is true
+    set:
+      global.clusterAutoscaling: true
+    asserts:
+      - equal:
+          path: spec.nodeScaleAdjuster.service.enabled
+          value: true
+
+  # ======================================
+  # Multiple Services Disabled
+  # ======================================
+  - it: should allow disabling multiple services at once
+    set:
+      podgrouper.enabled: false
+      podgroupcontroller.enabled: false
+      admission.enabled: false
+    asserts:
+      - equal:
+          path: spec.podGrouper.service.enabled
+          value: false
+      - equal:
+          path: spec.podGroupController.service.enabled
+          value: false
+      - equal:
+          path: spec.admission.service.enabled
+          value: false
+      - equal:
+          path: spec.binder.service.enabled
+          value: true
+      - equal:
+          path: spec.queueController.service.enabled
+          value: true
+      - equal:
+          path: spec.scheduler.service.enabled
+          value: true
+
+  - it: should allow disabling all optional services
+    set:
+      binder.enabled: false
+      podgrouper.enabled: false
+      podgroupcontroller.enabled: false
+      queuecontroller.enabled: false
+      admission.enabled: false
+      scheduler.enabled: false
+    asserts:
+      - equal:
+          path: spec.binder.service.enabled
+          value: false
+      - equal:
+          path: spec.podGrouper.service.enabled
+          value: false
+      - equal:
+          path: spec.podGroupController.service.enabled
+          value: false
+      - equal:
+          path: spec.queueController.service.enabled
+          value: false
+      - equal:
+          path: spec.admission.service.enabled
+          value: false
+      - equal:
+          path: spec.scheduler.service.enabled
+          value: false

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -47,6 +47,7 @@ operator:
   burst: 300
 
 podgrouper:
+  enabled: true
   image:
     name: podgrouper
     pullPolicy: IfNotPresent
@@ -55,12 +56,14 @@ podgrouper:
   affinity: {}
 
 podgroupcontroller:
+  enabled: true
   image:
     name: podgroupcontroller
     pullPolicy: IfNotPresent
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
   affinity: {}
 binder:
+  enabled: true
   name: binder
   image:
     name: binder
@@ -85,6 +88,7 @@ binder:
     metricsPort: 8080
   affinity: {}
 scheduler:
+  enabled: true
   image:
     name: scheduler
     pullPolicy: IfNotPresent
@@ -123,6 +127,7 @@ scheduler:
   actions: {}
 
 queuecontroller:
+  enabled: true
   image:
     name: queuecontroller
     pullPolicy: IfNotPresent
@@ -131,6 +136,7 @@ queuecontroller:
   affinity: {}
 
 admission:
+  enabled: true
   name: kai-admission
   image:
     name: admission


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

The kai-config template previously hardcoded `enabled: true` for binder, podGrouper, podGroupController, queueController, and admission services, and omitted the `enabled` field entirely for the scheduler. This prevented users from disabling individual components via `values.yaml` or `--set` overrides at install/upgrade time.

This PR adds an `enabled: true` default to `values.yaml` for each of these six components and wires the template to read from the corresponding value. The nodeScaleAdjuster already read its enabled state from `global.clusterAutoscaling` and is left unchanged.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes
None. Default behavior is preserved for all components remain enabled unless explicitly set to `false`.

## Additional Notes

**Files changed:**
- `deployments/kai-scheduler/values.yaml` - added `enabled: true` to `binder`, `podgrouper`, `podgroupcontroller`, `queuecontroller`, `admission`, and `scheduler` sections.
- `deployments/kai-scheduler/templates/kai-config.yaml` replaced hardcoded `enabled: true` with `{{ .Values.<component>.enabled }}` for the six components above; added the previously missing `enabled` field to the scheduler service block.
- `deployments/kai-scheduler/tests/enabled_test.yaml` - 20 new helm unittest cases covering defaults, per-component enable/disable, multi-disable, and nodeScaleAdjuster behavior.
