### PR TITLE
fix: Added missing PVs to snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Allow users to override minMember for k8s batch Jobs and JobSets using the `kai.scheduler/batch-min-member` annotation [#1308](https://github.com/kai-scheduler/KAI-Scheduler/pull/1308) [itsomri](https://github.com/itsomri)
 - Fixed a bug where nil minMember caused subgroups creation to fail in scheduler [#1407](https://github.com/kai-scheduler/KAI-Scheduler/pull/1407) [itsomri](https://github.com/itsomri)
 - Improved performance by evaluating SetNode once per session instead of on each predicate evaluation  [#1421](https://github.com/kai-scheduler/KAI-Scheduler/pull/1421) [itsomri](https://github.com/itsomri)
+- Added persistent volumes to cluster snapshot [#1424](https://github.com/kai-scheduler/KAI-Scheduler/pull/1424) [itsomri](https://github.com/itsomri)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/cmd/snapshot-tool/main.go
+++ b/cmd/snapshot-tool/main.go
@@ -251,6 +251,13 @@ func loadClientsWithSnapshot(rawObjects *snapshot.RawKubernetesObjects, discover
 		}
 	}
 
+	for _, persistentVolume := range rawObjects.PersistentVolumes {
+		_, err := kubeClient.CoreV1().PersistentVolumes().Create(context.TODO(), persistentVolume, v1.CreateOptions{})
+		if err != nil {
+			log.InfraLogger.Errorf("Failed to create persistent volume: %v", err)
+		}
+	}
+
 	for _, persistentVolumeClaim := range rawObjects.PersistentVolumeClaims {
 		_, err := kubeClient.CoreV1().PersistentVolumeClaims(persistentVolumeClaim.Namespace).Create(context.TODO(), persistentVolumeClaim, v1.CreateOptions{})
 		if err != nil {

--- a/pkg/scheduler/cache/cluster_info/data_lister/data_lister_mock.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/data_lister_mock.go
@@ -168,6 +168,21 @@ func (mr *MockDataListerMockRecorder) ListPersistentVolumeClaims() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPersistentVolumeClaims", reflect.TypeOf((*MockDataLister)(nil).ListPersistentVolumeClaims))
 }
 
+// ListPersistentVolumes mocks base method.
+func (m *MockDataLister) ListPersistentVolumes() ([]*v1.PersistentVolume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPersistentVolumes")
+	ret0, _ := ret[0].([]*v1.PersistentVolume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPersistentVolumes indicates an expected call of ListPersistentVolumes.
+func (mr *MockDataListerMockRecorder) ListPersistentVolumes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPersistentVolumes", reflect.TypeOf((*MockDataLister)(nil).ListPersistentVolumes))
+}
+
 // ListPodByIndex mocks base method.
 func (m *MockDataLister) ListPodByIndex(index, value string) ([]any, error) {
 	m.ctrl.T.Helper()

--- a/pkg/scheduler/cache/cluster_info/data_lister/interface.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/interface.go
@@ -24,6 +24,7 @@ type DataLister interface {
 	ListPriorityClasses() ([]*scheduling.PriorityClass, error)
 	GetPriorityClassByName(name string) (*scheduling.PriorityClass, error)
 	ListPodByIndex(index, value string) ([]interface{}, error)
+	ListPersistentVolumes() ([]*v1.PersistentVolume, error)
 	ListPersistentVolumeClaims() ([]*v1.PersistentVolumeClaim, error)
 	ListCSIStorageCapacities() ([]*storage.CSIStorageCapacity, error)
 	ListStorageClasses() ([]*storage.StorageClass, error)

--- a/pkg/scheduler/cache/cluster_info/data_lister/kubernetes_lister.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/kubernetes_lister.go
@@ -44,6 +44,7 @@ type k8sLister struct {
 	cmLister       listv1.ConfigMapLister
 	usageLister    *usagedb.UsageLister
 
+	pvLister              listv1.PersistentVolumeLister
 	pvcLister             listv1.PersistentVolumeClaimLister
 	storageCapacityLister v12.CSIStorageCapacityLister
 	storageClassLister    v12.StorageClassLister
@@ -79,6 +80,7 @@ func New(
 		cmLister:       informerFactory.Core().V1().ConfigMaps().Lister(),
 		usageLister:    usageLister,
 
+		pvLister:              informerFactory.Core().V1().PersistentVolumes().Lister(),
 		pvcLister:             informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
 		storageCapacityLister: informerFactory.Storage().V1().CSIStorageCapacities().Lister(),
 		storageClassLister:    informerFactory.Storage().V1().StorageClasses().Lister(),
@@ -146,6 +148,10 @@ func (k *k8sLister) ListPodByIndex(index, value string) ([]interface{}, error) {
 }
 
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims;persistentvolumes,verbs=get;list;watch
+
+func (k *k8sLister) ListPersistentVolumes() ([]*v1.PersistentVolume, error) {
+	return k.pvLister.List(labels.Everything())
+}
 
 func (k *k8sLister) ListPersistentVolumeClaims() ([]*v1.PersistentVolumeClaim, error) {
 	return k.pvcLister.List(labels.Everything())

--- a/pkg/scheduler/plugins/snapshot/snapshot.go
+++ b/pkg/scheduler/plugins/snapshot/snapshot.go
@@ -43,6 +43,7 @@ type RawKubernetesObjects struct {
 	BindRequests           []*schedulingv1alpha2.BindRequest `json:"bindRequests"`
 	PriorityClasses        []*v14.PriorityClass              `json:"priorityClasses"`
 	ConfigMaps             []*v1.ConfigMap                   `json:"configMaps"`
+	PersistentVolumes      []*v1.PersistentVolume             `json:"persistentVolumes"`
 	PersistentVolumeClaims []*v1.PersistentVolumeClaim       `json:"persistentVolumeClaims"`
 	CSIStorageCapacities   []*storage.CSIStorageCapacity     `json:"csiStorageCapacities"`
 	StorageClasses         []*storage.StorageClass           `json:"storageClasses"`
@@ -127,6 +128,12 @@ func (sp *snapshotPlugin) serveSnapshot(writer http.ResponseWriter, request *htt
 	if err != nil {
 		log.InfraLogger.Errorf("Error getting raw config maps: %v", err)
 		rawObjects.ConfigMaps = []*v1.ConfigMap{}
+	}
+
+	rawObjects.PersistentVolumes, err = dataLister.ListPersistentVolumes()
+	if err != nil {
+		log.InfraLogger.Errorf("Error getting raw persistent volumes: %v", err)
+		rawObjects.PersistentVolumes = []*v1.PersistentVolume{}
 	}
 
 	rawObjects.PersistentVolumeClaims, err = dataLister.ListPersistentVolumeClaims()

--- a/pkg/scheduler/plugins/snapshot/snapshot.go
+++ b/pkg/scheduler/plugins/snapshot/snapshot.go
@@ -43,7 +43,7 @@ type RawKubernetesObjects struct {
 	BindRequests           []*schedulingv1alpha2.BindRequest `json:"bindRequests"`
 	PriorityClasses        []*v14.PriorityClass              `json:"priorityClasses"`
 	ConfigMaps             []*v1.ConfigMap                   `json:"configMaps"`
-	PersistentVolumes      []*v1.PersistentVolume             `json:"persistentVolumes"`
+	PersistentVolumes      []*v1.PersistentVolume            `json:"persistentVolumes"`
 	PersistentVolumeClaims []*v1.PersistentVolumeClaim       `json:"persistentVolumeClaims"`
 	CSIStorageCapacities   []*storage.CSIStorageCapacity     `json:"csiStorageCapacities"`
 	StorageClasses         []*storage.StorageClass           `json:"storageClasses"`


### PR DESCRIPTION
## Description

Persistent volumes were missing from the snapshot plugin, which caused false errors when replaying snapshots from real clusters, such as failed scheduling attempts and unnecessary load when simulating allocations.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
