### PR TITLE
fix(ci): fall back to kind load when local registry push fails

### DIFF
--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -143,11 +143,22 @@ if [ "$LOCAL_IMAGES_BUILD" = "true" ]; then
     trap "kill $PORT_FORWARD_PID 2>/dev/null || true" EXIT
     sleep 2
 
-    # Push images to local registry
-    echo "Pushing images to local registry..."
-    for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep $PACKAGE_VERSION); do
-        docker push $image
-    done
+    # Probe whether docker push can reach the registry (fails on Docker Desktop where the
+    # daemon runs in a VM and cannot reach the host-side port-forward on localhost).
+    PROBE_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "$PACKAGE_VERSION" | head -1)
+    if docker push "$PROBE_IMAGE" > /dev/null 2>&1; then
+        echo "Pushing images to local registry via port-forward..."
+        for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep $PACKAGE_VERSION); do
+            docker push "$image"
+        done
+    else
+        echo "docker push failed (likely Docker Desktop — daemon cannot reach host port-forward). Falling back to 'kind load docker-image'..."
+        kill "$PORT_FORWARD_PID" 2>/dev/null || true
+        for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep "localhost:30100/.*${PACKAGE_VERSION}"); do
+            echo "  loading: $image"
+            kind load docker-image "$image" --name "$CLUSTER_NAME"
+        done
+    fi
 
     # Package and install helm chart
     helm package ./deployments/kai-scheduler -d ./charts --app-version $PACKAGE_VERSION --version $PACKAGE_VERSION


### PR DESCRIPTION
## Description

When `LOCAL_IMAGES_BUILD` is enabled, the setup script pushes images to a registry exposed via port-forward. On Docker Desktop on mac, the Docker daemon runs in a VM and often cannot reach `localhost` on the host, so `docker push` fails.

This change probes a single push first; if it fails, it stops the port-forward and loads the built images into the kind cluster with `kind load docker-image` instead.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes