### PR TITLE
fix: Exponential job solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed a bug where nil minMember caused subgroups creation to fail in scheduler [#1407](https://github.com/kai-scheduler/KAI-Scheduler/pull/1407) [itsomri](https://github.com/itsomri)
 - Improved performance by evaluating SetNode once per session instead of on each predicate evaluation  [#1421](https://github.com/kai-scheduler/KAI-Scheduler/pull/1421) [itsomri](https://github.com/itsomri)
 - Added persistent volumes to cluster snapshot [#1424](https://github.com/kai-scheduler/KAI-Scheduler/pull/1424) [itsomri](https://github.com/itsomri)
+- Improved scheduling performance for preempt/reclaim/consolidate actions on jobs with many tasks by replacing per-task linear probing with exponential+binary search in the job solver, reducing the number of scenario simulations from O(n) to O(log n) [#1435](https://github.com/kai-scheduler/KAI-Scheduler/pull/1435) [itsomri](https://github.com/itsomri)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -44,39 +44,33 @@ func NewJobsSolver(
 	}
 }
 
+// Solve attempts to allocate all tasksToAllocate for pendingJob, finding victims as needed.
+// Uses exponential-then-binary search over k = number of leading tasks to allocate, probing
+// solvePartialJob at each k. Every search probe is discarded (session left clean) and hints
+// from successful probes are accumulated in state. After the search, a final solve is
+// attempted at n with the accumulated hints — this doubles as producing the live statement
+// returned on success and as a retry that recovers false negatives caused by hint gaps
+// during the search (a k-probe may fail with weak hints yet succeed once later probes
+// strengthen them). Matches prior all-or-nothing semantics: full n or nothing.
 func (s *JobSolver) Solve(
 	ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo) (bool, *framework.Statement, []string) {
 	state := solvingState{}
 	originalNumActiveTasks := pendingJob.GetNumActiveUsedTasks()
 
-	var statement *framework.Statement
-	var pendingTasks []*pod_info.PodInfo
 	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, ssn.PodSetOrderFn, ssn.TaskOrderFn, false)
-	for _, nextTaskToSolve := range tasksToAllocate {
-		nextTasksToSolve := []*pod_info.PodInfo{nextTaskToSolve}
-		pendingTasks = append(pendingTasks, nextTasksToSolve...)
-		satisfactorySolution := len(pendingTasks) == len(tasksToAllocate)
-		partialPendingJob := getPartialJobRepresentative(pendingJob, pendingTasks)
+	n := len(tasksToAllocate)
+	if n == 0 {
+		return false, nil, calcVictimNames(state.recordedVictimsTasks)
+	}
 
-		result := s.solvePartialJob(ssn, &state, partialPendingJob)
-		if result == nil || !result.solved {
-			log.InfraLogger.V(5).Infof("No solution found for %d tasks out of %d tasks to allocate for %s",
-				len(pendingTasks), len(tasksToAllocate), pendingJob.Name)
-			break
-		}
+	maxSolvedK := s.searchMaxSolvableK(ssn, &state, pendingJob, tasksToAllocate)
+	if maxSolvedK == 0 {
+		return false, nil, calcVictimNames(state.recordedVictimsTasks)
+	}
 
-		if !satisfactorySolution && result.statement != nil {
-			result.statement.Discard()
-		}
-
-		statement = result.statement
-		state.recordedVictimsTasks = result.victimsTasks
-		state.recordedVictimsJobs = result.victimJobs
-
-		log.InfraLogger.V(4).Infof(
-			"Scenario solved for %d tasks out of %d tasks to allocate for %s. Victims: %s",
-			len(pendingTasks), len(tasksToAllocate), pendingJob.Name,
-			victimPrintingStruct{result.victimsTasks})
+	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n)
+	if result == nil || !result.solved {
+		return false, nil, calcVictimNames(state.recordedVictimsTasks)
 	}
 
 	numActiveTasks := pendingJob.GetNumActiveUsedTasks()
@@ -85,7 +79,93 @@ func (s *JobSolver) Solve(
 		jobSolved = false
 	}
 
-	return jobSolved, statement, calcVictimNames(state.recordedVictimsTasks)
+	log.InfraLogger.V(4).Infof(
+		"Scenario solved for %d tasks to allocate for %s. Victims: %s",
+		n, pendingJob.Name, victimPrintingStruct{result.victimsTasks})
+	return jobSolved, result.statement, calcVictimNames(result.victimsTasks)
+}
+
+// searchMaxSolvableK returns the largest k in [0, n] for which a probe at k succeeds.
+// Each probe is discarded before returning, so session state is clean on return.
+// Successful probes update hints in state for use by subsequent probes.
+// Complexity: O(log n) probes — exponential doubling to locate a failing k (or reach n),
+// then binary search between the last success and first failure.
+func (s *JobSolver) searchMaxSolvableK(
+	ssn *framework.Session,
+	state *solvingState,
+	pendingJob *podgroup_info.PodGroupInfo,
+	tasksToAllocate []*pod_info.PodInfo,
+) int {
+	n := len(tasksToAllocate)
+	if n == 0 {
+		return 0
+	}
+
+	lo := 0
+	var hi int
+	k := 1
+	for {
+		if !s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, k) {
+			hi = k
+			break
+		}
+		lo = k
+		if k == n {
+			return n
+		}
+		k *= 2
+		if k > n {
+			k = n
+		}
+	}
+
+	for hi-lo > 1 {
+		mid := (lo + hi) / 2
+		if s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, mid) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
+// tryProbeAndDiscard probes at k and always discards the resulting statement so the session
+// is left clean. On success, hints are written to state; returns whether the probe succeeded.
+func (s *JobSolver) tryProbeAndDiscard(
+	ssn *framework.Session,
+	state *solvingState,
+	pendingJob *podgroup_info.PodGroupInfo,
+	tasksToAllocate []*pod_info.PodInfo,
+	k int,
+) bool {
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k)
+	if result == nil || !result.solved {
+		log.InfraLogger.V(5).Infof("No solution found for %d tasks out of %d tasks to allocate for %s",
+			k, len(tasksToAllocate), pendingJob.Name)
+		return false
+	}
+	log.InfraLogger.V(5).Infof(
+		"Scenario probed for %d tasks out of %d tasks to allocate for %s. Victims: %s",
+		k, len(tasksToAllocate), pendingJob.Name, victimPrintingStruct{result.victimsTasks})
+	state.recordedVictimsTasks = result.victimsTasks
+	state.recordedVictimsJobs = result.victimJobs
+	if result.statement != nil {
+		result.statement.Discard()
+	}
+	return true
+}
+
+func (s *JobSolver) probeAtK(
+	ssn *framework.Session,
+	state *solvingState,
+	pendingJob *podgroup_info.PodGroupInfo,
+	tasksToAllocate []*pod_info.PodInfo,
+	k int,
+) *solutionResult {
+	pendingTasks := tasksToAllocate[:k]
+	partialPendingJob := getPartialJobRepresentative(pendingJob, pendingTasks)
+	return s.solvePartialJob(ssn, state, partialPendingJob)
 }
 
 func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo) *solutionResult {

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -44,14 +44,18 @@ func NewJobsSolver(
 	}
 }
 
-// Solve attempts to allocate all tasksToAllocate for pendingJob, finding victims as needed.
-// Uses exponential-then-binary search over k = number of leading tasks to allocate, probing
-// solvePartialJob at each k. Every search probe is discarded (session left clean) and hints
-// from successful probes are accumulated in state. After the search, a final solve is
-// attempted at n with the accumulated hints — this doubles as producing the live statement
-// returned on success and as a retry that recovers false negatives caused by hint gaps
-// during the search (a k-probe may fail with weak hints yet succeed once later probes
-// strengthen them). Matches prior all-or-nothing semantics: full n or nothing.
+// Solve attempts to find a feasible allocation for all of pendingJob's pending tasks,
+// evicting tasks from other jobs as victims when necessary. It operates with all-or-nothing
+// semantics: either the full set of pending tasks is scheduled, or no allocation is produced.
+//
+// Returns:
+//   - solved: true when every pending task was allocated and pendingJob is gang-satisfied.
+//   - statement: on success, a live Statement holding the speculative allocations and victim
+//     evictions; the caller is responsible for Commit or Discard. nil on failure.
+//   - victimTaskNames: formatted "<namespace>/<name>" strings of the victim tasks, for logging.
+//
+// Session state is mutated only on success (to reflect the speculative operations in the
+// returned statement) and is left unchanged on failure.
 func (s *JobSolver) Solve(
 	ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo) (bool, *framework.Statement, []string) {
 	state := solvingState{}


### PR DESCRIPTION
## Description

This PR changes the behavior of the JobSolver: instead of incremental, pod-by-pod search for a solution, it will now attempt solving in exponential steps (1 pod, 2 pods, 4 pods etc). If it fails, it will do a binary search from the last valid scenario until it finds the maximal solvable scenario.

This significantly improves reclaim/preempt/consolidate performance for large distributed jobs with many pending pods.

## Related Issues

Fixes #1410 

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Improved scheduler job allocation efficiency, reducing processing time for scenario evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->