### PR TITLE
docs: fix typos and capitalization in README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ PRs trigger: `make validate` → `make test` → `make build` → E2E tests
 ## General Rules
 - Use `git mv` when moving files to preserve history
 - DO NOT add obvious comments that duplicate the code.
-    - Write comments ONLY when ABSOLUTELY nessessary
+    - Write comments ONLY when ABSOLUTELY necessary
     - Keep Comments short, explicit and concise
     - DO NOT use `I`, `we` or any other pronoun
 - When performing a major change, run `make validate` after changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Open an issue with a clear description, steps to reproduce, and relevant environ
 ### Improving Documentation
 Help us keep the docs clear and useful by fixing typos, updating outdated information, or adding examples.
 
-### Contributing changes
+### Contributing Changes
 - Fork and Clone – Begin by forking the repository and cloning it to your local machine.
 - Create a Branch – Use a descriptive branch name, such as feature/add-cool-feature or bugfix/fix-issue123.
 - Make Changes – Keep your commits small, focused, and well-documented. For detailed build and test instructions, refer to [Building from Source](docs/developer/building-from-source.md).

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ It can run alongside other schedulers installed on the cluster.
 - [Hierarchical Queues](docs/queues/README.md): Manage workloads with two-level queue hierarchies for flexible organizational control.
 - [Resource distribution](docs/fairness/README.md#resource-division-algorithm): Customize quotas, over-quota weights, limits, and priorities per queue.
 - [Fairness Policies](docs/fairness/README.md#reclaim-strategies): Ensure equitable resource distribution using Dominant Resource Fairness (DRF) and resource reclamation across queues.
-- [Time-based Fairshare](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/time-based-fairshare): Over-time fair usage of resources, considering historical usage, time decay, and other parameters for fine-tunning. 
+- [Time-based Fairshare](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/time-based-fairshare): Over-time fair usage of resources, considering historical usage, time decay, and other parameters for fine-tuning. 
 - [Min-guaranteed-runtime](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/developer/designs/min-runtime): ensures a time period in which the scheduler must not preempt or reclaim a running workload, even if preemptible.
 - Workload Consolidation: Reallocate running workloads intelligently to reduce fragmentation and increase cluster utilization.
 - [Elastic Workloads](docs/elastic/README.md): Dynamically scale workloads within defined minimum and maximum pod counts.
 - Dynamic Resource Allocation (DRA): Support vendor-specific hardware resources through Kubernetes ResourceClaims (e.g., GPUs from NVIDIA or AMD).
 - [Topology-Aware Scheduling (TAS)](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/topology): supports optimized placement with [topology aware scheduling](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/developer/designs/topology-awareness) and hierarchical topology aware scheduling for [Hierarchical PodGroups](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/developer/designs/hierarchical-podgroup).
 - [Hierarchical PodGroups](https://github.com/kai-scheduler/KAI-scheduler/tree/main/docs/developer/designs/hierarchical-podgroup): supports gang scheduling with optimized topology aware scheduling of multi-level workloads, such as distributed and disaggregated workloads such as Dynamo/Grove.
-- DRA support - supporting DRA for NVidia ComputeResources (GB200/GB300)
+- DRA support - supporting DRA for NVIDIA ComputeResources (GB200/GB300)
 - Workload signatures: KAI Scheduler provides performance optimization for large  multi-pod submissions using workload signatures. 
 - Scheduler explainability: based on K8S Events, every major step of the scheduling process is logged.
 
@@ -84,7 +84,7 @@ Follow the instructions [here](docs/developer/building-from-source.md)
 
 ## Flavor Specific Instructions
 
-### Openshift
+### OpenShift
 
 When `gpu-operator` <v25.10.0 is installed, the following flag should be added to the installation command:
 


### PR DESCRIPTION
## Summary

Fix minor typos and capitalization issues in README.md.

## Changes

| Location | Before | After |
|---|---|---|
| Key Features - Time-based Fairshare | `fine-tunning` | `fine-tuning` |
| Key Features - DRA support | `NVidia` | `NVIDIA` |
| Flavor Specific Instructions | `Openshift` | `OpenShift` |

## Notes

- `NVIDIA` follows the official brand name capitalization used consistently
  elsewhere in this document
- `OpenShift` follows Red Hat's official product name capitalization