### PR TITLE
fix: Podgroup name for distributed batch jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 bin/
 .claude/
+.gocache/
+.gotmp/
 .idea/
 charts/
 cover.out

--- a/pkg/podgrouper/podgrouper/plugins/job/job_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/job/job_grouper.go
@@ -68,38 +68,37 @@ func (g *K8sJobGrouper) GetPodGroupMetadata(topOwner *unstructured.Unstructured,
 }
 
 func (g *K8sJobGrouper) calcPodGroupName(topOwner *unstructured.Unstructured, pod *v1.Pod) (string, error) {
-	if g.searchForLegacyPodGroups {
-		legacyName := calcLegacyName(topOwner, pod)
-		if legacyName != "" {
-			legacyPodGroupObj := &v2alpha2.PodGroup{}
-			err := g.client.Get(context.Background(), types.NamespacedName{Namespace: pod.Namespace, Name: legacyName},
-				legacyPodGroupObj)
-			if err == nil {
-				logger.V(1).Info("Using legacy pod-group %s/%s", pod.Namespace, legacyName)
-				return legacyName, nil
-			} else if !errors.IsNotFound(err) {
-				logger.V(1).Error(err,
-					"While searching for legacy pod group for pod %s/%s, an error has occurred.",
-					pod.Namespace, legacyName)
-				return "", err
-			}
-		}
+	newName := fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, topOwner.GetName(), topOwner.GetUID())
+
+	// Prior versions named the podgroup after the pod (pg-<pod>-<uid>) so that
+	// each pod of a multi-pod Job had its own podgroup. Keep using that name if
+	// such a podgroup already exists, so running pods aren't re-parented during
+	// an upgrade. During the upgrade window new pods of the same Job may join
+	// the new unified podgroup while older pods remain on their legacy ones;
+	// with the default MinAvailable=1 this is harmless.
+	if !g.searchForLegacyPodGroups {
+		return newName, nil
 	}
 
-	return fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, pod.Name, topOwner.GetUID()), nil
-}
-
-func calcLegacyName(topOwner *unstructured.Unstructured, pod *v1.Pod) string {
-	jobParallelism, found, err := unstructured.NestedInt64(topOwner.Object, "spec", "parallelism")
-
-	var baseName string
-	if found && err == nil && jobParallelism > 1 {
-		baseName = pod.Name
-	} else {
-		baseName = topOwner.GetName()
+	legacyName := fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, pod.Name, topOwner.GetUID())
+	if legacyName == newName {
+		return newName, nil
 	}
 
-	return fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, baseName, topOwner.GetUID())
+	legacyPodGroupObj := &v2alpha2.PodGroup{}
+	err := g.client.Get(context.Background(), types.NamespacedName{Namespace: pod.Namespace, Name: legacyName},
+		legacyPodGroupObj)
+	if err == nil {
+		logger.V(1).Info("Using legacy pod-group %s/%s", pod.Namespace, legacyName)
+		return legacyName, nil
+	}
+	if !errors.IsNotFound(err) {
+		logger.V(1).Error(err,
+			"While searching for legacy pod group for pod %s/%s, an error has occurred.",
+			pod.Namespace, legacyName)
+		return "", err
+	}
+	return newName, nil
 }
 
 func calcMinMember(topOwner *unstructured.Unstructured, pod *v1.Pod) (int32, error) {

--- a/pkg/podgrouper/podgrouper/plugins/job/job_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/job/job_grouper.go
@@ -53,12 +53,13 @@ func (g *K8sJobGrouper) GetPodGroupMetadata(topOwner *unstructured.Unstructured,
 		return nil, err
 	}
 
-	podGroupMetadata.Name, err = g.calcPodGroupName(topOwner, pod)
+	var legacy bool
+	podGroupMetadata.Name, legacy, err = g.calcPodGroupName(topOwner, pod)
 	if err != nil {
 		return nil, err
 	}
 
-	minMember, err := calcMinMember(topOwner, pod)
+	minMember, err := calcMinMember(topOwner, pod, legacy)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,7 @@ func (g *K8sJobGrouper) GetPodGroupMetadata(topOwner *unstructured.Unstructured,
 	return podGroupMetadata, nil
 }
 
-func (g *K8sJobGrouper) calcPodGroupName(topOwner *unstructured.Unstructured, pod *v1.Pod) (string, error) {
+func (g *K8sJobGrouper) calcPodGroupName(topOwner *unstructured.Unstructured, pod *v1.Pod) (string, bool, error) {
 	newName := fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, topOwner.GetName(), topOwner.GetUID())
 
 	// Prior versions named the podgroup after the pod (pg-<pod>-<uid>) so that
@@ -77,12 +78,12 @@ func (g *K8sJobGrouper) calcPodGroupName(topOwner *unstructured.Unstructured, po
 	// the new unified podgroup while older pods remain on their legacy ones;
 	// with the default MinAvailable=1 this is harmless.
 	if !g.searchForLegacyPodGroups {
-		return newName, nil
+		return newName, false, nil
 	}
 
 	legacyName := fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, pod.Name, topOwner.GetUID())
 	if legacyName == newName {
-		return newName, nil
+		return newName, false, nil
 	}
 
 	legacyPodGroupObj := &v2alpha2.PodGroup{}
@@ -90,18 +91,22 @@ func (g *K8sJobGrouper) calcPodGroupName(topOwner *unstructured.Unstructured, po
 		legacyPodGroupObj)
 	if err == nil {
 		logger.V(1).Info("Using legacy pod-group %s/%s", pod.Namespace, legacyName)
-		return legacyName, nil
+		return legacyName, true, nil
 	}
 	if !errors.IsNotFound(err) {
 		logger.V(1).Error(err,
 			"While searching for legacy pod group for pod %s/%s, an error has occurred.",
 			pod.Namespace, legacyName)
-		return "", err
+		return "", false, err
 	}
-	return newName, nil
+	return newName, false, nil
 }
 
-func calcMinMember(topOwner *unstructured.Unstructured, pod *v1.Pod) (int32, error) {
+func calcMinMember(topOwner *unstructured.Unstructured, pod *v1.Pod, legacy bool) (int32, error) {
+	if legacy {
+		return 1, nil
+	}
+
 	override, found := topOwner.GetAnnotations()[constants.MinMemberOverrideKey]
 	if !found {
 		return 1, nil

--- a/pkg/podgrouper/podgrouper/plugins/job/job_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/job/job_grouper_test.go
@@ -25,7 +25,7 @@ const (
 	nodePoolLabelKey = "kai.scheduler/node-pool"
 )
 
-func TestGetPodGroupMetadata_Hpo(t *testing.T) {
+func TestGetPodGroupMetadata_MultiPodJobSharesPodGroup(t *testing.T) {
 	owner := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "test_kind",
@@ -79,9 +79,8 @@ func TestGetPodGroupMetadata_Hpo(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Nil(t, err2)
-	assert.Equal(t, "pg-test_name-4kgrb-1234-5678", podGroupMetadata.Name)
-	assert.NotEqual(t, podGroupMetadata.Name, podGroupMetadata2.Name)
-	assert.Equal(t, "pg-test_name-77t4m-1234-5678", podGroupMetadata2.Name)
+	assert.Equal(t, "pg-test_name-1234-5678", podGroupMetadata.Name)
+	assert.Equal(t, podGroupMetadata.Name, podGroupMetadata2.Name)
 
 	assert.Equal(t, "test_kind", podGroupMetadata.Owner.Kind)
 	assert.Equal(t, "test_version", podGroupMetadata.Owner.APIVersion)
@@ -227,7 +226,7 @@ func TestGetPodGroupMetadata_LegacyDisabledPodGroup(t *testing.T) {
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "pg-test_name-4kgrb-1234-5678", podGroupMetadata.Name)
+	assert.Equal(t, "pg-test_name-1234-5678", podGroupMetadata.Name)
 
 	assert.Equal(t, "test_kind", podGroupMetadata.Owner.Kind)
 	assert.Equal(t, "test_version", podGroupMetadata.Owner.APIVersion)
@@ -284,7 +283,7 @@ func TestGetPodGroupMetadata_LegacyNotFound(t *testing.T) {
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "pg-test_name-4kgrb-1234-5678", podGroupMetadata.Name)
+	assert.Equal(t, "pg-test_name-1234-5678", podGroupMetadata.Name)
 
 	assert.Equal(t, "test_kind", podGroupMetadata.Owner.Kind)
 	assert.Equal(t, "test_version", podGroupMetadata.Owner.APIVersion)
@@ -383,6 +382,91 @@ func TestGetPodGroupMetadata_MinMemberOverrideInvalid(t *testing.T) {
 	}
 }
 
+func TestGetPodGroupMetadata_MixedUpgradeOnlyOnePodHasLegacy(t *testing.T) {
+	owner := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "Job",
+			"apiVersion": "batch/v1",
+			"metadata": map[string]interface{}{
+				"name":      "test_job",
+				"namespace": "test_namespace",
+				"uid":       "1234-5678",
+				"labels":    map[string]interface{}{},
+			},
+			"spec": map[string]interface{}{
+				"parallelism": int64(2),
+			},
+		},
+	}
+	podWithLegacy := &v1.Pod{
+		ObjectMeta: v12.ObjectMeta{Name: "test_job-aaaaa", Namespace: "test_namespace"},
+	}
+	podWithoutLegacy := &v1.Pod{
+		ObjectMeta: v12.ObjectMeta{Name: "test_job-bbbbb", Namespace: "test_namespace"},
+	}
+
+	testResources := []runtime.Object{
+		&schedulingv2.PodGroup{
+			TypeMeta:   metav1.TypeMeta{Kind: "PodGroup", APIVersion: "scheduling.run.ai/v2alpha2"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pg-test_job-aaaaa-1234-5678", Namespace: "test_namespace"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, schedulingv2.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
+
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
+	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, true)
+
+	legacyMeta, err := jobGrouper.GetPodGroupMetadata(owner, podWithLegacy)
+	assert.NoError(t, err)
+	assert.Equal(t, "pg-test_job-aaaaa-1234-5678", legacyMeta.Name)
+
+	newMeta, err := jobGrouper.GetPodGroupMetadata(owner, podWithoutLegacy)
+	assert.NoError(t, err)
+	assert.Equal(t, "pg-test_job-1234-5678", newMeta.Name)
+}
+
+func TestGetPodGroupMetadata_LegacySearchDisabledIgnoresLegacyPodGroup(t *testing.T) {
+	owner := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "Job",
+			"apiVersion": "batch/v1",
+			"metadata": map[string]interface{}{
+				"name":      "test_job",
+				"namespace": "test_namespace",
+				"uid":       "1234-5678",
+				"labels":    map[string]interface{}{},
+			},
+			"spec": map[string]interface{}{
+				"parallelism": int64(2),
+			},
+		},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: v12.ObjectMeta{Name: "test_job-aaaaa", Namespace: "test_namespace"},
+	}
+
+	testResources := []runtime.Object{
+		&schedulingv2.PodGroup{
+			TypeMeta:   metav1.TypeMeta{Kind: "PodGroup", APIVersion: "scheduling.run.ai/v2alpha2"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pg-test_job-aaaaa-1234-5678", Namespace: "test_namespace"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, schedulingv2.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(testResources...).Build()
+
+	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, client)
+	jobGrouper := NewK8sJobGrouper(client, defaultGrouper, false)
+
+	meta, err := jobGrouper.GetPodGroupMetadata(owner, pod)
+	assert.NoError(t, err)
+	assert.Equal(t, "pg-test_job-1234-5678", meta.Name)
+}
+
 func TestGetPodGroupMetadata_RegularPodGroup(t *testing.T) {
 	owner := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -426,7 +510,7 @@ func TestGetPodGroupMetadata_RegularPodGroup(t *testing.T) {
 	podGroupMetadata, err := jobGrouper.GetPodGroupMetadata(owner, pod)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "pg-test_name-4kgrb-1234-5678", podGroupMetadata.Name)
+	assert.Equal(t, "pg-test_name-1234-5678", podGroupMetadata.Name)
 
 	assert.Equal(t, "test_kind", podGroupMetadata.Owner.Kind)
 	assert.Equal(t, "test_version", podGroupMetadata.Owner.APIVersion)


### PR DESCRIPTION
## Description

This PR fixes the behavior of the PodGrouper for batch jobs: all pods will now be grouped together. Changelog skipped as no released version included the bug.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
