### PR TITLE
feat(chart): expose kai-operator log level via Helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added validation for `subgroup` name in podgroup [faizanexe](https://github.com/faizan-exe)
 - Added memory profile and run duration to snapshot tool [#1411](https://github.com/NVIDIA/KAI-Scheduler/issues/1411)
 - Added support for configuring pod and container security contexts on resource reservation pods via CLI flags [AdheipSingh](https://github.com/AdheipSingh)
+- Added `operator.logLevel` Helm value to configure the operator log level (maps to `--zap-log-level` when set) [#1446](https://github.com/kai-scheduler/KAI-Scheduler/pull/1446) [dttung2905](https://github.com/dttung2905)
 
 ### Changed
 - **Breaking:** JobSet PodGroups no longer auto-calculate `minAvailable` from `parallelism × replicas`. The default is now 1. Use the `kai.scheduler/batch-min-member` annotation to set a custom value.

--- a/deployments/kai-scheduler/templates/services/operator.yaml
+++ b/deployments/kai-scheduler/templates/services/operator.yaml
@@ -34,8 +34,8 @@ spec:
           - --qps={{ .Values.operator.qps | default 50 }}
           - --burst={{ .Values.operator.burst | default 300 }}
           - --namespace={{ .Release.Namespace }}
-          {{- if .Values.operator.zapLogLevel }}
-          - --zap-log-level={{ .Values.operator.zapLogLevel }}
+          {{- if .Values.operator.logLevel }}
+          - --zap-log-level={{ .Values.operator.logLevel }}
           {{- end }}
         env:
         - name: WATCH_NAMESPACE

--- a/deployments/kai-scheduler/templates/services/operator.yaml
+++ b/deployments/kai-scheduler/templates/services/operator.yaml
@@ -34,6 +34,9 @@ spec:
           - --qps={{ .Values.operator.qps | default 50 }}
           - --burst={{ .Values.operator.burst | default 300 }}
           - --namespace={{ .Release.Namespace }}
+          {{- if .Values.operator.zapLogLevel }}
+          - --zap-log-level={{ .Values.operator.zapLogLevel }}
+          {{- end }}
         env:
         - name: WATCH_NAMESPACE
           value: {{ .Release.Namespace }}

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -45,6 +45,9 @@ operator:
   probeBindAddress: ":8081"
   qps: 50
   burst: 300
+  # Zap log level for the operator (controller-runtime --zap-log-level). Leave empty to use binary defaults.
+  # When set: debug, info, error, panic. Example: "info"
+  zapLogLevel: ""
 
 podgrouper:
   enabled: true

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -45,9 +45,9 @@ operator:
   probeBindAddress: ":8081"
   qps: 50
   burst: 300
-  # Zap log level for the operator (controller-runtime --zap-log-level). Leave empty to use binary defaults.
+  # Log level for the operator (currently mapped to controller-runtime --zap-log-level). Leave empty to use binary defaults.
   # When set: debug, info, error, panic. Example: "info"
-  zapLogLevel: ""
+  logLevel: ""
 
 podgrouper:
   enabled: true


### PR DESCRIPTION

## Description

Add an `operator.zapLogLevel` value (default empty for backward compatibility).
When non-empty, append the operator CLI flag `--zap-log-level=<value>` to the operator Deployment args. The binary already supports this via controller-runtime `zap.Options / BindFlags` (not a custom `-log-level` flag).
Allowed values align with upstream: `debug`, `info`, `error`, `panic`, or a positive integer for custom verbosity; empty means omit the flag and keep current binary defaults.

## Related Issues

Fixes https://github.com/kai-scheduler/KAI-Scheduler/issues/1445

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes
No it is backward compatible

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
