### PR TITLE
fix: propagate priorityClass, preemptibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Improved performance by evaluating SetNode once per session instead of on each predicate evaluation  [#1421](https://github.com/kai-scheduler/KAI-Scheduler/pull/1421) [itsomri](https://github.com/itsomri)
 - Added persistent volumes to cluster snapshot [#1424](https://github.com/kai-scheduler/KAI-Scheduler/pull/1424) [itsomri](https://github.com/itsomri)
 - Improved scheduling performance for preempt/reclaim/consolidate actions on jobs with many tasks by replacing per-task linear probing with exponential+binary search in the job solver, reducing the number of scenario simulations from O(n) to O(log n) [#1435](https://github.com/kai-scheduler/KAI-Scheduler/pull/1435) [itsomri](https://github.com/itsomri)
+- Fixed `skipTopOwnerGrouper` not propagating per-type defaults (priority class and preemptibility) for skipped owners (e.g. `DynamoGraphDeployment`), causing PodGroup spec to retain stale values after defaults ConfigMap updates.
 
 ## [v0.14.0] - 2026-03-30
 

--- a/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
@@ -317,6 +317,25 @@ func (dg *DefaultGrouper) getDefaultPriorityClassNameForKind(groupKind *schema.G
 	return ""
 }
 
+func (dg *DefaultGrouper) ResolveDefaultsForKind(groupKind schema.GroupKind) (string, string, error) {
+	defaults, err := dg.getDefaultConfigsPerTypeMapping()
+	if err != nil {
+		return "", "", err
+	}
+
+	defaultConfig, found := selectDefaultsForKind(defaults, &groupKind)
+	if !found {
+		return "", "", nil
+	}
+
+	priorityClassName := defaultConfig.PriorityName
+	if !dg.validatePriorityClassExists(priorityClassName) {
+		priorityClassName = ""
+	}
+
+	return priorityClassName, defaultConfig.Preemptibility, nil
+}
+
 // getDefaultConfigsPerTypeMapping - returns a map of workload groupKind to default workload-type config (priorityClassName and preemptibility).
 // It fetches the defaults from a ConfigMap if configured, otherwise returns an empty map.
 func (dg *DefaultGrouper) getDefaultConfigsPerTypeMapping() (map[string]workloadTypePriorityConfig, error) {

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgroup"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
 )
@@ -55,10 +56,49 @@ func (sk *skipTopOwnerGrouper) GetPodGroupMetadata(
 		return nil, fmt.Errorf("failed to get last owner: %w", err)
 	}
 
+	sk.applyDefaultsFromSkippedOwner(lastOwnerPartial, lastOwner, skippedOwner)
+
 	// propagate labels down chain
 	sk.propagateMetadataDownChain(lastOwner, skippedOwner)
 
 	return sk.getSupportedTypePGMetadata(lastOwner, pod, otherOwners[:len(otherOwners)-1]...)
+}
+
+func (sk *skipTopOwnerGrouper) applyDefaultsFromSkippedOwner(lastOwnerPartial *metav1.PartialObjectMetadata, lastOwner, skippedOwner *unstructured.Unstructured) {
+	if sk == nil || sk.defaultPlugin == nil || lastOwner == nil || skippedOwner == nil {
+		return
+	}
+
+	skippedGK := skippedOwner.GroupVersionKind().GroupKind()
+	priorityClassName, preemptibility, err := sk.defaultPlugin.ResolveDefaultsForKind(skippedGK)
+	if err != nil {
+		return
+	}
+
+	lastOwnerLabels := lastOwner.GetLabels()
+	if lastOwnerLabels == nil {
+		lastOwnerLabels = map[string]string{}
+	}
+	if _, exists := lastOwnerLabels[constants.PriorityLabelKey]; !exists && priorityClassName != "" {
+		lastOwnerLabels[constants.PriorityLabelKey] = priorityClassName
+	}
+	if _, exists := lastOwnerLabels[constants.PreemptibilityLabelKey]; !exists && preemptibility != "" {
+		lastOwnerLabels[constants.PreemptibilityLabelKey] = preemptibility
+	}
+	lastOwner.SetLabels(lastOwnerLabels)
+
+	if lastOwnerPartial == nil {
+		return
+	}
+	if lastOwnerPartial.Labels == nil {
+		lastOwnerPartial.Labels = map[string]string{}
+	}
+	if _, exists := lastOwnerPartial.Labels[constants.PriorityLabelKey]; !exists && priorityClassName != "" {
+		lastOwnerPartial.Labels[constants.PriorityLabelKey] = priorityClassName
+	}
+	if _, exists := lastOwnerPartial.Labels[constants.PreemptibilityLabelKey]; !exists && preemptibility != "" {
+		lastOwnerPartial.Labels[constants.PreemptibilityLabelKey] = preemptibility
+	}
 }
 
 func (*skipTopOwnerGrouper) propagateMetadataDownChain(lastOwner *unstructured.Unstructured, skippedOwner *unstructured.Unstructured) {

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	grouperplugin "github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 )
 
 func TestSkipTopOwnerGrouper(t *testing.T) {
@@ -362,6 +364,69 @@ var _ = Describe("SkipTopOwnerGrouper", func() {
 				Expect(lastOwnerAfter.Annotations).To(HaveKeyWithValue("skipped-annotation", "skipped-ann-value"))
 				Expect(lastOwnerAfter.Annotations).To(HaveKeyWithValue("conflicting-annotation", "existing-ann-value")) // NOT overridden
 				Expect(lastOwnerAfter.Annotations).To(HaveKeyWithValue("existing-annotation", "existing-ann-value"))
+			})
+		})
+
+		Context("defaults propagation from skipped owner", func() {
+			It("injects skipped owner defaults as labels on last owner (priorityClassName)", func() {
+				const (
+					defaultsCMName      = "defaults"
+					defaultsCMNamespace = "default"
+					priorityClassName   = "very-high"
+				)
+
+				// ConfigMap defines a default priority for the skipped owner kind/group.
+				defaultsCM := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      defaultsCMName,
+						Namespace: defaultsCMNamespace,
+					},
+					Data: map[string]string{
+						constants.DefaultPrioritiesConfigMapTypesKey: `[{"typeName":"DynamoGraphDeployment","group":"nvidia.com","priorityName":"very-high","preemptibility":"non-preemptible"}]`,
+					},
+				}
+				pc := &schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: priorityClassName},
+					Value:      1000,
+				}
+				Expect(client.Create(context.TODO(), defaultsCM)).To(Succeed())
+				Expect(client.Create(context.TODO(), pc)).To(Succeed())
+
+				defaultGrouper.SetDefaultConfigPerTypeConfigMapParams(defaultsCMName, defaultsCMNamespace)
+
+				// lastOwner is a Pod (no labels), skippedOwner is DynamoGraphDeployment
+				pod := examplePod.DeepCopy()
+				Expect(client.Create(context.TODO(), pod)).To(Succeed())
+				pod.TypeMeta = metav1.TypeMeta{Kind: examplePod.Kind, APIVersion: examplePod.APIVersion}
+
+				skippedOwner := &unstructured.Unstructured{}
+				skippedOwner.SetAPIVersion("nvidia.com/v1alpha1")
+				skippedOwner.SetKind("DynamoGraphDeployment")
+				skippedOwner.SetNamespace("default")
+				skippedOwner.SetName("dgd")
+
+				// We need at least 2 owners so skipTopOwner doesn't treat the pod as last owner.
+				otherOwners := []*metav1.PartialObjectMetadata{
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pod.Name,
+							Namespace: pod.Namespace,
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "nvidia.com/v1alpha1", Kind: "DynamoGraphDeployment"},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      skippedOwner.GetName(),
+							Namespace: skippedOwner.GetNamespace(),
+						},
+					},
+				}
+
+				metadata, err := plugin.GetPodGroupMetadata(skippedOwner, pod, otherOwners...)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata).NotTo(BeNil())
+				Expect(metadata.PriorityClassName).To(Equal(priorityClassName))
 			})
 		})
 

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	grouperplugin "github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 )
 
 func TestSkipTopOwnerGrouper(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: SiorMeir <msior@nvidia.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

In the case of missing `ConfigMap` defaults on a resource using the `skiptopowner` grouper, 
We're enacting the same logic for labels and annotations,  and getting said defaults from the next-in-chain resource up the ownership chain 
## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where default priority class and preemptibility settings were not being correctly applied to PodGroup specifications when certain owner types were skipped, which could result in stale values persisting after configuration updates.

* **Tests**
  * Added test coverage for defaults propagation in skipped owner scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->