### PR TITLE
feat(chart): expose scheduler log level and custom args via Helm values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added memory profile and run duration to snapshot tool [#1411](https://github.com/NVIDIA/KAI-Scheduler/issues/1411)
 - Added support for configuring pod and container security contexts on resource reservation pods via CLI flags [AdheipSingh](https://github.com/AdheipSingh)
 - The scheduler now implements elastic PodGroups on both the subgroup level (`minSubGroup`) and pods (`minAvailable`). This allows for elasticity on all of the podgroup tree hierarchy. [#1416](https://github.com/kai-scheduler/KAI-Scheduler/pull/1416) - [davidLif](https://github.com/davidLif)
+- Added support for configuring scheduler log level and custom scheduler args via Helm values (`scheduler.args`) [#1452](https://github.com/kai-scheduler/KAI-Scheduler/pull/1452) [dttung2905](https://github.com/dttung2905)
 
 ### Changed
 - **Breaking:** JobSet PodGroups no longer auto-calculate `minAvailable` from `parallelism × replicas`. The default is now 1. Use the `kai.scheduler/batch-min-member` annotation to set a custom value.

--- a/deployments/kai-scheduler/templates/default-shard.yaml
+++ b/deployments/kai-scheduler/templates/default-shard.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   partitionLabelValue: ""
+  {{- if .Values.scheduler.args }}
+  args:
+    {{- toYaml .Values.scheduler.args | nindent 4 }}
+  {{- end }}
   {{- if .Values.scheduler.placementStrategy }}
   placementStrategy:
     gpu: {{ .Values.scheduler.placementStrategy }}

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -96,6 +96,12 @@ scheduler:
   placementStrategy: binpack
   ports:
     metricsPort: 8080
+  # args allows passing scheduler CLI flags through the default SchedulingShard spec.args map.
+  # Values must be strings because SchedulingShard.spec.args is map[string]string.
+  # Example:
+  # args:
+  #   v: "0"
+  args: {}
   # plugins allows overriding or adding custom scheduler plugins
   # Built-in plugins can be disabled, reordered, or have their arguments changed.
   # New plugins can be added by specifying a name not in the default set.

--- a/docs/operator/scheduling-shards.md
+++ b/docs/operator/scheduling-shards.md
@@ -40,7 +40,7 @@ spec:
   # Custom scheduler arguments
   args:
     leader-elect: "true"
-    log-level: "3"
+    v: "3"
   
   # Placement strategy
   placementStrategy:
@@ -58,6 +58,9 @@ spec:
     preemptMinRuntime: "10m"
     reclaimMinRuntime: "5m"
 ```
+
+The `args` field maps directly to scheduler CLI flags (`--<flag>=<value>`), for example `v`, `qps`, `burst`, and `leader-elect`.
+When installing with Helm, configure these via `scheduler.args` in your values file (for example `scheduler.args.v: "3"`).
 
 For customizing which plugins and actions run in a shard (disabling, reordering, overriding arguments), see [Scheduler Config Customization](./scheduler-config-customization.md).
 


### PR DESCRIPTION


## Description
- Add `scheduler.args` in chart values (map of scheduler CLI flags).
- Wire `scheduler.args` into `SchedulingShard.spec.args` in `default-shard.yaml`
- Allow users to set scheduler log level with: `scheduler.args.v: "0"` (or another desired value).
- Update docs to use `args.v (scheduler flag --v)` instead of `log-level`.

## Related Issues

Fixes https://github.com/kai-scheduler/KAI-Scheduler/issues/1451

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

No, it is backward compatible

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
