### PR TITLE
fix(scheduler): Do not assume dra claims for completed/failure pods

### DIFF
--- a/pkg/scheduler/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/plugins/dynamicresources/dynamicresources.go
@@ -88,6 +88,10 @@ func (drap *draPlugin) assumePendingClaims(ssn *framework.Session) {
 			if pod.BindRequest == nil {
 				continue
 			}
+			if pod.Pod.Status.Phase == v1.PodSucceeded || pod.Pod.Status.Phase == v1.PodFailed {
+				// If the pod has already succeeded or failed, the resources are freed and we can skip assuming pending claims
+				continue
+			}
 			for _, claim := range pod.BindRequest.BindRequest.Spec.ResourceClaimAllocations {
 				err := drap.assumePendingClaim(&claim, pod.Pod)
 				if err != nil {


### PR DESCRIPTION
## Description

For completed/failed pods, do not try to claim resources by the binding request, as resources are freed as the pod finishes it's lifecycle

## Related Issues

Fixes # 
https://github.com/kai-scheduler/KAI-Scheduler/issues/1455

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
