### PR TITLE
fix(chart,operator): imagePullSecrets fixes backport to v0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update go version to v1.25.6, With appropriate upgrades to the base docker images, linter, and controller generator. [#1279](https://github.com/kai-scheduler/KAI-Scheduler/pull/1279) [davidLif](https://github.com/davidLif)
 
 ### Fixed
+- Fixed `additionalImagePullSecrets` in Config CR rendering as `map[name:...]` instead of plain strings by extracting `.name` from `global.imagePullSecrets` objects. Also propagated `global.imagePullSecrets` to the `crd-upgrader` hook job.
 - Fixed Helm template writing `imagesPullSecret` (string) instead of `additionalImagePullSecrets` (array) in Config CR, causing image pull secrets to be silently ignored. Added backward-compatible deprecated `imagesPullSecret` field to CRD schema. [#942](https://github.com/kai-scheduler/KAI-Scheduler/issues/942)
 
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update go version to v1.25.6, With appropriate upgrades to the base docker images, linter, and controller generator. [#1279](https://github.com/kai-scheduler/KAI-Scheduler/pull/1279) [davidLif](https://github.com/davidLif)
 
 ### Fixed
+- Fixed Helm template writing `imagesPullSecret` (string) instead of `additionalImagePullSecrets` (array) in Config CR, causing image pull secrets to be silently ignored. Added backward-compatible deprecated `imagesPullSecret` field to CRD schema. [#942](https://github.com/kai-scheduler/KAI-Scheduler/issues/942)
 
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
 

--- a/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
@@ -1308,6 +1308,11 @@ spec:
                           type: string
                       type: object
                     type: array
+                  imagesPullSecret:
+                    description: |-
+                      Deprecated: ImagePullSecret defines a single container registry secret credential.
+                      Use ImagePullSecrets instead.
+                    type: string
                   namespaceLabelSelector:
                     additionalProperties:
                       type: string

--- a/deployments/kai-scheduler/templates/crd-upgrader.yaml
+++ b/deployments/kai-scheduler/templates/crd-upgrader.yaml
@@ -22,6 +22,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: kai-scheduler-crd-manager
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterversions.config.openshift.io") }}
       securityContext:
         runAsUser: 10000

--- a/deployments/kai-scheduler/templates/kai-config.yaml
+++ b/deployments/kai-scheduler/templates/kai-config.yaml
@@ -37,9 +37,9 @@ spec:
     {{- end }}
     {{- if .Values.global.imagePullSecrets }}
     additionalImagePullSecrets:
-    {{- range .Values.global.imagePullSecrets }}
-      - {{ . | quote }}
-    {{- end }}
+      {{- range .Values.global.imagePullSecrets }}
+      - {{ .name }}
+      {{- end }}
     {{- end }}
     replicaCount: {{ .Values.operator.replicaCount | default 1 }}
 

--- a/deployments/kai-scheduler/templates/kai-config.yaml
+++ b/deployments/kai-scheduler/templates/kai-config.yaml
@@ -36,7 +36,10 @@ spec:
       {{- toYaml .Values.global.securityContext | nindent 6 }}
     {{- end }}
     {{- if .Values.global.imagePullSecrets }}
-    imagesPullSecret: {{ index .Values.global.imagePullSecrets 0 | default "" }}
+    additionalImagePullSecrets:
+    {{- range .Values.global.imagePullSecrets }}
+      - {{ . | quote }}
+    {{- end }}
     {{- end }}
     replicaCount: {{ .Values.operator.replicaCount | default 1 }}
 

--- a/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
+++ b/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: {{ .Values.global.resourceReservation.namespace }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+{{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}

--- a/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
+++ b/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
@@ -18,7 +18,7 @@ tests:
   - it: should render additionalImagePullSecrets as array when configured
     set:
       global.imagePullSecrets:
-        - my-secret
+        - name: my-secret
     asserts:
       - exists:
           path: spec.global.additionalImagePullSecrets
@@ -30,7 +30,7 @@ tests:
   - it: should not render legacy imagesPullSecret field
     set:
       global.imagePullSecrets:
-        - my-secret
+        - name: my-secret
     asserts:
       - notExists:
           path: spec.global.imagesPullSecret
@@ -38,9 +38,9 @@ tests:
   - it: should render multiple additionalImagePullSecrets
     set:
       global.imagePullSecrets:
-        - secret1
-        - secret2
-        - secret3
+        - name: secret1
+        - name: secret2
+        - name: secret3
     asserts:
       - equal:
           path: spec.global.additionalImagePullSecrets

--- a/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
+++ b/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
@@ -1,0 +1,50 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test imagePullSecrets configuration
+templates:
+  - kai-config.yaml
+tests:
+  - it: should not render additionalImagePullSecrets when not configured
+    asserts:
+      - notExists:
+          path: spec.global.additionalImagePullSecrets
+
+  - it: should not render legacy imagesPullSecret when not configured
+    asserts:
+      - notExists:
+          path: spec.global.imagesPullSecret
+
+  - it: should render additionalImagePullSecrets as array when configured
+    set:
+      global.imagePullSecrets:
+        - my-secret
+    asserts:
+      - exists:
+          path: spec.global.additionalImagePullSecrets
+      - equal:
+          path: spec.global.additionalImagePullSecrets
+          value:
+            - my-secret
+
+  - it: should not render legacy imagesPullSecret field
+    set:
+      global.imagePullSecrets:
+        - my-secret
+    asserts:
+      - notExists:
+          path: spec.global.imagesPullSecret
+
+  - it: should render multiple additionalImagePullSecrets
+    set:
+      global.imagePullSecrets:
+        - secret1
+        - secret2
+        - secret3
+    asserts:
+      - equal:
+          path: spec.global.additionalImagePullSecrets
+          value:
+            - secret1
+            - secret2
+            - secret3

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -6,7 +6,7 @@ global:
   tag: latest
   imagePullPolicy: IfNotPresent
   securityContext: {}
-  imagePullSecrets: []
+  imagePullSecrets: [] # format: [{name: secret1}, {name: secret2}]
   leaderElection: false
   gpuSharing: false
   clusterAutoscaling: false

--- a/pkg/apis/kai/v1/global.go
+++ b/pkg/apis/kai/v1/global.go
@@ -25,6 +25,11 @@ type GlobalConfig struct {
 	// +kubebuilder:validation:Optional
 	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
 
+	// Deprecated: ImagePullSecret defines a single container registry secret credential.
+	// Use ImagePullSecrets instead.
+	// +kubebuilder:validation:Optional
+	ImagePullSecret *string `json:"imagesPullSecret,omitempty"`
+
 	// ImagePullSecrets defines the container registry additional secret credentials
 	// +kubebuilder:validation:Optional
 	ImagePullSecrets []string `json:"additionalImagePullSecrets,omitempty"`
@@ -76,6 +81,19 @@ func (g *GlobalConfig) SetDefaultWhereNeeded() {
 
 	if g.ImagePullSecrets == nil {
 		g.ImagePullSecrets = []string{}
+	}
+	if g.ImagePullSecret != nil && *g.ImagePullSecret != "" {
+		found := false
+		for _, s := range g.ImagePullSecrets {
+			if s == *g.ImagePullSecret {
+				found = true
+				break
+			}
+		}
+		if !found {
+			g.ImagePullSecrets = append(g.ImagePullSecrets, *g.ImagePullSecret)
+		}
+		g.ImagePullSecret = nil
 	}
 	if g.DaemonsetsTolerations == nil {
 		g.DaemonsetsTolerations = []v1.Toleration{}

--- a/pkg/apis/kai/v1/global_test.go
+++ b/pkg/apis/kai/v1/global_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGlobalConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GlobalConfig Suite")
+}
+
+var _ = Describe("SetDefaultWhereNeeded", func() {
+	var globalConfig *GlobalConfig
+
+	BeforeEach(func() {
+		globalConfig = &GlobalConfig{}
+	})
+
+	Context("deprecated ImagePullSecret migration", func() {
+		It("should merge deprecated ImagePullSecret into ImagePullSecrets", func() {
+			secret := "legacy-secret"
+			globalConfig.ImagePullSecret = &secret
+			globalConfig.SetDefaultWhereNeeded()
+			Expect(globalConfig.ImagePullSecrets).To(ContainElement("legacy-secret"))
+			Expect(globalConfig.ImagePullSecret).To(BeNil())
+		})
+
+		It("should not duplicate when ImagePullSecret already exists in ImagePullSecrets", func() {
+			secret := "secret1"
+			globalConfig.ImagePullSecret = &secret
+			globalConfig.ImagePullSecrets = []string{"secret1", "secret2"}
+			globalConfig.SetDefaultWhereNeeded()
+			Expect(globalConfig.ImagePullSecrets).To(Equal([]string{"secret1", "secret2"}))
+			Expect(globalConfig.ImagePullSecret).To(BeNil())
+		})
+
+		It("should append unique deprecated secret to existing list", func() {
+			secret := "secret3"
+			globalConfig.ImagePullSecret = &secret
+			globalConfig.ImagePullSecrets = []string{"secret1", "secret2"}
+			globalConfig.SetDefaultWhereNeeded()
+			Expect(globalConfig.ImagePullSecrets).To(Equal([]string{"secret1", "secret2", "secret3"}))
+			Expect(globalConfig.ImagePullSecret).To(BeNil())
+		})
+	})
+})

--- a/pkg/apis/kai/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kai/v1/zz_generated.deepcopy.go
@@ -170,6 +170,11 @@ func (in *GlobalConfig) DeepCopyInto(out *GlobalConfig) {
 		*out = new(corev1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ImagePullSecret != nil {
+		in, out := &in.ImagePullSecret, &out.ImagePullSecret
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
 		*out = make([]string, len(*in))


### PR DESCRIPTION
Backport of #1368 and #1385 to `v0.9`.

## Changes

- **#1368**: Align Helm template `imagePullSecrets` with CRD schema — adds deprecated `imagesPullSecret` field, fixes `additionalImagePullSecrets` rendering
- **#1385**: Fix `additionalImagePullSecrets` rendering as `map[name:...]`, propagate `global.imagePullSecrets` to `crd-upgrader` hook job

## Adaptations for v0.9

- `post-delete-job.yaml` and `topology-migration/job.yaml` hook changes dropped (files not present on this branch)
- E2e tests dropped (`testconfig`/`wait` modules not available on v0.9)