### PR TITLE
fix(chart,operator): imagePullSecrets fixes backport to v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added memory profile and run duration to snapshot tool [#1414](https://github.com/NVIDIA/KAI-Scheduler/issues/1414)
 
 ### Fixed
+- Fixed Helm template writing `imagesPullSecret` (string) instead of `additionalImagePullSecrets` (array) in Config CR, causing image pull secrets to be silently ignored. Added backward-compatible deprecated `imagesPullSecret` field to CRD schema. [#942](https://github.com/kai-scheduler/KAI-Scheduler/issues/942)
 - Race condition where `SyncForGpuGroup` could prematurely delete reservation pods when the informer cache had not yet propagated GPU group labels on recently-bound fraction pods. The binder now checks for active BindRequests referencing the GPU group before deleting a reservation pod.
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)
 - Added `resourceclaims/binding` RBAC permission to the binder ClusterRole for compatibility with Kubernetes v1.36+, where the `DRAResourceClaimGranularStatusAuthorization` feature gate requires explicit permission on the `resourceclaims/binding` subresource to modify `status.allocation` and `status.reservedFor` on ResourceClaims. [#1372](https://github.com/kai-scheduler/KAI-Scheduler/pull/1372) [praveen0raj](https://github.com/praveen0raj)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added memory profile and run duration to snapshot tool [#1414](https://github.com/NVIDIA/KAI-Scheduler/issues/1414)
 
 ### Fixed
+- Fixed `additionalImagePullSecrets` in Config CR rendering as `map[name:...]` instead of plain strings by extracting `.name` from `global.imagePullSecrets` objects. Also propagated `global.imagePullSecrets` to all Helm hook jobs (`crd-upgrader`, `topology-migration`, `post-delete-cleanup`)
+- Added `global.nodeSelector`, `global.tolerations`, `global.affinity`, `global.securityContext` support to the post-delete job hook.
 - Fixed Helm template writing `imagesPullSecret` (string) instead of `additionalImagePullSecrets` (array) in Config CR, causing image pull secrets to be silently ignored. Added backward-compatible deprecated `imagesPullSecret` field to CRD schema. [#942](https://github.com/kai-scheduler/KAI-Scheduler/issues/942)
 - Race condition where `SyncForGpuGroup` could prematurely delete reservation pods when the informer cache had not yet propagated GPU group labels on recently-bound fraction pods. The binder now checks for active BindRequests referencing the GPU group before deleting a reservation pod.
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)

--- a/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
@@ -3498,6 +3498,11 @@ spec:
                           type: string
                       type: object
                     type: array
+                  imagesPullSecret:
+                    description: |-
+                      Deprecated: ImagePullSecret defines a single container registry secret credential.
+                      Use ImagePullSecrets instead.
+                    type: string
                   namespaceLabelSelector:
                     additionalProperties:
                       type: string

--- a/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
@@ -16,11 +16,37 @@ spec:
         app.kubernetes.io/name: post-delete-cleanup
     spec:
       serviceAccountName: {{ .Values.postCleanup.serviceAccountName }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterversions.config.openshift.io") }}
+      securityContext:
+        runAsUser: 10000
+        runAsNonRoot: true
+        fsGroup: 10000
+      {{- end }}
       restartPolicy: Never
+      {{- if .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.global.affinity }}
+      affinity:
+        {{- toYaml .Values.global.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - name: deleter
           image: "{{ .Values.global.registry }}/{{ .Values.postCleanup.image.name }}:{{ .Values.postCleanup.image.tag | default .Values.global.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.postCleanup.image.pullPolicy }}
+          {{- if .Values.global.securityContext }}
+          securityContext:
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
+++ b/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
@@ -22,6 +22,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: kai-scheduler-crd-manager
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterversions.config.openshift.io") }}
       securityContext:
         runAsUser: 10000

--- a/deployments/kai-scheduler/templates/hooks/pre/topology-migration/job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/pre/topology-migration/job.yaml
@@ -23,6 +23,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: kai-topology-migration
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterversions.config.openshift.io") }}
       securityContext:
         runAsUser: 10000

--- a/deployments/kai-scheduler/templates/kai-config.yaml
+++ b/deployments/kai-scheduler/templates/kai-config.yaml
@@ -41,9 +41,9 @@ spec:
     {{- end }}
     {{- if .Values.global.imagePullSecrets }}
     additionalImagePullSecrets:
-    {{- range .Values.global.imagePullSecrets }}
-      - {{ . | quote }}
-    {{- end }}
+      {{- range .Values.global.imagePullSecrets }}
+      - {{ .name }}
+      {{- end }}
     {{- end }}
     replicaCount: {{ .Values.operator.replicaCount | default 1 }}
     {{- if .Values.global.vpa }}

--- a/deployments/kai-scheduler/templates/kai-config.yaml
+++ b/deployments/kai-scheduler/templates/kai-config.yaml
@@ -40,7 +40,10 @@ spec:
       {{- toYaml .Values.global.securityContext | nindent 6 }}
     {{- end }}
     {{- if .Values.global.imagePullSecrets }}
-    imagesPullSecret: {{ index .Values.global.imagePullSecrets 0 | default "" }}
+    additionalImagePullSecrets:
+    {{- range .Values.global.imagePullSecrets }}
+      - {{ . | quote }}
+    {{- end }}
     {{- end }}
     replicaCount: {{ .Values.operator.replicaCount | default 1 }}
     {{- if .Values.global.vpa }}

--- a/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
+++ b/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: {{ .Values.global.resourceReservation.namespace }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+{{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}

--- a/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
+++ b/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
@@ -18,7 +18,7 @@ tests:
   - it: should render additionalImagePullSecrets as array when configured
     set:
       global.imagePullSecrets:
-        - my-secret
+        - name: my-secret
     asserts:
       - exists:
           path: spec.global.additionalImagePullSecrets
@@ -30,7 +30,7 @@ tests:
   - it: should not render legacy imagesPullSecret field
     set:
       global.imagePullSecrets:
-        - my-secret
+        - name: my-secret
     asserts:
       - notExists:
           path: spec.global.imagesPullSecret
@@ -38,9 +38,9 @@ tests:
   - it: should render multiple additionalImagePullSecrets
     set:
       global.imagePullSecrets:
-        - secret1
-        - secret2
-        - secret3
+        - name: secret1
+        - name: secret2
+        - name: secret3
     asserts:
       - equal:
           path: spec.global.additionalImagePullSecrets

--- a/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
+++ b/deployments/kai-scheduler/tests/image_pull_secrets_test.yaml
@@ -1,0 +1,50 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test imagePullSecrets configuration
+templates:
+  - kai-config.yaml
+tests:
+  - it: should not render additionalImagePullSecrets when not configured
+    asserts:
+      - notExists:
+          path: spec.global.additionalImagePullSecrets
+
+  - it: should not render legacy imagesPullSecret when not configured
+    asserts:
+      - notExists:
+          path: spec.global.imagesPullSecret
+
+  - it: should render additionalImagePullSecrets as array when configured
+    set:
+      global.imagePullSecrets:
+        - my-secret
+    asserts:
+      - exists:
+          path: spec.global.additionalImagePullSecrets
+      - equal:
+          path: spec.global.additionalImagePullSecrets
+          value:
+            - my-secret
+
+  - it: should not render legacy imagesPullSecret field
+    set:
+      global.imagePullSecrets:
+        - my-secret
+    asserts:
+      - notExists:
+          path: spec.global.imagesPullSecret
+
+  - it: should render multiple additionalImagePullSecrets
+    set:
+      global.imagePullSecrets:
+        - secret1
+        - secret2
+        - secret3
+    asserts:
+      - equal:
+          path: spec.global.additionalImagePullSecrets
+          value:
+            - secret1
+            - secret2
+            - secret3

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -6,7 +6,7 @@ global:
   tag: ""
   imagePullPolicy: IfNotPresent
   securityContext: {}
-  imagePullSecrets: []
+  imagePullSecrets: [] # format: [{name: secret1}, {name: secret2}]
   leaderElection: false
   gpuSharing: false
   clusterAutoscaling: false

--- a/pkg/apis/kai/v1/global.go
+++ b/pkg/apis/kai/v1/global.go
@@ -35,6 +35,11 @@ type GlobalConfig struct {
 	// +kubebuilder:validation:Optional
 	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
 
+	// Deprecated: ImagePullSecret defines a single container registry secret credential.
+	// Use ImagePullSecrets instead.
+	// +kubebuilder:validation:Optional
+	ImagePullSecret *string `json:"imagesPullSecret,omitempty"`
+
 	// ImagePullSecrets defines the container registry additional secret credentials
 	// +kubebuilder:validation:Optional
 	ImagePullSecrets []string `json:"additionalImagePullSecrets,omitempty"`
@@ -90,6 +95,19 @@ func (g *GlobalConfig) SetDefaultWhereNeeded() {
 
 	if g.ImagePullSecrets == nil {
 		g.ImagePullSecrets = []string{}
+	}
+	if g.ImagePullSecret != nil && *g.ImagePullSecret != "" {
+		found := false
+		for _, s := range g.ImagePullSecrets {
+			if s == *g.ImagePullSecret {
+				found = true
+				break
+			}
+		}
+		if !found {
+			g.ImagePullSecrets = append(g.ImagePullSecrets, *g.ImagePullSecret)
+		}
+		g.ImagePullSecret = nil
 	}
 	if g.DaemonsetsTolerations == nil {
 		g.DaemonsetsTolerations = []v1.Toleration{}

--- a/pkg/apis/kai/v1/global_test.go
+++ b/pkg/apis/kai/v1/global_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGlobalConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GlobalConfig Suite")
+}
+
+var _ = Describe("SetDefaultWhereNeeded", func() {
+	var globalConfig *GlobalConfig
+
+	BeforeEach(func() {
+		globalConfig = &GlobalConfig{}
+	})
+
+	Context("deprecated ImagePullSecret migration", func() {
+		It("should merge deprecated ImagePullSecret into ImagePullSecrets", func() {
+			secret := "legacy-secret"
+			globalConfig.ImagePullSecret = &secret
+			globalConfig.SetDefaultWhereNeeded()
+			Expect(globalConfig.ImagePullSecrets).To(ContainElement("legacy-secret"))
+			Expect(globalConfig.ImagePullSecret).To(BeNil())
+		})
+
+		It("should not duplicate when ImagePullSecret already exists in ImagePullSecrets", func() {
+			secret := "secret1"
+			globalConfig.ImagePullSecret = &secret
+			globalConfig.ImagePullSecrets = []string{"secret1", "secret2"}
+			globalConfig.SetDefaultWhereNeeded()
+			Expect(globalConfig.ImagePullSecrets).To(Equal([]string{"secret1", "secret2"}))
+			Expect(globalConfig.ImagePullSecret).To(BeNil())
+		})
+
+		It("should append unique deprecated secret to existing list", func() {
+			secret := "secret3"
+			globalConfig.ImagePullSecret = &secret
+			globalConfig.ImagePullSecrets = []string{"secret1", "secret2"}
+			globalConfig.SetDefaultWhereNeeded()
+			Expect(globalConfig.ImagePullSecrets).To(Equal([]string{"secret1", "secret2", "secret3"}))
+			Expect(globalConfig.ImagePullSecret).To(BeNil())
+		})
+	})
+})

--- a/pkg/apis/kai/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kai/v1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *GlobalConfig) DeepCopyInto(out *GlobalConfig) {
 		*out = new(corev1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ImagePullSecret != nil {
+		in, out := &in.ImagePullSecret, &out.ImagePullSecret
+		*out = new(string)
+		**out = **in
+	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
 		*out = make([]string, len(*in))

--- a/test/e2e/suites/api/config/config_suite_test.go
+++ b/test/e2e/suites/api/config/config_suite_test.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package config
+
+import (
+	"testing"
+
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	utils.SetLogger()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/test/e2e/suites/api/config/image_pull_secrets_test.go
+++ b/test/e2e/suites/api/config/image_pull_secrets_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package config
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/testconfig"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
+)
+
+var _ = Describe("Image Pull Secrets", Ordered, func() {
+	var (
+		testCtx             *testcontext.TestContext
+		originalPullSecrets []string
+		setupComplete       bool
+		testSecretName      = "test-image-pull-secret"
+	)
+
+	BeforeAll(func(ctx context.Context) {
+		testCtx = testcontext.GetConnectivity(ctx, Default)
+
+		kaiConfig := &kaiv1.Config{}
+		Expect(testCtx.ControllerClient.Get(ctx,
+			runtimeClient.ObjectKey{Name: constants.DefaultKAIConfigSingeltonInstanceName},
+			kaiConfig)).To(Succeed())
+		originalPullSecrets = kaiConfig.Spec.Global.ImagePullSecrets
+		setupComplete = true
+	})
+
+	AfterAll(func(ctx context.Context) {
+		if !setupComplete {
+			return
+		}
+		err := configurations.PatchKAIConfig(ctx, testCtx, func(conf *kaiv1.Config) {
+			conf.Spec.Global.ImagePullSecrets = originalPullSecrets
+		})
+		Expect(err).To(Succeed())
+		wait.ForKAIConfigStatusOK(ctx, testCtx.ControllerClient)
+	})
+
+	It("should propagate additionalImagePullSecrets to deployment pods", func(ctx context.Context) {
+		err := configurations.PatchKAIConfig(ctx, testCtx, func(conf *kaiv1.Config) {
+			conf.Spec.Global.ImagePullSecrets = append(conf.Spec.Global.ImagePullSecrets, testSecretName)
+		})
+		Expect(err).To(Succeed())
+		wait.ForKAIConfigStatusOK(ctx, testCtx.ControllerClient)
+
+		cfg := testconfig.GetConfig()
+		deployments := &appsv1.DeploymentList{}
+		Expect(testCtx.ControllerClient.List(ctx, deployments,
+			runtimeClient.InNamespace(cfg.SystemPodsNamespace),
+		)).To(Succeed())
+		Expect(deployments.Items).NotTo(BeEmpty(), "expected at least one deployment in %s", cfg.SystemPodsNamespace)
+
+		operatorManagedDeployments := filterManagedDeployments(deployments.Items)
+		Expect(operatorManagedDeployments).NotTo(BeEmpty(), "expected at least one operator-managed deployment")
+
+		for _, deployment := range operatorManagedDeployments {
+			Expect(deployment.Spec.Template.Spec.ImagePullSecrets).To(
+				ContainElement(v1.LocalObjectReference{Name: testSecretName}),
+				fmt.Sprintf("deployment %s missing imagePullSecret %s", deployment.Name, testSecretName),
+			)
+		}
+	})
+})
+
+func filterManagedDeployments(deployments []appsv1.Deployment) []appsv1.Deployment {
+	var managed []appsv1.Deployment
+	for _, d := range deployments {
+		if _, hasAppLabel := d.Labels[constants.AppLabelName]; hasAppLabel {
+			if d.Name == "kai-operator" {
+				continue
+			}
+			managed = append(managed, d)
+		}
+	}
+	return managed
+}


### PR DESCRIPTION
Backport of #1368 and #1385 to `v0.14`.

## Changes

- **#1368**: Align Helm template `imagePullSecrets` with CRD schema — adds deprecated `imagesPullSecret` field, fixes `additionalImagePullSecrets` rendering
- **#1385**: Fix `additionalImagePullSecrets` rendering as `map[name:...]`, propagate `global.imagePullSecrets` to all hook jobs, add `global.nodeSelector/tolerations/affinity/securityContext` to post-delete hook