### PR TITLE
fix: propagate priorityClass, preemptibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated resource enumeration logic to exclude resources with count of 0. [#1120](https://github.com/NVIDIA/KAI-Scheduler/issues/1120)
 - Added `resourceclaims/binding` RBAC permission to the binder ClusterRole for compatibility with Kubernetes v1.36+, where the `DRAResourceClaimGranularStatusAuthorization` feature gate requires explicit permission on the `resourceclaims/binding` subresource to modify `status.allocation` and `status.reservedFor` on ResourceClaims. [#1372](https://github.com/kai-scheduler/KAI-Scheduler/pull/1372) [praveen0raj](https://github.com/praveen0raj)
 - Fixed non-preemptible multi-device GPU memory jobs being allowed to exceed their queue's deserved GPU quota. The per-node quota check now correctly accounts for all requested GPU devices. [#1369](https://github.com/kai-scheduler/KAI-Scheduler/issues/1369)
+- Fixed `skipTopOwnerGrouper` not propagating per-type defaults (priority class and preemptibility) for skipped owners (e.g. `DynamoGraphDeployment`), causing PodGroup spec to retain stale values after defaults ConfigMap updates.
 
 ## [v0.12.17] - 2026-03-04
 ### Fixed

--- a/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/defaultgrouper/default_grouper.go
@@ -317,6 +317,25 @@ func (dg *DefaultGrouper) getDefaultPriorityClassNameForKind(groupKind *schema.G
 	return ""
 }
 
+func (dg *DefaultGrouper) ResolveDefaultsForKind(groupKind schema.GroupKind) (string, string, error) {
+	defaults, err := dg.getDefaultConfigsPerTypeMapping()
+	if err != nil {
+		return "", "", err
+	}
+
+	defaultConfig, found := selectDefaultsForKind(defaults, &groupKind)
+	if !found {
+		return "", "", nil
+	}
+
+	priorityClassName := defaultConfig.PriorityName
+	if !dg.validatePriorityClassExists(priorityClassName) {
+		priorityClassName = ""
+	}
+
+	return priorityClassName, defaultConfig.Preemptibility, nil
+}
+
 // getDefaultConfigsPerTypeMapping - returns a map of workload groupKind to default workload-type config (priorityClassName and preemptibility).
 // It fetches the defaults from a ConfigMap if configured, otherwise returns an empty map.
 func (dg *DefaultGrouper) getDefaultConfigsPerTypeMapping() (map[string]workloadTypePriorityConfig, error) {

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgroup"
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
 )
@@ -55,10 +56,49 @@ func (sk *skipTopOwnerGrouper) GetPodGroupMetadata(
 		return nil, fmt.Errorf("failed to get last owner: %w", err)
 	}
 
+	sk.applyDefaultsFromSkippedOwner(lastOwnerPartial, lastOwner, skippedOwner)
+
 	// propagate labels down chain
 	sk.propagateMetadataDownChain(lastOwner, skippedOwner)
 
 	return sk.getSupportedTypePGMetadata(lastOwner, pod, otherOwners[:len(otherOwners)-1]...)
+}
+
+func (sk *skipTopOwnerGrouper) applyDefaultsFromSkippedOwner(lastOwnerPartial *metav1.PartialObjectMetadata, lastOwner, skippedOwner *unstructured.Unstructured) {
+	if sk == nil || sk.defaultPlugin == nil || lastOwner == nil || skippedOwner == nil {
+		return
+	}
+
+	skippedGK := skippedOwner.GroupVersionKind().GroupKind()
+	priorityClassName, preemptibility, err := sk.defaultPlugin.ResolveDefaultsForKind(skippedGK)
+	if err != nil {
+		return
+	}
+
+	lastOwnerLabels := lastOwner.GetLabels()
+	if lastOwnerLabels == nil {
+		lastOwnerLabels = map[string]string{}
+	}
+	if _, exists := lastOwnerLabels[constants.PriorityLabelKey]; !exists && priorityClassName != "" {
+		lastOwnerLabels[constants.PriorityLabelKey] = priorityClassName
+	}
+	if _, exists := lastOwnerLabels[constants.PreemptibilityLabelKey]; !exists && preemptibility != "" {
+		lastOwnerLabels[constants.PreemptibilityLabelKey] = preemptibility
+	}
+	lastOwner.SetLabels(lastOwnerLabels)
+
+	if lastOwnerPartial == nil {
+		return
+	}
+	if lastOwnerPartial.Labels == nil {
+		lastOwnerPartial.Labels = map[string]string{}
+	}
+	if _, exists := lastOwnerPartial.Labels[constants.PriorityLabelKey]; !exists && priorityClassName != "" {
+		lastOwnerPartial.Labels[constants.PriorityLabelKey] = priorityClassName
+	}
+	if _, exists := lastOwnerPartial.Labels[constants.PreemptibilityLabelKey]; !exists && preemptibility != "" {
+		lastOwnerPartial.Labels[constants.PreemptibilityLabelKey] = preemptibility
+	}
 }
 
 func (*skipTopOwnerGrouper) propagateMetadataDownChain(lastOwner *unstructured.Unstructured, skippedOwner *unstructured.Unstructured) {

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	grouperplugin "github.com/NVIDIA/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
 )
@@ -362,6 +364,69 @@ var _ = Describe("SkipTopOwnerGrouper", func() {
 				Expect(lastOwnerAfter.Annotations).To(HaveKeyWithValue("skipped-annotation", "skipped-ann-value"))
 				Expect(lastOwnerAfter.Annotations).To(HaveKeyWithValue("conflicting-annotation", "existing-ann-value")) // NOT overridden
 				Expect(lastOwnerAfter.Annotations).To(HaveKeyWithValue("existing-annotation", "existing-ann-value"))
+			})
+		})
+
+		Context("defaults propagation from skipped owner", func() {
+			It("injects skipped owner defaults as labels on last owner (priorityClassName)", func() {
+				const (
+					defaultsCMName      = "defaults"
+					defaultsCMNamespace = "default"
+					priorityClassName   = "very-high"
+				)
+
+				// ConfigMap defines a default priority for the skipped owner kind/group.
+				defaultsCM := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      defaultsCMName,
+						Namespace: defaultsCMNamespace,
+					},
+					Data: map[string]string{
+						constants.DefaultPrioritiesConfigMapTypesKey: `[{"typeName":"DynamoGraphDeployment","group":"nvidia.com","priorityName":"very-high","preemptibility":"non-preemptible"}]`,
+					},
+				}
+				pc := &schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: priorityClassName},
+					Value:      1000,
+				}
+				Expect(client.Create(context.TODO(), defaultsCM)).To(Succeed())
+				Expect(client.Create(context.TODO(), pc)).To(Succeed())
+
+				defaultGrouper.SetDefaultConfigPerTypeConfigMapParams(defaultsCMName, defaultsCMNamespace)
+
+				// lastOwner is a Pod (no labels), skippedOwner is DynamoGraphDeployment
+				pod := examplePod.DeepCopy()
+				Expect(client.Create(context.TODO(), pod)).To(Succeed())
+				pod.TypeMeta = metav1.TypeMeta{Kind: examplePod.Kind, APIVersion: examplePod.APIVersion}
+
+				skippedOwner := &unstructured.Unstructured{}
+				skippedOwner.SetAPIVersion("nvidia.com/v1alpha1")
+				skippedOwner.SetKind("DynamoGraphDeployment")
+				skippedOwner.SetNamespace("default")
+				skippedOwner.SetName("dgd")
+
+				// We need at least 2 owners so skipTopOwner doesn't treat the pod as last owner.
+				otherOwners := []*metav1.PartialObjectMetadata{
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pod.Name,
+							Namespace: pod.Namespace,
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "nvidia.com/v1alpha1", Kind: "DynamoGraphDeployment"},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      skippedOwner.GetName(),
+							Namespace: skippedOwner.GetNamespace(),
+						},
+					},
+				}
+
+				metadata, err := plugin.GetPodGroupMetadata(skippedOwner, pod, otherOwners...)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata).NotTo(BeNil())
+				Expect(metadata.PriorityClassName).To(Equal(priorityClassName))
 			})
 		})
 


### PR DESCRIPTION
## Summary
Backport of #1450 to v0.12

This PR cherry-picks commit 5079510d12fc23ed441529eb192ea98d56b49d5d which propagates priorityClass and preemptibility from skipped owners.

## Changes
- Adds constants import to skiptopowner plugin
- Propagates priorityClass and preemptibility labels from skipped owners to last owners
- Adds tests for defaults propagation

## Test plan
- [x] Cherry-pick applied cleanly with minimal conflicts
- [ ] CI tests pass
- [ ] E2E tests pass