### PR TITLE
fix(binder): probe DRA availability on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added persistent volumes to cluster snapshot [#1424](https://github.com/kai-scheduler/KAI-Scheduler/pull/1424) [itsomri](https://github.com/itsomri)
 - Improved scheduling performance for preempt/reclaim/consolidate actions on jobs with many tasks by replacing per-task linear probing with exponential+binary search in the job solver, reducing the number of scenario simulations from O(n) to O(log n) [#1435](https://github.com/kai-scheduler/KAI-Scheduler/pull/1435) [itsomri](https://github.com/itsomri)
 - Fixed `skipTopOwnerGrouper` not propagating per-type defaults (priority class and preemptibility) for skipped owners (e.g. `DynamoGraphDeployment`), causing PodGroup spec to retain stale values after defaults ConfigMap updates.
+- Fixed binder DRA detection on clusters where the upstream `DynamicResourceAllocation` feature gate does not reflect server-side DRA availability. The binder now probes the API server during init (matching the scheduler) so the DRA plugin is gated on the same authoritative decision. [#1481](https://github.com/kai-scheduler/KAI-Scheduler/issues/1481)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/cmd/binder/app/app.go
+++ b/cmd/binder/app/app.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	featuregates "github.com/kai-scheduler/KAI-scheduler/pkg/common/feature_gates"
 	draversionawareclient "github.com/kai-scheduler/KAI-scheduler/pkg/common/resources/dra_version_aware_client"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/binder/binding"
@@ -103,6 +104,8 @@ func New(options *Options, config *rest.Config) (*App, error) {
 
 	kubeClient := draversionawareclient.NewDRAAwareClient(kubernetes.NewForConfigOrDie(config))
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+
+	featuregates.SetDRAFeatureGate(kubeClient.Discovery())
 
 	rrs := resourcereservation.NewService(options.FakeGPUNodes, clientWithWatch, options.ResourceReservationPodImage,
 		time.Duration(options.ResourceReservationAllocationTimeout)*time.Second,


### PR DESCRIPTION
## Description

The binder wires k8s plugins via `pkg/binder/plugins/k8s-plugins/k8s_plugins.go:46`, where it reads `featuregates.DynamicResourcesEnabled()` to set `EnableDynamicResourceAllocation` on the `k8splfeature.Features` struct passed to the upstream `volumebinding` and `dynamicresources` plugins.

Nothing in the binder ever called `featuregates.SetDRAFeatureGate`, so the process-wide flag in `pkg/common/feature_gates/feature_gates.go` stayed at its zero value (`false`) regardless of cluster state. The scheduler already probes correctly at `pkg/scheduler/cache/cache.go:154`; this PR mirrors that in the binder's init path.

The probe runs in `App.New` after `kubeClient` is built and before `registerPlugins` calls `k8s_plugins.New`, so the flag is populated before any binder code reads it.

## Related Issues

Fixes #1481

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Behavior matrix:

| Cluster | Before | After |
| --- | --- | --- |
| 1.32–1.34, DRA off | flag = false (zero value, accidentally correct) | flag = false (probed) |
| 1.32–1.34, DRA on | flag = false (incorrect) | flag = true (probed) |
| 1.35+ | flag = false (zero value); upstream gate locked to true | flag reflects actual API server availability |

The binder now does a `ServerVersion` + `ServerGroups` discovery call at init even on clusters that won't use DRA. Discovery failures are logged inside `IsDynamicResourcesEnabled` and silently treated as "DRA off" — the binder still starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)