### PR TITLE
ci: Do not dco check a backporting created by github actions

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -34,5 +34,7 @@ jobs:
           fi
 
           pip3 install -U dco-check
-          dco-check --verbose --exclude-pattern "dependabot\[bot\]@users\.noreply\.github.com"
+          dco-check --verbose \
+            --exclude-pattern "dependabot\[bot\]@users\.noreply\.github\.com" \
+            --exclude-pattern ".*github-actions\[bot\]@users\.noreply\.github\.com"
 


### PR DESCRIPTION
## Description

Do not dco check a backporting created by github actions

## Related Issues

Fixes #1465

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
