### PR TITLE
docs: design external pod group support

### DIFF
--- a/docs/developer/designs/external-podgroups/README.md
+++ b/docs/developer/designs/external-podgroups/README.md
@@ -1,0 +1,185 @@
+# Externally-Created PodGroups
+
+## Overview
+
+KAI currently assumes that the podgrouper owns PodGroup creation for KAI-scheduled pods. The podgrouper derives a PodGroup from each pod's owner chain, creates or updates that PodGroup, and patches the pod with `pod-group-name` and, when relevant, `kai.scheduler/subgroup-name`.
+
+This blocks cross-workload gang scheduling. If multiple independent workloads should be scheduled as one atomic unit, an external controller or user needs to create one PodGroup and attach all participating pods to it without podgrouper rewriting the membership.
+
+## Goals
+
+- Support user-created or controller-created PodGroups.
+- Allow pods from multiple workloads to join the same PodGroup.
+- Prevent podgrouper from creating competing PodGroups for opted-out pods.
+- Prevent podgrouper from overwriting external `pod-group-name` and `kai.scheduler/subgroup-name`.
+- Detect pods that reference missing subgroups and prevent unsafe scheduling.
+- Preserve current auto-created PodGroup behavior unless users explicitly opt out.
+
+## Non-Goals
+
+- No automatic segmentation or `segmentSize` support.
+- No subgroup inference for external PodGroups.
+- No cross-namespace PodGroup membership.
+- No new lifecycle controller for external PodGroups.
+- No event fan-out to all participating workload owners.
+
+## API
+
+Pods still join a PodGroup with the existing annotation:
+
+```yaml
+metadata:
+  annotations:
+    pod-group-name: post-training-pipeline
+```
+
+Pods still join a subgroup with the existing label:
+
+```yaml
+metadata:
+  labels:
+    kai.scheduler/subgroup-name: train-workers-rack-0
+```
+
+A pod or any object in its owner chain may opt out of automatic podgrouper management with:
+
+```yaml
+metadata:
+  annotations:
+    kai.scheduler/skip-podgrouper: "true"
+```
+
+This annotation only tells podgrouper to leave the pod alone. It does not attach the pod to a PodGroup. Users must still set `pod-group-name`, and must set `kai.scheduler/subgroup-name` when using non-default subgroups.
+
+`PodGroup.spec.queue` is authoritative for scheduling. Pod queue labels are not used to select the queue for an external PodGroup.
+
+## Example
+
+```yaml
+apiVersion: scheduling.run.ai/v2alpha2
+kind: PodGroup
+metadata:
+  name: post-training-pipeline
+  namespace: default
+spec:
+  minMember: 5
+  queue: default-queue
+  priorityClassName: normal
+  topologyConstraint:
+    topology: cluster-topology
+    requiredTopologyLevel: topology.kubernetes.io/zone
+  subGroups:
+    - name: ray-head
+      minMember: 1
+    - name: ray-workers
+      minMember: 2
+      topologyConstraint:
+        topology: cluster-topology
+        requiredTopologyLevel: topology.kubernetes.io/rack
+    - name: evaluation
+      minMember: 2
+```
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-training-evaluation
+  annotations:
+    kai.scheduler/skip-podgrouper: "true"
+spec:
+  parallelism: 2
+  completions: 2
+  template:
+    metadata:
+      annotations:
+        pod-group-name: post-training-pipeline
+      labels:
+        kai.scheduler/subgroup-name: evaluation
+    spec:
+      schedulerName: kai-scheduler
+      containers:
+        - name: eval
+          image: ubuntu
+          command: ["sleep", "infinity"]
+      restartPolicy: Never
+```
+
+Other workload types, such as RayJob, use the same pattern: set `kai.scheduler/skip-podgrouper: "true"` on the workload or pod template, then set `pod-group-name` and subgroup labels on the generated pod templates.
+
+## Podgrouper Behavior
+
+Podgrouper should evaluate skip ownership before it applies PodGroup metadata or patches the pod:
+
+```text
+if pod schedulerName != configured scheduler:
+    return
+
+if pod has kai.scheduler/skip-podgrouper: "true":
+    return
+
+if pod is ownerless and already has pod-group-name:
+    return
+
+topOwner, allOwners = GetPodOwners(pod)
+
+if topOwner or any owner in allOwners has kai.scheduler/skip-podgrouper: "true":
+    return
+
+metadata = GetPGMetadata(pod, topOwner, allOwners)
+if metadata == nil:
+    return
+
+ApplyToCluster(metadata)
+assignPodToGroupAndSubGroup(pod, metadata)
+```
+
+Only the exact value `"true"` should skip. Missing or invalid values should preserve existing podgrouper behavior.
+
+## Scheduler Behavior
+
+The scheduler already discovers PodGroup membership from `pod-group-name`. However, the current behavior around invalid subgroup labels is unsafe for external PodGroups: if a pod has `kai.scheduler/subgroup-name` that does not exist in the referenced PodGroup, the pod is not assigned to a scheduler PodSet and can be ignored.
+
+This must become an explicit configuration error:
+
+- During snapshot construction, detect every pod whose `kai.scheduler/subgroup-name` does not match a subgroup in its referenced PodGroup.
+- Mark the PodGroup unschedulable and do not allocate any pod from that PodGroup in the cycle.
+- Add a PodGroup `SchedulingCondition` with reason such as `InvalidPodGroup` or `InvalidSubGroup`, and a message naming the pod and missing subgroup.
+- Record an event on the PodGroup. Optionally mark the offending pod unschedulable when `markUnschedulable` is enabled.
+
+This requirement is part of the MVP because external PodGroups move subgroup assignment responsibility to users and external controllers. Silent ignore makes configuration mistakes hard to diagnose and can break gang semantics.
+
+## Lifecycle And Events
+
+External PodGroups are owned by whoever creates them:
+
+- External controllers should set an owner reference or delete the PodGroup themselves.
+- Manually-created PodGroups without owner references require manual cleanup.
+- Multiple owner references are risky because Kubernetes may delete the PodGroup when any owner is deleted.
+
+Scheduling status and scheduling events remain on the PodGroup and pods. Users should inspect PodGroup events directly when no single workload owner represents the whole group.
+
+## Implementation Plan
+
+1. Add `kai.scheduler/skip-podgrouper` as a constant.
+2. Add pod-level and owner-chain skip checks in podgrouper.
+3. Keep `metadata == nil` handling only as plugin compatibility, not as the public API.
+4. Add scheduler validation for pods that reference missing subgroups.
+5. Set a PodGroup scheduling condition and prevent scheduling when invalid subgroup membership is found.
+6. Add tests for pod-level skip, owner-chain skip, normal podgrouper behavior, and invalid subgroup handling.
+
+## Test Plan
+
+- Pod annotation skips before owner lookup.
+- Top-owner and intermediate-owner annotations skip after owner lookup.
+- Owned pods with only `pod-group-name` continue through normal podgrouper reconciliation.
+- External PodGroup pods are not rewritten by podgrouper.
+- A missing subgroup label creates a PodGroup condition and prevents scheduling.
+- A valid cross-workload PodGroup schedules atomically.
+
+## Risks
+
+- Users can opt out without creating or referencing a valid PodGroup.
+- External controllers must handle PodGroup lifecycle correctly.
+- Owner-chain skip depends on KAI having RBAC to read owner objects.
+- Event visibility is weaker when users watch only the individual workload objects.

--- a/docs/developer/designs/external-podgroups/README.md
+++ b/docs/developer/designs/external-podgroups/README.md
@@ -12,7 +12,7 @@ This blocks cross-workload gang scheduling. If multiple independent workloads sh
 - Allow pods from multiple workloads to join the same PodGroup.
 - Prevent podgrouper from creating competing PodGroups for opted-out pods.
 - Prevent podgrouper from overwriting external `pod-group-name` and `kai.scheduler/subgroup-name`.
-- Detect pods that reference missing subgroups and prevent unsafe scheduling.
+- Detect pods that reference missing subgroups and make the failure visible.
 - Preserve current auto-created PodGroup behavior unless users explicitly opt out.
 
 ## Non-Goals
@@ -115,7 +115,7 @@ Podgrouper should evaluate skip ownership before it applies PodGroup metadata or
 if pod schedulerName != configured scheduler:
     return
 
-if pod has kai.scheduler/skip-podgrouper: "true":
+if pod has kai.scheduler/skip-podgrouper and value is not "false":
     return
 
 if pod is ownerless and already has pod-group-name:
@@ -123,7 +123,7 @@ if pod is ownerless and already has pod-group-name:
 
 topOwner, allOwners = GetPodOwners(pod)
 
-if topOwner or any owner in allOwners has kai.scheduler/skip-podgrouper: "true":
+if topOwner or any owner in allOwners has kai.scheduler/skip-podgrouper and value is not "false":
     return
 
 metadata = GetPGMetadata(pod, topOwner, allOwners)
@@ -134,20 +134,19 @@ ApplyToCluster(metadata)
 assignPodToGroupAndSubGroup(pod, metadata)
 ```
 
-Only the exact value `"true"` should skip. Missing or invalid values should preserve existing podgrouper behavior.
+Any value other than explicit `"false"` should skip. If users do not want to skip podgrouper, they should omit the annotation.
+
+The ownerless pod with `pod-group-name` case should keep the current behavior: podgrouper skips it and does not re-create PodGroup metadata.
 
 ## Scheduler Behavior
 
-The scheduler already discovers PodGroup membership from `pod-group-name`. However, the current behavior around invalid subgroup labels is unsafe for external PodGroups: if a pod has `kai.scheduler/subgroup-name` that does not exist in the referenced PodGroup, the pod is not assigned to a scheduler PodSet and can be ignored.
+The scheduler already discovers PodGroup membership from `pod-group-name`.
 
-This must become an explicit configuration error:
+If a pod references a PodGroup that does not exist yet, the scheduler will not schedule it because scheduling happens at the PodGroup level. This may be a normal creation-order race, so the pod should not make a PodGroup fail and should not get a condition for the missing PodGroup.
 
-- During snapshot construction, detect every pod whose `kai.scheduler/subgroup-name` does not match a subgroup in its referenced PodGroup.
-- Mark the PodGroup unschedulable and do not allocate any pod from that PodGroup in the cycle.
-- Add a PodGroup `SchedulingCondition` with reason such as `InvalidPodGroup` or `InvalidSubGroup`, and a message naming the pod and missing subgroup.
-- Record an event on the PodGroup. Optionally mark the offending pod unschedulable when `markUnschedulable` is enabled.
+If a pod has `kai.scheduler/subgroup-name` that does not exist in its referenced PodGroup, only that pod should be ignored for scheduling. The scheduler should not mark the whole PodGroup unschedulable because elastic PodGroups may still be schedulable when some pods are missing or invalid.
 
-This requirement is part of the MVP because external PodGroups move subgroup assignment responsibility to users and external controllers. Silent ignore makes configuration mistakes hard to diagnose and can break gang semantics.
+The missing-subgroup case should be visible on the offending pod: the scheduler should set a pod condition explaining that the pod references a subgroup that does not exist in the PodGroup.
 
 ## Lifecycle And Events
 
@@ -164,9 +163,9 @@ Scheduling status and scheduling events remain on the PodGroup and pods. Users s
 1. Add `kai.scheduler/skip-podgrouper` as a constant.
 2. Add pod-level and owner-chain skip checks in podgrouper.
 3. Keep `metadata == nil` handling only as plugin compatibility, not as the public API.
-4. Add scheduler validation for pods that reference missing subgroups.
-5. Set a PodGroup scheduling condition and prevent scheduling when invalid subgroup membership is found.
-6. Add tests for pod-level skip, owner-chain skip, normal podgrouper behavior, and invalid subgroup handling.
+4. Keep missing-PodGroup references as ignored pods without setting a pod condition.
+5. Keep missing-subgroup handling pod-scoped: ignore the offending pod and set a pod condition explaining the invalid subgroup label.
+6. Add tests for pod-level skip, owner-chain skip, normal podgrouper behavior, missing PodGroup behavior, and invalid subgroup handling.
 
 ## Test Plan
 
@@ -174,7 +173,8 @@ Scheduling status and scheduling events remain on the PodGroup and pods. Users s
 - Top-owner and intermediate-owner annotations skip after owner lookup.
 - Owned pods with only `pod-group-name` continue through normal podgrouper reconciliation.
 - External PodGroup pods are not rewritten by podgrouper.
-- A missing subgroup label creates a PodGroup condition and prevents scheduling.
+- A missing PodGroup reference does not create a pod or PodGroup condition.
+- A missing subgroup label causes only the offending pod to be ignored and creates a pod condition.
 - A valid cross-workload PodGroup schedules atomically.
 
 ## Risks

--- a/docs/developer/designs/external-podgroups/README.md
+++ b/docs/developer/designs/external-podgroups/README.md
@@ -115,7 +115,7 @@ Podgrouper should evaluate skip ownership before it applies PodGroup metadata or
 if pod schedulerName != configured scheduler:
     return
 
-if pod has kai.scheduler/skip-podgrouper and value is not "false":
+if pod has kai.scheduler/skip-podgrouper: "true":
     return
 
 if pod is ownerless and already has pod-group-name:
@@ -123,7 +123,7 @@ if pod is ownerless and already has pod-group-name:
 
 topOwner, allOwners = GetPodOwners(pod)
 
-if topOwner or any owner in allOwners has kai.scheduler/skip-podgrouper and value is not "false":
+if topOwner or any owner in allOwners has kai.scheduler/skip-podgrouper: "true":
     return
 
 metadata = GetPGMetadata(pod, topOwner, allOwners)
@@ -134,7 +134,7 @@ ApplyToCluster(metadata)
 assignPodToGroupAndSubGroup(pod, metadata)
 ```
 
-Any value other than explicit `"false"` should skip. If users do not want to skip podgrouper, they should omit the annotation.
+Only the exact value `"true"` should skip. Missing, `"false"`, or invalid values should preserve existing podgrouper behavior.
 
 The ownerless pod with `pod-group-name` case should keep the current behavior: podgrouper skips it and does not re-create PodGroup metadata.
 


### PR DESCRIPTION
## Description

Design support for externally provided pod groups.

Today the pod grouper will overwrite pod group annotations on pods to point to a pod group that it creates but there are several use cases for externally created pod groups.

## Related Issues

Referes #1420 

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
