### PR TITLE
chore(release): update CHANGELOG for v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [v0.14.1] - 2026-04-29
+
+### Added
 - Allow users to override minMember for k8s batch Jobs and JobSets using the `kai.scheduler/batch-min-member` annotation [#1381](https://github.com/kai-scheduler/KAI-Scheduler/pull/1381) [itsomri](https://github.com/itsomri)
 - Added memory profile and run duration to snapshot tool [#1414](https://github.com/NVIDIA/KAI-Scheduler/issues/1414)
 


### PR DESCRIPTION
Updates CHANGELOG.md for v0.14.1 release.

## Changes
- Move unreleased changes to v0.14.1 section
- Add release date
- Reset Unreleased section

Please review and merge before pushing the tag.