### PR TITLE
fix(podgrouper): silence transient PodGroup update conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Improved scheduling performance for preempt/reclaim/consolidate actions on jobs with many tasks by replacing per-task linear probing with exponential+binary search in the job solver, reducing the number of scenario simulations from O(n) to O(log n) [#1435](https://github.com/kai-scheduler/KAI-Scheduler/pull/1435) [itsomri](https://github.com/itsomri)
 - Fixed `skipTopOwnerGrouper` not propagating per-type defaults (priority class and preemptibility) for skipped owners (e.g. `DynamoGraphDeployment`), causing PodGroup spec to retain stale values after defaults ConfigMap updates.
 - Fixed binder DRA detection on clusters where the upstream `DynamicResourceAllocation` feature gate does not reflect server-side DRA availability. The binder now probes the API server during init (matching the scheduler) so the DRA plugin is gated on the same authoritative decision. [#1481](https://github.com/kai-scheduler/KAI-Scheduler/issues/1481)
+- Suppressed noisy `Reconciler error` logs and `PodGrouperWarning` events on transient PodGroup update conflicts. The podgrouper now treats `IsConflict` errors as expected and silently requeues the reconcile instead of surfacing the apiserver's "object has been modified" message.
 
 ## [v0.14.0] - 2026-03-30
 

--- a/pkg/podgrouper/pod_controller.go
+++ b/pkg/podgrouper/pod_controller.go
@@ -122,6 +122,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	err = r.PodGroupHandler.ApplyToCluster(ctx, *metadata)
 	if err != nil {
+		if errors.IsConflict(err) {
+			logger.V(1).Info("PodGroup update conflict, will retry", "namespace", metadata.Namespace, "name", metadata.Name)
+			err = nil
+			return ctrl.Result{Requeue: true}, nil
+		}
 		logger.V(1).Error(err, "Failed to apply metadata for pod group", metadata.Namespace, metadata.Name)
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
## Description

Optimistic-concurrency conflicts on `PodGroup` updates are expected during normal operation — multiple pods belonging to the same PodGroup can be reconciled in parallel (`MaxConcurrentReconciles > 1`), and other controllers (`pod-group-assigner`, scheduler, queue-controller) also write to the same object. The reconcile already self-heals via requeue, but the apiserver's `"object has been modified"` response was being surfaced as:

- a controller-runtime `Reconciler error` log line, and
- a `PodGrouperWarning` event on the pod (via the `defer` in `Reconcile`).

This PR detects `errors.IsConflict` from `ApplyToCluster` and returns `ctrl.Result{Requeue: true}, nil` instead of propagating the error. The conflict is logged at `V(1)` and `err` is cleared so the deferred Warning event no longer fires. Other errors are unchanged.

## Related Issues

Fixes # — internal: RUN-33994

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) — n/a, log/event suppression only
- [ ] Updated documentation (if needed) — n/a

## Breaking Changes

None.

## Additional Notes

Sample of the noise this removes:
```
ERROR  Failed to apply metadata for pod group  ... "the object has been modified; please apply your changes to the latest version and try again"
ERROR  Reconciler error                        ... same message
DEBUG  events  ... reason: PodGrouperWarning
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)