### PR TITLE
feat: Allow minSubGroup=0 for subgroups

### DIFF
--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook.go
@@ -200,10 +200,7 @@ func validateSubGroupMinFields(subGroup *SubGroup, childrenMap map[string][]stri
 				"subgroup %q: minMember cannot be set on a mid-level SubGroup (has child SubGroups); use minSubGroup instead", subGroup.Name)})
 		}
 		if subGroup.MinSubGroup != nil {
-			if *subGroup.MinSubGroup <= 0 {
-				minFieldsErrors = append(minFieldsErrors, &invalidMinSubGroupError{msg: fmt.Sprintf(
-					"subgroup %q: minSubGroup must be greater than 0", subGroup.Name)})
-			} else if int(*subGroup.MinSubGroup) > len(children) {
+			if int(*subGroup.MinSubGroup) > len(children) {
 				minFieldsErrors = append(minFieldsErrors, &minSubGroupExceedsChildCountError{msg: fmt.Sprintf(
 					"subgroup %q: minSubGroup (%d) exceeds the number of direct child SubGroups (%d)",
 					subGroup.Name, *subGroup.MinSubGroup, len(children))})

--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
@@ -172,15 +172,6 @@ func TestValidateSubGroups(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "Invalid: minSubGroup = 0 on SubGroup with children",
-			subGroups: []SubGroup{
-				{Name: "parent", MinSubGroup: ptr.To(int32(0))},
-				{Name: "child-1", Parent: ptr.To("parent"), MinMember: ptr.To(int32(4))},
-				{Name: "child-2", Parent: ptr.To("parent"), MinMember: ptr.To(int32(4))},
-			},
-			wantErr: &validationErrors{minDefinitionErrors: []error{&invalidMinSubGroupError{msg: `subgroup "parent": minSubGroup must be greater than 0`}}},
-		},
-		{
 			name: "Invalid: minSubGroup = 0 on leaf SubGroup",
 			subGroups: []SubGroup{
 				{Name: "A", MinSubGroup: ptr.To(int32(0))},
@@ -323,17 +314,6 @@ func TestValidatePodGroupSpec(t *testing.T) {
 				MinSubGroup: ptr.To(int32(1)),
 			},
 			want: &validationErrors{minDefinitionErrors: []error{&minSubGroupExceedsChildCountError{msg: "minSubGroup (1) exceeds the number of direct child SubGroups (0)"}}},
-		},
-		{
-			name: "Invalid: minSubGroup = 0 on PodGroup",
-			spec: PodGroupSpec{
-				MinSubGroup: ptr.To(int32(0)),
-				SubGroups: []SubGroup{
-					{Name: "a", MinMember: ptr.To(int32(4))},
-					{Name: "b", MinMember: ptr.To(int32(4))},
-				},
-			},
-			want: &validationErrors{minDefinitionErrors: []error{&invalidMinSubGroupError{msg: "minSubGroup at the podgroup level must be equal to or greater than 1"}}},
 		},
 	}
 

--- a/pkg/scheduler/api/podgroup_info/allocation_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info_test.go
@@ -220,6 +220,79 @@ func Test_GetTasksToAllocate(t *testing.T) {
 	}
 }
 
+func Test_GetTasksToAllocate_MinSubGroupZero(t *testing.T) {
+	tests := []struct {
+		name          string
+		subGroupTasks map[string][]*pod_info.PodInfo
+		minAvailMap   map[string]int32
+		wantNumTasks  int
+	}{
+		{
+			name: "root minSubGroup=0, all children unsatisfied: gang skipped, elastic returns one child's tasks",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"sgA": {
+					simpleTask("taskA1", "sgA", pod_status.Pending),
+				},
+				"sgB": {
+					simpleTask("taskB1", "sgB", pod_status.Pending),
+				},
+			},
+			minAvailMap:  map[string]int32{"sgA": 1, "sgB": 1},
+			wantNumTasks: 1,
+		},
+		{
+			name: "root minSubGroup=0, all children satisfied: elastic returns no tasks",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"sgA": {
+					simpleTask("taskA1", "sgA", pod_status.Running),
+				},
+				"sgB": {
+					simpleTask("taskB1", "sgB", pod_status.Running),
+				},
+			},
+			minAvailMap:  map[string]int32{"sgA": 1, "sgB": 1},
+			wantNumTasks: 0,
+		},
+		{
+			name: "root minSubGroup=0, one satisfied + one with elastic surplus: returns one elastic task",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"sgA": {
+					simpleTask("taskA1", "sgA", pod_status.Running),
+				},
+				"sgB": {
+					simpleTask("taskB1", "sgB", pod_status.Running),
+					simpleTask("taskB2", "sgB", pod_status.Pending),
+				},
+			},
+			minAvailMap:  map[string]int32{"sgA": 1, "sgB": 1},
+			wantNumTasks: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg := NewPodGroupInfo("pg")
+			root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+			min := int32(0)
+			root.SetMinSubGroup(&min)
+			pg.RootSubGroupSet = root
+			pg.PodSets = make(map[string]*subgroup_info.PodSet)
+			for subGroupName, pods := range tt.subGroupTasks {
+				ps := subgroup_info.NewPodSet(subGroupName, tt.minAvailMap[subGroupName], nil)
+				root.AddPodSet(ps)
+				pg.PodSets[subGroupName] = ps
+				for _, pod := range pods {
+					pg.AddTaskInfo(pod)
+				}
+			}
+			gotTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, true)
+			if len(gotTasks) != tt.wantNumTasks {
+				t.Errorf("GetTasksToAllocate len = %d, want %d", len(gotTasks), tt.wantNumTasks)
+			}
+		})
+	}
+}
+
 func Test_GetTasksToAllocateRequestedGPUs(t *testing.T) {
 	pg := NewPodGroupInfo("test-podgroup")
 	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(1)

--- a/pkg/scheduler/api/podgroup_info/eviction_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/eviction_info_test.go
@@ -324,6 +324,78 @@ func TestGetTasksToEvict_HierarchicalTree(t *testing.T) {
 			expectedHasMoreTasks: true,
 			numExpectTasks:       2,
 		},
+		{
+			name: "MinSubGroupZero_RootEntireSubtreeElasticDroppable",
+			job: func() *PodGroupInfo {
+				// Root with minSubGroup=0 and one PodSet child at exactly min.
+				// Phase 2 fires because 0 < numSatisfied(1) → drop the whole child.
+				psA := subgroup_info.NewPodSet("ps-a", 1, nil)
+				psA.AssignTask(simpleTask("pod-1", "ps-a", pod_status.Running))
+
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+				root.SetMinSubGroup(ptr.To(int32(0)))
+				root.AddPodSet(psA)
+
+				return &PodGroupInfo{
+					RootSubGroupSet: root,
+					PodSets:         root.GetDescendantPodSets(),
+				}
+			}(),
+			expectedHasMoreTasks: false,
+			numExpectTasks:       1,
+		},
+		{
+			name: "MinSubGroupZero_NestedInnerSubtreeElasticDroppable",
+			job: func() *PodGroupInfo {
+				// Inner SubGroupSet with minSubGroup=0 containing a PodSet at min.
+				// Root requires inner (no minSubGroup). Inner is treated as fully elastic:
+				// phase 1 finds elastic surplus inside inner → recurses → inner phase 2 drops ps-a.
+				psA := subgroup_info.NewPodSet("ps-a", 1, nil)
+				psA.AssignTask(simpleTask("pod-1", "ps-a", pod_status.Running))
+
+				inner := subgroup_info.NewSubGroupSet("inner", nil)
+				inner.SetMinSubGroup(ptr.To(int32(0)))
+				inner.AddPodSet(psA)
+
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+				root.AddSubGroup(inner)
+
+				return &PodGroupInfo{
+					RootSubGroupSet: root,
+					PodSets:         root.GetDescendantPodSets(),
+				}
+			}(),
+			expectedHasMoreTasks: false,
+			numExpectTasks:       1,
+		},
+		{
+			name: "MinSubGroupZero_NestedInnerLeavesSiblingAlone",
+			job: func() *PodGroupInfo {
+				// Root requires both children; inner has minSubGroup=0 (fully elastic),
+				// sibling required ps-keep is at min. Eviction must come from inner only.
+				psElastic := subgroup_info.NewPodSet("ps-elastic", 1, nil)
+				psElastic.AssignTask(simpleTask("pod-1", "ps-elastic", pod_status.Running))
+
+				inner := subgroup_info.NewSubGroupSet("inner", nil)
+				inner.SetMinSubGroup(ptr.To(int32(0)))
+				inner.AddPodSet(psElastic)
+
+				psKeep := subgroup_info.NewPodSet("ps-keep", 1, nil)
+				psKeep.AssignTask(simpleTask("pod-2", "ps-keep", pod_status.Running))
+
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+				root.AddSubGroup(inner)
+				root.AddPodSet(psKeep)
+
+				return &PodGroupInfo{
+					RootSubGroupSet: root,
+					PodSets:         root.GetDescendantPodSets(),
+				}
+			}(),
+			expectedHasMoreTasks: true, // pod-2 in ps-keep stays
+			numExpectTasks:       1,
+			expectedTaskNames:    []string{"pod-1"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
@@ -207,6 +207,51 @@ func TestGetMinChildrenToSatisfy(t *testing.T) {
 			t.Errorf("GetMinChildrenToSatisfy() = %d, want 1", got)
 		}
 	})
+	t.Run("minSubGroup_zero_returns_zero", func(t *testing.T) {
+		root := NewSubGroupSet("root", nil)
+		root.AddSubGroup(NewSubGroupSet("a", nil))
+		root.AddSubGroup(NewSubGroupSet("b", nil))
+		min := int32(0)
+		root.SetMinSubGroup(&min)
+		if got := root.GetMinMembersToSatisfy(); got != 0 {
+			t.Errorf("GetMinChildrenToSatisfy() = %d, want 0 (fully elastic subtree)", got)
+		}
+	})
+}
+
+func TestSubGroupSet_MinSubGroupZero_AlwaysSatisfied(t *testing.T) {
+	t.Run("no_allocated_children_still_satisfied", func(t *testing.T) {
+		root := NewSubGroupSet("root", nil)
+		root.AddPodSet(podSetWithRunningPods("ps", 3, 0))
+		min := int32(0)
+		root.SetMinSubGroup(&min)
+		if !root.IsMinRequirementSatisfied() {
+			t.Errorf("IsMinRequirementSatisfied() = false, want true (minSubGroup=0)")
+		}
+	})
+	t.Run("no_ready_members_still_ready_for_scheduling", func(t *testing.T) {
+		root := NewSubGroupSet("root", nil)
+		root.AddPodSet(podSetWithRunningPods("ps", 3, 0))
+		min := int32(0)
+		root.SetMinSubGroup(&min)
+		if !root.IsReadyForScheduling() {
+			t.Errorf("IsReadyForScheduling() = false, want true (minSubGroup=0)")
+		}
+	})
+	t.Run("nested_minSubGroup_zero_satisfied", func(t *testing.T) {
+		root := NewSubGroupSet("root", nil)
+		inner := NewSubGroupSet("inner", nil)
+		inner.AddPodSet(podSetWithRunningPods("ps", 2, 0))
+		min := int32(0)
+		inner.SetMinSubGroup(&min)
+		root.AddSubGroup(inner)
+		if !inner.IsMinRequirementSatisfied() {
+			t.Errorf("inner.IsMinRequirementSatisfied() = false, want true")
+		}
+		if got := root.GetNumActiveAllocatedDirectSubGroups(); got != 1 {
+			t.Errorf("root.GetNumActiveAllocatedDirectSubGroups() = %d, want 1 (inner is satisfied via minSubGroup=0)", got)
+		}
+	})
 }
 
 func TestGetNumActiveAllocatedDirectSubGroups(t *testing.T) {

--- a/pkg/scheduler/plugins/subgrouporder/subgroup_order_test.go
+++ b/pkg/scheduler/plugins/subgrouporder/subgroup_order_test.go
@@ -116,6 +116,41 @@ func TestSubGroupOrderFn(t *testing.T) {
 			want: rPrioritized,
 		},
 		{
+			name: "left non-leaf optional (minSubGroup=0 with children), right required and satisfied",
+			// Non-leaf with minSubGroup=0: threshold=0 → deprioritized vs. a satisfied required sibling.
+			left: makeSubGroupSetWithPodSetMembers("l", ptr.To(int32(0)), []podSetSpec{
+				{minAvail: 2, numAlloc: 0},
+				{minAvail: 2, numAlloc: 0},
+			}),
+			right: makeSubGroupSetWithPodSetMembers("r", ptr.To(int32(2)), []podSetSpec{
+				{minAvail: 3, numAlloc: 5},
+				{minAvail: 3, numAlloc: 4},
+			}),
+			want: rPrioritized,
+		},
+		{
+			name: "both non-leaf optional (minSubGroup=0), neither has allocated members",
+			// Both threshold=0, both 0 allocated members → equal.
+			left: makeSubGroupSetWithPodSetMembers("l", ptr.To(int32(0)), []podSetSpec{
+				{minAvail: 2, numAlloc: 0},
+			}),
+			right: makeSubGroupSetWithPodSetMembers("r", ptr.To(int32(0)), []podSetSpec{
+				{minAvail: 3, numAlloc: 0},
+			}),
+			want: equalPrioritization,
+		},
+		{
+			name: "both non-leaf optional (minSubGroup=0), left has fewer allocated members",
+			// Both threshold=0; tie-break: prioritize the one with fewer allocated members.
+			left: makeSubGroupSetWithPodSetMembers("l", ptr.To(int32(0)), []podSetSpec{
+				{minAvail: 1, numAlloc: 0}, // not satisfied → 0 allocated members
+			}),
+			right: makeSubGroupSetWithPodSetMembers("r", ptr.To(int32(0)), []podSetSpec{
+				{minAvail: 1, numAlloc: 1}, // satisfied → 1 allocated member
+			}),
+			want: lPrioritized,
+		},
+		{
 			name: "nested SubGroupSets: left's member not satisfied, right's member satisfied",
 			left: func() *subgroup_info.SubGroupSet {
 				// outer left: minSubGroup=1, one member SubGroupSet not satisfied

--- a/test/e2e/suites/allocate/min_subgroups/min_subgroups_test.go
+++ b/test/e2e/suites/allocate/min_subgroups/min_subgroups_test.go
@@ -271,6 +271,93 @@ var _ = Describe("MinSubGroup backward compatibility", Ordered, func() {
 	})
 })
 
+var _ = Describe("Mid-level SubGroup with minSubGroup=0 (fully elastic subtree)", Ordered, func() {
+	var testCtx *testcontext.TestContext
+
+	BeforeAll(func(ctx context.Context) {
+		testCtx = testcontext.GetConnectivity(ctx, Default)
+
+		parentQueue := queue.CreateQueueObject(utils.GenerateRandomK8sName(10), "")
+		childQueue := queue.CreateQueueObject(utils.GenerateRandomK8sName(10), parentQueue.Name)
+		childQueue.Spec.Resources.CPU.Quota = 400
+		childQueue.Spec.Resources.CPU.Limit = 400
+		testCtx.InitQueues([]*v2.Queue{childQueue, parentQueue})
+
+		capacity.SkipIfInsufficientClusterTopologyResources(testCtx.KubeClientset, []capacity.ResourceList{
+			{
+				Cpu:      resource.MustParse("400m"),
+				PodCount: 5,
+			},
+		})
+	})
+
+	AfterAll(func(ctx context.Context) {
+		err := rd.DeleteAllE2EPriorityClasses(ctx, testCtx.ControllerClient)
+		Expect(err).To(Succeed())
+		testCtx.ClusterCleanup(ctx)
+	})
+
+	AfterEach(func(ctx context.Context) {
+		testCtx.TestContextCleanup(ctx)
+	})
+
+	// Hierarchy:
+	//   PodGroup (minSubGroup=2)
+	//   ├── group-required (minSubGroup=2): gang-required subtree
+	//   │   ├── leaf-r1 (minMember=1, 1 pod)
+	//   │   └── leaf-r2 (minMember=1, 1 pod)
+	//   └── group-optional (minSubGroup=0): fully elastic subtree
+	//       ├── leaf-o1 (minMember=1, 1 pod)
+	//       └── leaf-o2 (minMember=1, 1 pod)
+
+	It("should schedule both subtrees when resources are ample", func(ctx context.Context) {
+		_, h := pod_group.CreateWithHierarchy(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
+			utils.GenerateRandomK8sName(10), testCtx.Queues[0], ptr.To[int32](2),
+			optionalSubtreeHierarchy(), nil, "", cpuPerPod)
+
+		namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
+		wait.ForPodsScheduled(ctx, testCtx.ControllerClient, namespace, h.AllPods)
+	})
+
+	It("should schedule group-required and skip group-optional (minSubGroup=0) when resources are constrained", func(ctx context.Context) {
+		fillerPod := createFillerPod(ctx, testCtx.KubeClientset, testCtx.Queues[0], "200m")
+		wait.ForPodScheduled(ctx, testCtx.ControllerClient, fillerPod)
+
+		_, h := pod_group.CreateWithHierarchy(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
+			utils.GenerateRandomK8sName(10), testCtx.Queues[0], ptr.To[int32](2),
+			optionalSubtreeHierarchy(), nil, "", cpuPerPod)
+
+		namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
+		wait.ForAtLeastNPodsScheduled(ctx, testCtx.ControllerClient, namespace, h.Pods["leaf-r1"], 1)
+		wait.ForAtLeastNPodsScheduled(ctx, testCtx.ControllerClient, namespace, h.Pods["leaf-r2"], 1)
+		wait.ForAtLeastNPodsUnschedulable(ctx, testCtx.ControllerClient, namespace, h.Pods["leaf-o1"], 1)
+		wait.ForAtLeastNPodsUnschedulable(ctx, testCtx.ControllerClient, namespace, h.Pods["leaf-o2"], 1)
+	})
+})
+
+// optionalSubtreeHierarchy returns a 2-level hierarchy where one mid-level group has minSubGroup=0
+// (fully elastic: no children required) and the other has minSubGroup=2 (both leaves required).
+func optionalSubtreeHierarchy() []pod_group.SubGroupNode {
+	return []pod_group.SubGroupNode{
+		{
+			Name:        "group-required",
+			MinSubGroup: ptr.To[int32](2),
+			Children: []pod_group.SubGroupNode{
+				{Name: "leaf-r1", MinMember: ptr.To[int32](1), PodCount: 1},
+				{Name: "leaf-r2", MinMember: ptr.To[int32](1), PodCount: 1},
+			},
+		},
+		{
+			Name:        "group-optional",
+			MinSubGroup: ptr.To[int32](0),
+			Children: []pod_group.SubGroupNode{
+				{Name: "leaf-o1", MinMember: ptr.To[int32](1), PodCount: 1},
+				{Name: "leaf-o2", MinMember: ptr.To[int32](1), PodCount: 1},
+			},
+		},
+	}
+}
+
 // flatLeaves generates N leaf SubGroupNodes named "{prefix}-0", "{prefix}-1", etc.
 func flatLeaves(prefix string, count, podsPerLeaf int) []pod_group.SubGroupNode {
 	nodes := make([]pod_group.SubGroupNode, 0, count)


### PR DESCRIPTION
## Description

1- Drop admission block for non podgroup level minSubGroup
2- Add unitests with minSubGroup=0 to validate the logic still holds

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
