### PR TITLE
ci: Cherry pick "fix-backporting-changelog" action to v0.14

### DIFF
--- a/.github/scripts/update_changelog_from_diff.py
+++ b/.github/scripts/update_changelog_from_diff.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge CHANGELOG additions from a git unified diff into [Unreleased] for backport PRs.
+
+Backports cherry-pick changelog entries under release headers (e.g. ## [v0.9.0]) that do
+not exist on the target branch, causing merge conflicts. This script extracts only the
+added entries from a diff and re-inserts them under [Unreleased] on the target branch,
+preserving their ### subsection (Added/Fixed/Changed/etc.).
+"""
+
+import argparse
+import re
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("diff_path", help="path to unified diff (e.g. CHANGELOG.md from git show)")
+    args = parser.parse_args()
+
+    with open(args.diff_path) as f:
+        diff_lines = f.read().splitlines()
+
+    # Walk the diff and collect every '+' line, tagged with the ### subsection it belongs to.
+    # Section is tracked from both context (' ') and addition ('+') lines so an entry added
+    # under a pre-existing subsection still gets the right tag.
+    additions = []  # list of (section_header, entry_line)
+    current_section = None
+    for line in diff_lines:
+        # Skip diff metadata lines (file headers and hunk markers).
+        if line.startswith(("+++", "---", "@@")):
+            continue
+        raw = line[1:] if line else ""
+        if line.startswith((" ", "+")):
+            if raw.startswith("### "):
+                current_section = raw
+        # Collect actual added entries; skip blank additions and the section header itself
+        # (the header is re-emitted later only if missing in [Unreleased]).
+        if line.startswith("+") and not line.startswith("+++"):
+            if not raw.startswith("##") and raw.strip():
+                additions.append((current_section, raw))
+
+    if not additions:
+        sys.exit(0)
+
+    with open("CHANGELOG.md") as f:
+        content = f.read()
+
+    # Locate the [Unreleased] header; create one above the first version header if absent.
+    unreleased = re.search(r"## \[Unreleased\]\n", content)
+    if not unreleased:
+        m = re.search(r"\n## \[v", content)
+        insert_at = m.start() if m else len(content)
+        content = content[:insert_at] + "\n\n## [Unreleased]\n" + content[insert_at:]
+        unreleased = re.search(r"## \[Unreleased\]\n", content)
+
+    # Bound the [Unreleased] block by the next ## header (or EOF) so edits stay scoped to it.
+    unreleased_end = re.search(r"\n## \[", content[unreleased.end() :])
+    section_end = (unreleased.end() + unreleased_end.start()) if unreleased_end else len(content)
+    unreleased_block = content[unreleased.end() : section_end]
+
+    # Group by section, preserving order of first appearance
+    groups: dict[str, list[str]] = {}
+    order: list[str] = []
+    for section, entry in additions:
+        key = section or "__top__"
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(entry)
+
+    for key in order:
+        entries = groups[key]
+        entry_text = "\n".join(entries)
+        if key == "__top__":
+            # Entries that appeared before any ### header go to the top of [Unreleased].
+            unreleased_block = "\n" + entry_text + "\n" + unreleased_block
+        else:
+            # If the subsection already exists in [Unreleased], append entries right after
+            # its header; otherwise create the subsection at the end of the block.
+            m = re.search(re.escape(key) + r"\n", unreleased_block)
+            if m:
+                pos = m.end()
+                unreleased_block = unreleased_block[:pos] + entry_text + "\n" + unreleased_block[pos:]
+            else:
+                unreleased_block += "\n" + key + "\n" + entry_text + "\n"
+
+    # Splice the modified [Unreleased] block back into the original file content.
+    content = content[: unreleased.end()] + unreleased_block + content[section_end:]
+    with open("CHANGELOG.md", "w") as f:
+        f.write(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/fix-backport-changelog.yaml
+++ b/.github/workflows/fix-backport-changelog.yaml
@@ -1,0 +1,105 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+name: Fix Backport Changelog
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - 'v*.*'
+
+jobs:
+  fix-changelog:
+    name: Fix CHANGELOG.md on backport PR
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'backport-')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.KAIBOT_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Identify original PR
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Branch must match the action's exact pattern: backport-{N}-to-{base_ref}
+          if [[ "$HEAD_REF" =~ ^backport-([0-9]+)-to-(.+)$ ]]; then
+            PR_NUMBER="${BASH_REMATCH[1]}"
+            TARGET_BASE_REF="${BASH_REMATCH[2]}"
+          else
+            echo "Branch name does not match backport pattern; skipping."
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "$TARGET_BASE_REF" != "$BASE_REF" ]]; then
+            echo "Branch base ref mismatch; skipping."
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Original PR must exist, be merged, and carry a "backport $BASE_REF" label
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json state,labels,baseRefName 2>/dev/null || echo "")
+          if [ -z "$PR_JSON" ]; then
+            echo "Original PR #$PR_NUMBER not found; skipping."
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+          HAS_BACKPORT_LABEL=$(echo "$PR_JSON" | jq -r --arg t "backport $BASE_REF" \
+            '[.labels[].name] | contains([$t])')
+          if [ "$STATE" != "MERGED" ] || [ "$HAS_BACKPORT_LABEL" != "true" ]; then
+            echo "PR #$PR_NUMBER is not a merged backport source (state=$STATE, label=$HAS_BACKPORT_LABEL); skipping."
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "valid=true" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "labels=$(echo "$PR_JSON" | jq -c '[.labels[].name]')" >> $GITHUB_OUTPUT
+
+      - name: Propagate skip-changelog label
+        if: steps.pr-info.outputs.valid == 'true' && contains(fromJSON(steps.pr-info.outputs.labels), 'skip-changelog')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "skip-changelog"
+
+      - name: Extract CHANGELOG additions with section context
+        if: steps.pr-info.outputs.valid == 'true' && !contains(fromJSON(steps.pr-info.outputs.labels), 'skip-changelog')
+        id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use merge commit with wide context so ### section headers appear as context lines
+          MERGE_SHA=$(gh pr view ${{ steps.pr-info.outputs.pr_number }} \
+            --json mergeCommit --jq '.mergeCommit.oid' 2>/dev/null || echo "")
+          if [ -z "$MERGE_SHA" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          git show -U999 "$MERGE_SHA" -- CHANGELOG.md > "$RUNNER_TEMP/changelog_diff.txt" 2>/dev/null || true
+          grep -q '^+[^+]' "$RUNNER_TEMP/changelog_diff.txt" \
+            && echo "has_changes=true" >> $GITHUB_OUTPUT \
+            || echo "has_changes=false" >> $GITHUB_OUTPUT
+
+      - name: Reset CHANGELOG.md and insert entries under correct subsection
+        if: steps.changelog.outputs.has_changes == 'true'
+        run: |
+          git checkout origin/${{ github.base_ref }} -- CHANGELOG.md
+          python3 .github/scripts/update_changelog_from_diff.py "$RUNNER_TEMP/changelog_diff.txt"
+
+      - name: Commit and push
+        if: steps.changelog.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "chore: update CHANGELOG.md for backport"
+          git push origin ${{ github.head_ref }}


### PR DESCRIPTION
## Description

Cherry pick "fix-backporting-changelog" action to v0.14

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
