### PR TITLE
fix(scheduler): Fix jumping solver potential victims usage

### DIFF
--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -40,23 +40,26 @@ type solutionResult struct {
 }
 
 type byPodSolver struct {
-	feasibleNodes            map[string]*node_info.NodeInfo
-	solutionValidator        SolutionValidator
-	allowVictimConsolidation bool
-	actionType               framework.ActionType
+	feasibleNodes             map[string]*node_info.NodeInfo
+	amountOfNewPreemptorTasks int
+	solutionValidator         SolutionValidator
+	allowVictimConsolidation  bool
+	actionType                framework.ActionType
 }
 
 func newByPodSolver(
 	feasibleNodes map[string]*node_info.NodeInfo,
+	amountOfNewPreemptorTasks int,
 	checkVictims SolutionValidator,
 	allowVictimConsolidation bool,
 	action framework.ActionType,
 ) *byPodSolver {
 	return &byPodSolver{
-		feasibleNodes:            feasibleNodes,
-		solutionValidator:        checkVictims,
-		allowVictimConsolidation: allowVictimConsolidation,
-		actionType:               action,
+		feasibleNodes:             feasibleNodes,
+		amountOfNewPreemptorTasks: amountOfNewPreemptorTasks,
+		solutionValidator:         checkVictims,
+		allowVictimConsolidation:  allowVictimConsolidation,
+		actionType:                action,
 	}
 }
 
@@ -64,36 +67,38 @@ func (s *byPodSolver) solve(
 	session *framework.Session, scenario *scenario.ByNodeScenario,
 ) *solutionResult {
 	statement := session.Statement()
-
 	pendingJob := scenario.GetPreemptor()
-	nextTaskToFindAllocation := scenario.PendingTasks()[len(scenario.PendingTasks())-1]
-	latestPotentialVictim := scenario.LatestPotentialVictim()
+	nextTask := scenario.PendingTasks()[len(scenario.PendingTasks())-1]
 
-	err := common.EvictAllPreemptees(session, scenario.RecordedVictimsTasks(), pendingJob, statement, s.actionType)
-	if err != nil {
-		return handleSolveError(pendingJob, nextTaskToFindAllocation, err, statement)
+	if err := common.EvictAllPreemptees(session, scenario.RecordedVictimsTasks(), pendingJob, statement, s.actionType); err != nil {
+		return handleSolveError(pendingJob, nextTask, err, statement)
 	}
 
-	if latestPotentialVictim == nil {
+	var result *solutionResult
+	var err error
+
+	latestPotentialVictims := scenario.LatestPotentialVictims()
+	if latestPotentialVictims == nil {
 		if hasRecordedVictimsForSimulation(scenario) {
-			log.InfraLogger.V(6).Infof("Trying to solve scenario with priviously calculated victims only")
-			result := s.runSimulation(session, scenario, statement, scenario.RecordedVictimsTasks())
-			if result != nil {
-				return result
-			}
+			log.InfraLogger.V(6).Infof("Trying to solve scenario with previously calculated victims only")
+			result = s.runSimulation(session, scenario, statement, scenario.RecordedVictimsTasks())
 		}
 	} else {
-		potentialVictimNodes := getNodesOfJob(latestPotentialVictim)
-		result, err := s.solveOnPotentialNodes(session, scenario, statement, potentialVictimNodes)
-		if err != nil {
-			return handleSolveError(pendingJob, nextTaskToFindAllocation, err, statement)
+		potentialVictimNodes := getNodesOfJobs(latestPotentialVictims)
+		if s.amountOfNewPreemptorTasks <= 1 {
+			result, err = s.solveFromSingleNodePreemption(session, scenario, statement, potentialVictimNodes)
+		} else {
+			result, err = s.solveOnPotentialNodes(session, scenario, statement, potentialVictimNodes)
 		}
-		if result != nil {
-			return result
+		if err != nil {
+			return handleSolveError(pendingJob, nextTask, err, statement)
 		}
 	}
 
-	statement.Discard() // No solution for scenario
+	if result != nil {
+		return result
+	}
+	statement.Discard()
 	return &solutionResult{false, nil, nil, nil}
 }
 
@@ -115,29 +120,37 @@ func (s *byPodSolver) runSimulation(
 	return nil
 }
 
+// solveFromSingleNodePreemption tries to solve the scenario by preempting the least amount of potential victims possible, while looking for the best cleanup of a single node.
+// We can assume that cleaning a single node is enough only if we know that the preemptor job has only one more task then the previous scenario we solved.
+// We try to remove potential victims from each node separately, and see if the simulation will succeed.
+func (s *byPodSolver) solveFromSingleNodePreemption(ssn *framework.Session, scenario *scenario.ByNodeScenario,
+	statement *framework.Statement, potentialVictimNodeNames []string) (*solutionResult, error) {
+	for _, node := range potentialVictimNodeNames {
+		log.InfraLogger.V(6).Infof("Trying to solve scenario with potential victims from node: %s", node)
+		if result, err := s.solveOnPotentialNodes(ssn, scenario, statement, []string{node}); err != nil || result != nil {
+			return result, err
+		}
+	}
+	return nil, nil
+}
+
+// solveOnPotentialNodes tries to solve the scenario by preempting all the potential victims from the given nodes, and running a simulation
 func (s *byPodSolver) solveOnPotentialNodes(ssn *framework.Session, scenario *scenario.ByNodeScenario,
 	statement *framework.Statement, potentialVictimNodeNames []string) (*solutionResult, error) {
-	for _, nodeToTest := range potentialVictimNodeNames {
-		log.InfraLogger.V(6).Infof(
-			"Trying to solve scenario with potantial victims from node: %s", nodeToTest)
+	checkpoint, potentialVictimsTasks, err := s.evictPotentialVictimsFromNodes(ssn, scenario, statement, potentialVictimNodeNames...)
+	if err != nil {
+		return nil, err
+	}
+	newFeasibleNodes := s.updateFeasibleNodes(ssn, potentialVictimsTasks)
 
-		nodeVictimsEvictionCheckpoint, potentialVictimsTasks, err :=
-			s.evictPotentialVictimsFromNode(ssn, scenario, statement, nodeToTest)
-		if err != nil {
-			return nil, err
-		}
-		newFeasibleNodes := s.updateFeasibleNodes(ssn, potentialVictimsTasks)
+	victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), potentialVictimsTasks)
+	if result := s.runSimulation(ssn, scenario, statement, victimTasks); result != nil {
+		return result, nil
+	}
 
-		victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), potentialVictimsTasks)
-		result := s.runSimulation(ssn, scenario, statement, victimTasks)
-		if result != nil {
-			return result, nil
-		}
-
-		s.feasibleNodesRollback(newFeasibleNodes)
-		if err = statement.Rollback(*nodeVictimsEvictionCheckpoint); err != nil {
-			return nil, err
-		}
+	s.feasibleNodesRollback(newFeasibleNodes)
+	if err = statement.Rollback(*checkpoint); err != nil {
+		return nil, err
 	}
 	return nil, nil
 }
@@ -160,13 +173,13 @@ func (s *byPodSolver) updateFeasibleNodes(ssn *framework.Session, victimTasks []
 	return newFeasibleNodes
 }
 
-func (s *byPodSolver) evictPotentialVictimsFromNode(
-	session *framework.Session, scenario *scenario.ByNodeScenario, statement *framework.Statement, nodeToTest string,
+func (s *byPodSolver) evictPotentialVictimsFromNodes(
+	session *framework.Session, scenario *scenario.ByNodeScenario, statement *framework.Statement, nodeToTest ...string,
 ) (*framework.Checkpoint, []*pod_info.PodInfo, error) {
 	recordedVictimsCheckpoint := statement.Checkpoint()
 	pendingJob := scenario.GetPreemptor()
 
-	potentialVictimsTasks := scenario.VictimsTasksFromNodes([]string{nodeToTest})
+	potentialVictimsTasks := scenario.VictimsTasksFromNodes(nodeToTest)
 	if err := common.EvictAllPreemptees(session, potentialVictimsTasks, pendingJob, statement, s.actionType); err != nil {
 		return nil, nil, err
 	}
@@ -201,15 +214,18 @@ func (s *byPodSolver) handleScenarioSolution(
 	return &solutionResult{true, victimsTasks, actualVictimJobs, statement}
 }
 
-func getNodesOfJob(pj *podgroup_info.PodGroupInfo) []string {
+func getNodesOfJobs(pj []*podgroup_info.PodGroupInfo) []string {
 	if pj == nil {
 		return []string{}
 	}
 
 	pjNodeNames := map[string]string{}
-	for _, latestPotentialVictimTask := range pj.GetAllPodsMap() {
-		pjNodeNames[latestPotentialVictimTask.NodeName] = latestPotentialVictimTask.NodeName
+	for _, job := range pj {
+		for _, latestPotentialVictimTask := range job.GetAllPodsMap() {
+			pjNodeNames[latestPotentialVictimTask.NodeName] = latestPotentialVictimTask.NodeName
+		}
 	}
+
 	return maps.Keys(pjNodeNames)
 }
 

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -73,7 +73,7 @@ func (s *JobSolver) Solve(
 		return false, nil, calcVictimNames(state.recordedVictimsTasks)
 	}
 
-	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n)
+	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n, 0)
 	if result == nil || !result.solved {
 		return false, nil, calcVictimNames(state.recordedVictimsTasks)
 	}
@@ -110,7 +110,7 @@ func (s *JobSolver) searchMaxSolvableK(
 	var hi int
 	k := 1
 	for {
-		if !s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, k) {
+		if !s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, k, lo) {
 			hi = k
 			break
 		}
@@ -126,7 +126,7 @@ func (s *JobSolver) searchMaxSolvableK(
 
 	for hi-lo > 1 {
 		mid := (lo + hi) / 2
-		if s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, mid) {
+		if s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, mid, lo) {
 			lo = mid
 		} else {
 			hi = mid
@@ -143,8 +143,9 @@ func (s *JobSolver) tryProbeAndDiscard(
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
+	previousK int,
 ) bool {
-	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k)
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k, previousK)
 	if result == nil || !result.solved {
 		log.InfraLogger.V(5).Infof("No solution found for %d tasks out of %d tasks to allocate for %s",
 			k, len(tasksToAllocate), pendingJob.Name)
@@ -167,13 +168,15 @@ func (s *JobSolver) probeAtK(
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
+	previousK int,
 ) *solutionResult {
 	pendingTasks := tasksToAllocate[:k]
 	partialPendingJob := getPartialJobRepresentative(pendingJob, pendingTasks)
-	return s.solvePartialJob(ssn, state, partialPendingJob)
+	return s.solvePartialJob(ssn, state, partialPendingJob, k-previousK)
 }
 
-func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo) *solutionResult {
+func (s *JobSolver) solvePartialJob(
+	ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo, amountOfNewPreemptorTasks int) *solutionResult {
 	feasibleNodeMap := map[string]*node_info.NodeInfo{}
 	for _, node := range s.feasibleNodes {
 		feasibleNodeMap[node.Name] = node
@@ -188,8 +191,8 @@ func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState,
 
 	for scenarioToSolve := scenarioBuilder.GetValidScenario(); scenarioToSolve != nil; scenarioToSolve =
 		scenarioBuilder.GetNextScenario() {
-		scenarioSolver := newByPodSolver(feasibleNodeMap, s.solutionValidator, ssn.AllowConsolidatingReclaim(),
-			s.actionType)
+		scenarioSolver := newByPodSolver(feasibleNodeMap, amountOfNewPreemptorTasks, s.solutionValidator,
+			ssn.AllowConsolidatingReclaim(), s.actionType)
 
 		log.InfraLogger.V(5).Infof("Trying to solve scenario: %s", scenarioToSolve)
 		metrics.IncScenarioSimulatedByAction()

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -28,6 +28,8 @@ type PodAccumulatedScenarioBuilder struct {
 	victimsJobsQueue *utils.JobsOrderByQueues
 
 	recordedVictimsTasks map[common_info.PodID]*pod_info.PodInfo
+
+	amountOfNewPotentialTasksInCurrentScenario int
 }
 
 func NewPodAccumulatedScenarioBuilder(
@@ -73,6 +75,7 @@ func NewPodAccumulatedScenarioBuilder(
 		recordedVictimsTasks: recordedVictimsTasks,
 		lastScenario:         scenario,
 		scenarioFilters:      scenarioFilters,
+		amountOfNewPotentialTasksInCurrentScenario: 0,
 	}
 }
 
@@ -130,6 +133,7 @@ func (asb *PodAccumulatedScenarioBuilder) addNextPotentialVictims() bool {
 
 	if asb.lastScenario != nil {
 		asb.lastScenario.AddPotentialVictimsTasks(potentialVictimTasks)
+		asb.amountOfNewPotentialTasksInCurrentScenario += len(potentialVictimTasks)
 	}
 	return true
 }
@@ -141,6 +145,8 @@ func (asb *PodAccumulatedScenarioBuilder) GetValidScenario() *solverscenario.ByN
 
 		return asb.GetNextScenario()
 	}
+	asb.lastScenario.SetAmountOfNewPotentialTasks(asb.amountOfNewPotentialTasksInCurrentScenario)
+	asb.amountOfNewPotentialTasksInCurrentScenario = 0
 	return asb.lastScenario
 }
 

--- a/pkg/scheduler/actions/common/solvers/scenario/base_scenario.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/base_scenario.go
@@ -18,12 +18,13 @@ var _ api.ScenarioInfo = &BaseScenario{}
 type BaseScenario struct {
 	session *framework.Session
 
-	preemptor             *podgroup_info.PodGroupInfo
-	victims               map[common_info.PodGroupID]*api.VictimInfo
-	pendingTasks          []*pod_info.PodInfo
-	potentialVictimsTasks []*pod_info.PodInfo
-	recordedVictimsJobs   []*podgroup_info.PodGroupInfo
-	recordedVictimsTasks  []*pod_info.PodInfo
+	preemptor                 *podgroup_info.PodGroupInfo
+	victims                   map[common_info.PodGroupID]*api.VictimInfo
+	pendingTasks              []*pod_info.PodInfo
+	potentialVictimsTasks     []*pod_info.PodInfo
+	amountOfNewPotentialTasks int
+	recordedVictimsJobs       []*podgroup_info.PodGroupInfo
+	recordedVictimsTasks      []*pod_info.PodInfo
 
 	// Deprecated: Use preemptor instead
 	victimsJobsTaskGroups map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo
@@ -34,14 +35,15 @@ func NewBaseScenario(
 	recordedVictimsJobs []*podgroup_info.PodGroupInfo,
 ) *BaseScenario {
 	s := &BaseScenario{
-		session:               session,
-		preemptor:             originalJob,
-		victims:               make(map[common_info.PodGroupID]*api.VictimInfo),
-		pendingTasks:          make([]*pod_info.PodInfo, 0),
-		potentialVictimsTasks: make([]*pod_info.PodInfo, 0),
-		recordedVictimsJobs:   make([]*podgroup_info.PodGroupInfo, len(recordedVictimsJobs)),
-		recordedVictimsTasks:  nil,
-		victimsJobsTaskGroups: make(map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo),
+		session:                   session,
+		preemptor:                 originalJob,
+		victims:                   make(map[common_info.PodGroupID]*api.VictimInfo),
+		pendingTasks:              make([]*pod_info.PodInfo, 0),
+		potentialVictimsTasks:     make([]*pod_info.PodInfo, 0),
+		amountOfNewPotentialTasks: 0,
+		recordedVictimsJobs:       make([]*podgroup_info.PodGroupInfo, len(recordedVictimsJobs)),
+		recordedVictimsTasks:      nil,
+		victimsJobsTaskGroups:     make(map[common_info.PodGroupID][]*podgroup_info.PodGroupInfo),
 	}
 
 	for _, task := range pendingTasks {
@@ -50,6 +52,7 @@ func NewBaseScenario(
 	for _, task := range victimsTasks {
 		s.AddPotentialVictimsTasks([]*pod_info.PodInfo{task})
 	}
+	s.SetAmountOfNewPotentialTasks(len(victimsTasks))
 	for index, recordedVictimJob := range recordedVictimsJobs {
 		s.recordedVictimsJobs[index] = recordedVictimJob
 		var tasks []*pod_info.PodInfo
@@ -86,9 +89,13 @@ func (s *BaseScenario) RecordedVictimsJobs() []*podgroup_info.PodGroupInfo {
 	return s.recordedVictimsJobs
 }
 
-func (s *BaseScenario) LatestPotentialVictim() *podgroup_info.PodGroupInfo {
+func (s *BaseScenario) LatestPotentialVictims() []*podgroup_info.PodGroupInfo {
 	if len(s.potentialVictimsTasks) > 0 {
-		return s.getJobForTask(s.potentialVictimsTasks[len(s.potentialVictimsTasks)-1])
+		latestPotentialVictims := []*podgroup_info.PodGroupInfo{}
+		for i := len(s.potentialVictimsTasks) - s.amountOfNewPotentialTasks; i < len(s.potentialVictimsTasks); i++ {
+			latestPotentialVictims = append(latestPotentialVictims, s.getJobForTask(s.potentialVictimsTasks[i]))
+		}
+		return latestPotentialVictims
 	} else {
 		return nil
 	}
@@ -105,6 +112,15 @@ func (s *BaseScenario) AddPotentialVictimsTasks(tasks []*pod_info.PodInfo) {
 
 	s.potentialVictimsTasks = append(s.potentialVictimsTasks, tasks...)
 	s.appendTasksAsVictimJob(tasks)
+}
+
+// SetAmountOfNewPotentialTasks sets the amount of new potential tasks that have been added to the scenario in comparison to the previous scenario tested.
+func (s *BaseScenario) SetAmountOfNewPotentialTasks(amount int) {
+	s.amountOfNewPotentialTasks = amount
+}
+
+func (s *BaseScenario) GetAmountOfNewPotentialTasks() int {
+	return s.amountOfNewPotentialTasks
 }
 
 func (s *BaseScenario) appendTasksAsVictimJob(tasks []*pod_info.PodInfo) {

--- a/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/base_scenario_test.go
@@ -533,7 +533,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   *podgroup_info.PodGroupInfo
+		want   []*podgroup_info.PodGroupInfo
 	}{
 		{
 			name: "tasks only in ctor",
@@ -577,7 +577,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 				},
 			},
 			args: args{},
-			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
+			want: []*podgroup_info.PodGroupInfo{podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name1",
 					Namespace: "n1",
@@ -586,7 +586,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			}, nil, resource_info.NewResourceVectorMap())),
+			}, nil, resource_info.NewResourceVectorMap()))},
 		},
 		{
 			name: "return latest task from AddPotentialVictimsTasks",
@@ -652,7 +652,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 					}, nil, resource_info.NewResourceVectorMap()),
 				},
 			},
-			want: podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
+			want: []*podgroup_info.PodGroupInfo{podgroup_info.NewPodGroupInfo("pg1", pod_info.NewTaskInfo(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name1",
 					Namespace: "n1",
@@ -670,7 +670,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{},
-			}, nil, resource_info.NewResourceVectorMap())),
+			}, nil, resource_info.NewResourceVectorMap()))},
 		},
 	}
 	for _, tt := range tests {
@@ -685,7 +685,7 @@ func TestPodSimpleScenario_LatestPotentialVictim(t *testing.T) {
 			if tt.args.tasks != nil {
 				s.AddPotentialVictimsTasks(tt.args.tasks)
 			}
-			if got := s.LatestPotentialVictim(); !reflect.DeepEqual(got, tt.want) {
+			if got := s.LatestPotentialVictims(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LatestPotentialVictim() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario.go
@@ -37,6 +37,7 @@ func NewByNodeScenario(
 	for _, task := range potentialVictimsTasks {
 		bns.addPotentialVictimTask(task)
 	}
+	bns.SetAmountOfNewPotentialTasks(len(potentialVictimsTasks))
 
 	return bns
 }

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -74,8 +74,8 @@ func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 		Queue0DeservedGPUs:      0,
 		Queue1DeservedGPUs:      numNodes * 8,
 		NumberOfCacheBinds:      numNodes * 4,
-		NumberOfCacheEvictions:  numNodes * 4,
-		NumberOfPipelineActions: numNodes * 4,
+		NumberOfCacheEvictions:  numNodes * 8,
+		NumberOfPipelineActions: numNodes * 8,
 	}
 
 	topology := buildReclaimTopology(params)

--- a/pkg/scheduler/actions/preempt/preemptGang_test.go
+++ b/pkg/scheduler/actions/preempt/preemptGang_test.go
@@ -312,7 +312,7 @@ func getTestsScatteredNodesForGangMetadata() []integration_tests_utils.TestTopol
 				CacheRequirements: &test_utils.CacheMocking{
 					NumberOfCacheBinds:      2,
 					NumberOfCacheEvictions:  200,
-					NumberOfPipelineActions: 2,
+					NumberOfPipelineActions: 4,
 				},
 			},
 		},

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -4036,5 +4036,131 @@ func getTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
 				},
 			},
 		},
+		{
+			// Regression: a pending reclaimer needs one victim from each of several
+			// single-GPU nodes. The exponential job solver probes prefixes of pending
+			// tasks (k=1, 2, 4, ...) and skips intermediates, which previously caused
+			// the final probe for the full job to miss the multi-node victim set.
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Reclaim across many single-GPU nodes",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "q0_n0_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node0", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n1_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node1", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n2_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node2", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n3_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node3", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n4_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node4", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "reclaimer",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {GPUs: 1},
+					"node1": {GPUs: 1},
+					"node2": {GPUs: 1},
+					"node3": {GPUs: 1},
+					"node4": {GPUs: 1},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						DeservedGPUs:       0,
+						GPUOverQuotaWeight: 1,
+					},
+					{
+						Name:               "queue1",
+						DeservedGPUs:       5,
+						GPUOverQuotaWeight: 1,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"q0_n0_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n1_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n2_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n3_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n4_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"reclaimer": {
+						GPUsRequired:         5,
+						Status:               pod_status.Pipelined,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheEvictions:  5,
+						NumberOfPipelineActions: 5,
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -22,6 +22,7 @@ package framework
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -233,35 +234,52 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 }
 
 func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_info.PodInfo) []*node_info.NodeInfo {
-	var (
-		nodeScores = make(map[float64][]*node_info.NodeInfo)
-		mutex      sync.Mutex
-		wg         sync.WaitGroup
-	)
-
 	ssn.NodePreOrderFn(task, nodes)
 
-	for _, node := range nodes {
-		wg.Add(1)
-		go func(node *node_info.NodeInfo) {
-			defer wg.Done()
-			score, err := ssn.NodeOrderFn(task, node)
-			if err != nil {
-				log.InfraLogger.Errorf("Error in Calculating Priority for the node:%v", err)
-				return
-			}
+	numWorkers := min(runtime.GOMAXPROCS(0), len(nodes))
 
-			mutex.Lock()
-			nodeScores[score] = append(nodeScores[score], node)
-			mutex.Unlock()
-
-			log.InfraLogger.V(5).Infof("Overall priority node score of node <%v> for task <%v/%v> is: %f",
-				node.Name, task.Namespace, task.Name, score)
-		}(node)
+	localScores := make([]map[float64][]*node_info.NodeInfo, numWorkers)
+	for i := range localScores {
+		localScores[i] = make(map[float64][]*node_info.NodeInfo)
 	}
 
+	var wg sync.WaitGroup
+	chunkSize := (len(nodes) + numWorkers - 1) / numWorkers
+	for workerIdx := range numWorkers {
+		wg.Add(1)
+		go func(workerIdx int) {
+			defer wg.Done()
+			ssn.scoreNodesPerChuck(nodes, task, workerIdx, chunkSize, localScores)
+		}(workerIdx)
+	}
 	wg.Wait()
+
+	nodeScores := localScores[0]
+	for _, m := range localScores[1:] {
+		for score, ns := range m {
+			nodeScores[score] = append(nodeScores[score], ns...)
+		}
+	}
 	return sortNodesByScore(nodeScores)
+}
+
+func (ssn *Session) scoreNodesPerChuck(nodes []*node_info.NodeInfo, task *pod_info.PodInfo,
+	workerIdx int, chunkSize int, localScores []map[float64][]*node_info.NodeInfo) {
+	start := workerIdx * chunkSize
+	end := min(start+chunkSize, len(nodes))
+	if start >= end {
+		return
+	}
+	for _, node := range nodes[start:end] {
+		score, err := ssn.NodeOrderFn(task, node)
+		if err != nil {
+			log.InfraLogger.Errorf("Error in Calculating Priority for the node:%v", err)
+			continue
+		}
+		localScores[workerIdx][score] = append(localScores[workerIdx][score], node)
+		log.InfraLogger.V(5).Infof("Overall priority node score of node <%v> for task <%v/%v> is: %f",
+			node.Name, task.Namespace, task.Name, score)
+	}
 }
 
 func (ssn *Session) isTaskAllocatableOnNode(task *pod_info.PodInfo, job *podgroup_info.PodGroupInfo,

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -236,7 +236,7 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_info.PodInfo) []*node_info.NodeInfo {
 	ssn.NodePreOrderFn(task, nodes)
 
-	numWorkers := min(runtime.GOMAXPROCS(0), len(nodes))
+	numWorkers := max(min(runtime.GOMAXPROCS(0), len(nodes)), 1)
 
 	localScores := make([]map[float64][]*node_info.NodeInfo, numWorkers)
 	for i := range localScores {


### PR DESCRIPTION
## Description

1- Add unitest that requires a jumping solver to evict from multiple nodes to successfully simulate a reclaim
2- Remember how many new tasks have been added to the partial representation job in the solver. In case it is more then 1, evict all potential victims at once.
3- Fix "LatestPotentialVictims" implementation.

## Related Issues

Fixes #1546

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
