### PR TITLE
docs: link scale-tests and benchmark dashboards from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Refer to the [Breaking Changes](https://github.com/kai-scheduler/KAI-scheduler/b
 
 To start scheduling workloads with KAI Scheduler, please continue to [Quick Start example](docs/quickstart/README.md)
 
+## Performance & Scale
+
+- **[Scale tests dashboard](https://kai-scheduler.github.io/KAI-Scheduler/)**: results from large-cluster scale tests run every 24 hours on dedicated infrastructure. See [scale tests docs](docs/developer/scale-tests.md) for methodology.
+- **[Benchmark history](https://kai-scheduler.github.io/KAI-Scheduler/dev/bench/)**: Go benchmark trends published on every push to `main`.
+
 ## Roadmap
 
 You can find the updated KAI Scheduler roadmap (historical, near year and future) [here](roadmap.md).

--- a/docs/developer/scale-tests.md
+++ b/docs/developer/scale-tests.md
@@ -81,7 +81,7 @@ Minimal cluster requirements:
 
 - Tests run on dedicated infrastructure every 24 hours
 - Test results are stored in S3 and displayed on a public dashboard
-- Dashboard URL: [KAI Scheduler Scale Tests](https://kai-scheduler.github.io/KAI-Scheduler/) (update with actual URL after deployment)
+- Dashboard URL: [KAI Scheduler Scale Tests](https://kai-scheduler.github.io/KAI-Scheduler/)
 
 ## Results Dashboard
 


### PR DESCRIPTION
## Description

The scale-tests dashboard and the benchmark-history dashboard (added in #1526) are both published under `kai-scheduler.github.io/KAI-Scheduler` but neither is linked from the repo, so neither is discoverable.

This PR:

- Adds a `Performance & Scale` section to `README.md` linking both dashboards, with a one-line description of each and a pointer to the scale-tests methodology doc.
- Drops the stale `(update with actual URL after deployment)` caveat in `docs/developer/scale-tests.md` now that the dashboard is live.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) — N/A, docs-only
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Docs-only — `skip-changelog` applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)