### PR TITLE
fix(chart): unblock crd-upgrader hook retries and allow per-image registry override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The scheduler now implements elastic PodGroups on both the subgroup level (`minSubGroup`) and pods (`minAvailable`). This allows for elasticity on all of the podgroup tree hierarchy. [#1416](https://github.com/kai-scheduler/KAI-Scheduler/pull/1416) - [davidLif](https://github.com/davidLif)
 - Allow the configuration of plugins in the binder service. [#1480](https://github.com/kai-scheduler/KAI-Scheduler/pull/1480) - [davidLif](https://github.com/davidLif)
 - Added support for configuring scheduler log level and custom scheduler args via Helm values (`scheduler.args`) [#1452](https://github.com/kai-scheduler/KAI-Scheduler/pull/1452) [dttung2905](https://github.com/dttung2905)
+- Added `crdupgrader.image.registry` Helm value to override `global.registry` for the `crd-upgrader` pre-install/pre-upgrade hook image, allowing the hook image to be served from a separate mirror without redirecting all chart images. [#1404](https://github.com/kai-scheduler/KAI-Scheduler/issues/1404)
 
 ### Changed
 - **Breaking:** JobSet PodGroups no longer auto-calculate `minAvailable` from `parallelism × replicas`. The default is now 1. Use the `kai.scheduler/batch-min-member` annotation to set a custom value.
@@ -37,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed `skipTopOwnerGrouper` not propagating per-type defaults (priority class and preemptibility) for skipped owners (e.g. `DynamoGraphDeployment`), causing PodGroup spec to retain stale values after defaults ConfigMap updates.
 - Fixed binder DRA detection on clusters where the upstream `DynamicResourceAllocation` feature gate does not reflect server-side DRA availability. The binder now probes the API server during init (matching the scheduler) so the DRA plugin is gated on the same authoritative decision. [#1481](https://github.com/kai-scheduler/KAI-Scheduler/issues/1481)
 - Suppressed noisy `Reconciler error` logs and `PodGrouperWarning` events on transient PodGroup update conflicts. The podgrouper now treats `IsConflict` errors as expected and silently requeues the reconcile instead of surfacing the apiserver's "object has been modified" message.
+- Added `before-hook-creation` to the `crd-upgrader` Helm hook delete policy so failed hook Jobs no longer block subsequent `helm upgrade --install` retries. Aligns with the policy already used by the chart's other hook resources. [#1404](https://github.com/kai-scheduler/KAI-Scheduler/issues/1404)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
+++ b/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
       - name: upgrader
-        image: "{{ .Values.global.registry }}/{{ .Values.crdupgrader.image.name }}:{{ .Values.crdupgrader.image.tag | default .Values.global.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.crdupgrader.image.registry | default .Values.global.registry }}/{{ .Values.crdupgrader.image.name }}:{{ .Values.crdupgrader.image.tag | default .Values.global.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.crdupgrader.image.pullPolicy }}
         {{- if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterversions.config.openshift.io") }}
         securityContext:

--- a/deployments/kai-scheduler/tests/crd_upgrader_test.yaml
+++ b/deployments/kai-scheduler/tests/crd_upgrader_test.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test crd-upgrader hook configuration
+templates:
+  - hooks/pre/crd-upgrader.yaml
+tests:
+  - it: should set hook-delete-policy to hook-succeeded,before-hook-creation
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: hook-succeeded,before-hook-creation
+
+  - it: should default image registry to global.registry
+    set:
+      global.registry: ghcr.io/nvidia/kai-scheduler
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/nvidia/kai-scheduler/crd-upgrader:0.0.0
+
+  - it: should override image registry when crdupgrader.image.registry is set
+    set:
+      global.registry: ghcr.io/nvidia/kai-scheduler
+      crdupgrader.image.registry: my-mirror.example.com/kai
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my-mirror.example.com/kai/crd-upgrader:0.0.0

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -187,6 +187,7 @@ crdupgrader:
   image:
     name: crd-upgrader
     pullPolicy: IfNotPresent
+    # registry: ""  # Optional: Override global.registry (e.g. to mirror only the hook image)
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
 
 topologyMigration:


### PR DESCRIPTION
## Description

Two small chart fixes for the `crd-upgrader` pre-install/pre-upgrade hook discussed in #1404.

### 1. Add `before-hook-creation` to the hook delete policy

When the hook Job fails (the issue reports image-pull timeouts on cold CI runners), the failed Job stays in the namespace because the policy only removes successful hooks. Subsequent `helm upgrade --install` attempts then fail with:

```
Error: UPGRADE FAILED: pre-upgrade hooks failed: resource Job/kai-scheduler/crd-upgrader not ready.
status: Failed, message: Job Failed. failed: 1/1
```

Adding `before-hook-creation` lets the next install replace the stale Job. This matches the policy already used by the chart's other hook resources (`rbac/crd-manager.yaml`, `rbac/post-delete-*.yaml`, `hooks/pre/topology-migration/rbac.yaml`).

### 2. Add `crdupgrader.image.registry` override

The hook image is currently sourced from `global.registry`, so a user who wants to mirror only the hook image (e.g. to a closer/faster registry on cold CI runners) has to redirect every chart image. Adding an optional per-component override — falling back to `global.registry` when unset — is a non-breaking change:

```yaml
crdupgrader:
  image:
    # registry: my-mirror.example.com/kai   # Optional override
    name: crd-upgrader
```

The image-size reduction also mentioned in the issue is left for a follow-up since it lives in the build, not the chart.

## Related Issues

Refs #1404

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed) — added `tests/crd_upgrader_test.yaml`, all 91 chart tests pass
- [x] Updated documentation (if needed) — `CHANGELOG.md` updated, `values.yaml` comment added

## Breaking Changes

None. The new `crdupgrader.image.registry` defaults to `global.registry`, preserving existing behavior. The hook delete policy change only affects retry semantics on failed hooks.

## Additional Notes

Verified locally with `make test-chart` (helm-unittest 3.17.2-0.8.1):

```
Charts:      1 passed, 1 total
Test Suites: 8 passed, 8 total
Tests:       91 passed, 91 total
```