### PR TITLE
fix: Exponential solver regression

### DIFF
--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -139,7 +139,55 @@ func (s *byPodSolver) solveOnPotentialNodes(ssn *framework.Session, scenario *sc
 			return nil, err
 		}
 	}
+
+	return s.solveOnAllPotentialNodes(ssn, scenario, statement)
+}
+
+// solveOnAllPotentialNodes is a fallback used when no single host node's potential
+// victims are sufficient: it evicts every potential victim recorded in the scenario
+// at once and runs a single simulation. The scenario validator has already approved
+// the full potentials set, so this expands the simulator's view across nodes
+// without violating fair-share.
+func (s *byPodSolver) solveOnAllPotentialNodes(ssn *framework.Session, scenario *scenario.ByNodeScenario,
+	statement *framework.Statement) (*solutionResult, error) {
+	allPotentialVictims := scenario.PotentialVictimsTasks()
+	if len(allPotentialVictims) == 0 {
+		return nil, nil
+	}
+	log.InfraLogger.V(6).Infof(
+		"Per-node iteration exhausted; trying scenario with all potential victims evicted at once")
+
+	checkpoint := statement.Checkpoint()
+	pendingJob := scenario.GetPreemptor()
+	if err := common.EvictAllPreemptees(ssn, allPotentialVictims, pendingJob, statement, s.actionType); err != nil {
+		return nil, err
+	}
+	newFeasibleNodes := s.updateFeasibleNodes(ssn, allPotentialVictims)
+
+	victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), allPotentialVictims)
+	result := s.runSimulation(ssn, scenario, statement, victimTasks)
+	if result != nil {
+		return result, nil
+	}
+
+	s.feasibleNodesRollback(newFeasibleNodes)
+	if err := statement.Rollback(checkpoint); err != nil {
+		return nil, err
+	}
 	return nil, nil
+}
+
+func (s *byPodSolver) evictPotentialVictimsFromNode(
+	session *framework.Session, scenario *scenario.ByNodeScenario, statement *framework.Statement, nodeToTest string,
+) (*framework.Checkpoint, []*pod_info.PodInfo, error) {
+	recordedVictimsCheckpoint := statement.Checkpoint()
+	pendingJob := scenario.GetPreemptor()
+
+	potentialVictimsTasks := scenario.VictimsTasksFromNodes([]string{nodeToTest})
+	if err := common.EvictAllPreemptees(session, potentialVictimsTasks, pendingJob, statement, s.actionType); err != nil {
+		return nil, nil, err
+	}
+	return &recordedVictimsCheckpoint, potentialVictimsTasks, nil
 }
 
 func (s *byPodSolver) feasibleNodesRollback(newFeasibleNodes map[string]bool) {
@@ -158,19 +206,6 @@ func (s *byPodSolver) updateFeasibleNodes(ssn *framework.Session, victimTasks []
 		s.feasibleNodes[potentialVictimTasks.NodeName] = ssn.ClusterInfo.Nodes[potentialVictimTasks.NodeName]
 	}
 	return newFeasibleNodes
-}
-
-func (s *byPodSolver) evictPotentialVictimsFromNode(
-	session *framework.Session, scenario *scenario.ByNodeScenario, statement *framework.Statement, nodeToTest string,
-) (*framework.Checkpoint, []*pod_info.PodInfo, error) {
-	recordedVictimsCheckpoint := statement.Checkpoint()
-	pendingJob := scenario.GetPreemptor()
-
-	potentialVictimsTasks := scenario.VictimsTasksFromNodes([]string{nodeToTest})
-	if err := common.EvictAllPreemptees(session, potentialVictimsTasks, pendingJob, statement, s.actionType); err != nil {
-		return nil, nil, err
-	}
-	return &recordedVictimsCheckpoint, potentialVictimsTasks, nil
 }
 
 func (s *byPodSolver) handleScenarioSolution(

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -60,27 +60,17 @@ func newByPodSolver(
 	}
 }
 
-// solve runs one simulation for the given scenario: evict all of its recorded and
-// potential victims, then try to virtually allocate the preemptor across the resulting
-// feasible nodes. The scenario builder owns the search strategy (which victims to put
-// in this scenario and in what order). solve is intentionally a single path with no
-// per-node fallbacks of its own.
-func (s *byPodSolver) solve(
-	session *framework.Session, scenario *scenario.ByNodeScenario,
-) *solutionResult {
+// solve evaluates a scenario's feasibility by simulating it: evicting its victims and simulating the allocation loop.
+// This simulates allocation order, node sorting, predicates, and all relevant scheduling logic, so the scheduler will
+// not perform evictions that will not result in successful allocation of the pending job. This also helps the scheduler
+// avoid evictions which are not relevant to the specific scenario.
+func (s *byPodSolver) solve(session *framework.Session, scenario *scenario.ByNodeScenario) *solutionResult {
 	statement := session.Statement()
 
 	pendingJob := scenario.GetPreemptor()
 	nextTaskToFindAllocation := scenario.PendingTasks()[len(scenario.PendingTasks())-1]
 
 	allVictims := getVictimTasks(scenario.RecordedVictimsTasks(), scenario.PotentialVictimsTasks())
-	if len(allVictims) == 0 {
-		// Nothing to evict. byPodSolver is only invoked when the preemptor needs
-		// to displace at least one task; pure idle-capacity fits are the allocate
-		// action's job, not ours. Signal failure so the builder advances.
-		statement.Discard()
-		return &solutionResult{false, nil, nil, nil}
-	}
 
 	checkpoint := statement.Checkpoint()
 	if err := common.EvictAllPreemptees(session, allVictims, pendingJob, statement, s.actionType); err != nil {

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -77,7 +77,8 @@ func (s *byPodSolver) solve(
 	if latestPotentialVictim == nil {
 		if hasRecordedVictimsForSimulation(scenario) {
 			log.InfraLogger.V(6).Infof("Trying to solve scenario with priviously calculated victims only")
-			result := s.runSimulation(session, scenario, statement, scenario.RecordedVictimsTasks())
+			result := s.runSimulation(session, scenario, statement, scenario.RecordedVictimsTasks(),
+				maps.Values(s.feasibleNodes))
 			if result != nil {
 				return result
 			}
@@ -99,12 +100,12 @@ func (s *byPodSolver) solve(
 
 func (s *byPodSolver) runSimulation(
 	session *framework.Session, scenario *scenario.ByNodeScenario, statement *framework.Statement,
-	victimTasks []*pod_info.PodInfo) *solutionResult {
+	victimTasks []*pod_info.PodInfo, nodes []*node_info.NodeInfo) *solutionResult {
 	pendingJob := scenario.GetPreemptor()
 	nextTaskToFindAllocation := scenario.PendingTasks()[len(scenario.PendingTasks())-1]
 
 	successfulSimulation, solutionVictims, err :=
-		s.tryScenarioWithEvictedVictims(session, scenario, statement, victimTasks)
+		s.tryScenarioWithEvictedVictims(session, scenario, statement, victimTasks, nodes)
 
 	if err != nil {
 		return handleSolveError(pendingJob, nextTaskToFindAllocation, err, statement)
@@ -129,7 +130,7 @@ func (s *byPodSolver) solveOnPotentialNodes(ssn *framework.Session, scenario *sc
 		newFeasibleNodes := s.updateFeasibleNodes(ssn, potentialVictimsTasks)
 
 		victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), potentialVictimsTasks)
-		result := s.runSimulation(ssn, scenario, statement, victimTasks)
+		result := s.runSimulation(ssn, scenario, statement, victimTasks, maps.Values(s.feasibleNodes))
 		if result != nil {
 			return result, nil
 		}
@@ -148,6 +149,11 @@ func (s *byPodSolver) solveOnPotentialNodes(ssn *framework.Session, scenario *sc
 // at once and runs a single simulation. The scenario validator has already approved
 // the full potentials set, so this expands the simulator's view across nodes
 // without violating fair-share.
+//
+// The simulation is run against only the nodes that could plausibly host at least one
+// pending task after eviction. The full potential-victim set may span hundreds of nodes,
+// most of which cannot fit any pending task; including them in the simulation makes
+// every AllocateJob call scan and score nodes that have no chance of helping.
 func (s *byPodSolver) solveOnAllPotentialNodes(ssn *framework.Session, scenario *scenario.ByNodeScenario,
 	statement *framework.Statement) (*solutionResult, error) {
 	allPotentialVictims := scenario.PotentialVictimsTasks()
@@ -165,7 +171,8 @@ func (s *byPodSolver) solveOnAllPotentialNodes(ssn *framework.Session, scenario 
 	newFeasibleNodes := s.updateFeasibleNodes(ssn, allPotentialVictims)
 
 	victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), allPotentialVictims)
-	result := s.runSimulation(ssn, scenario, statement, victimTasks)
+	simulationNodes := s.nodesFittingMinPendingTask(scenario)
+	result := s.runSimulation(ssn, scenario, statement, victimTasks, simulationNodes)
 	if result != nil {
 		return result, nil
 	}
@@ -175,6 +182,40 @@ func (s *byPodSolver) solveOnAllPotentialNodes(ssn *framework.Session, scenario 
 		return nil, err
 	}
 	return nil, nil
+}
+
+// nodesFittingMinPendingTask returns the subset of feasibleNodes whose post-eviction
+// idle+releasing GPU capacity is at least the smallest pending-task GPU requirement.
+// Nodes that cannot host any pending task are dropped: the simulation would scan and
+// score them on every AllocateJob call, but they cannot contribute to a pending
+// allocation. Victims pipelined back to dropped nodes are lost as an optimization,
+// which only matters when total post-eviction capacity exceeds total pending demand;
+// in the large-cluster reclaim case it does not.
+func (s *byPodSolver) nodesFittingMinPendingTask(scenario *scenario.ByNodeScenario) []*node_info.NodeInfo {
+	minPendingGpu := -1.0
+	for _, task := range scenario.PendingTasks() {
+		req := task.GpuRequirement.GetGpusQuota()
+		if minPendingGpu < 0 || req < minPendingGpu {
+			minPendingGpu = req
+		}
+	}
+	if minPendingGpu <= 0 {
+		return maps.Values(s.feasibleNodes)
+	}
+
+	filtered := make([]*node_info.NodeInfo, 0, len(s.feasibleNodes))
+	for _, node := range s.feasibleNodes {
+		if nodeIdleOrReleasingGpus(node) >= minPendingGpu {
+			filtered = append(filtered, node)
+		}
+	}
+	return filtered
+}
+
+func nodeIdleOrReleasingGpus(ni *node_info.NodeInfo) float64 {
+	idle, _ := ni.GetSumOfIdleGPUs()
+	releasing, _ := ni.GetSumOfReleasingGPUs()
+	return idle + releasing
 }
 
 func (s *byPodSolver) evictPotentialVictimsFromNode(
@@ -249,10 +290,9 @@ func getNodesOfJob(pj *podgroup_info.PodGroupInfo) []string {
 }
 
 func (s *byPodSolver) tryScenarioWithEvictedVictims(ssn *framework.Session, scenario *scenario.ByNodeScenario,
-	statement *framework.Statement, victimTasks []*pod_info.PodInfo) (bool, *simulationVictims, error) {
+	statement *framework.Statement, victimTasks []*pod_info.PodInfo, nodes []*node_info.NodeInfo) (bool, *simulationVictims, error) {
 	pendingJob := scenario.GetPreemptor()
 
-	nodes := maps.Values(s.feasibleNodes)
 	jobsToAllocate := common.GetJobsToAllocate(ssn, victimTasks, pendingJob)
 	isSuccessfulAllocations, _ :=
 		common.TryToVirtuallyAllocatePreemptorAndGetVictims(ssn, statement, nodes, pendingJob,

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -60,6 +60,11 @@ func newByPodSolver(
 	}
 }
 
+// solve runs one simulation for the given scenario: evict all of its recorded and
+// potential victims, then try to virtually allocate the preemptor across the resulting
+// feasible nodes. The scenario builder owns the search strategy (which victims to put
+// in this scenario and in what order). solve is intentionally a single path with no
+// per-node fallbacks of its own.
 func (s *byPodSolver) solve(
 	session *framework.Session, scenario *scenario.ByNodeScenario,
 ) *solutionResult {
@@ -67,34 +72,32 @@ func (s *byPodSolver) solve(
 
 	pendingJob := scenario.GetPreemptor()
 	nextTaskToFindAllocation := scenario.PendingTasks()[len(scenario.PendingTasks())-1]
-	latestPotentialVictim := scenario.LatestPotentialVictim()
 
-	err := common.EvictAllPreemptees(session, scenario.RecordedVictimsTasks(), pendingJob, statement, s.actionType)
-	if err != nil {
+	allVictims := getVictimTasks(scenario.RecordedVictimsTasks(), scenario.PotentialVictimsTasks())
+	if len(allVictims) == 0 {
+		// Nothing to evict. byPodSolver is only invoked when the preemptor needs
+		// to displace at least one task; pure idle-capacity fits are the allocate
+		// action's job, not ours. Signal failure so the builder advances.
+		statement.Discard()
+		return &solutionResult{false, nil, nil, nil}
+	}
+
+	checkpoint := statement.Checkpoint()
+	if err := common.EvictAllPreemptees(session, allVictims, pendingJob, statement, s.actionType); err != nil {
 		return handleSolveError(pendingJob, nextTaskToFindAllocation, err, statement)
 	}
+	newFeasibleNodes := s.updateFeasibleNodes(session, allVictims)
 
-	if latestPotentialVictim == nil {
-		if hasRecordedVictimsForSimulation(scenario) {
-			log.InfraLogger.V(6).Infof("Trying to solve scenario with priviously calculated victims only")
-			result := s.runSimulation(session, scenario, statement, scenario.RecordedVictimsTasks(),
-				maps.Values(s.feasibleNodes))
-			if result != nil {
-				return result
-			}
-		}
-	} else {
-		potentialVictimNodes := getNodesOfJob(latestPotentialVictim)
-		result, err := s.solveOnPotentialNodes(session, scenario, statement, potentialVictimNodes)
-		if err != nil {
-			return handleSolveError(pendingJob, nextTaskToFindAllocation, err, statement)
-		}
-		if result != nil {
-			return result
-		}
+	result := s.runSimulation(session, scenario, statement, allVictims, maps.Values(s.feasibleNodes))
+	if result != nil {
+		return result
 	}
 
-	statement.Discard() // No solution for scenario
+	s.feasibleNodesRollback(newFeasibleNodes)
+	if err := statement.Rollback(checkpoint); err != nil {
+		return handleSolveError(pendingJob, nextTaskToFindAllocation, err, statement)
+	}
+	statement.Discard()
 	return &solutionResult{false, nil, nil, nil}
 }
 
@@ -114,121 +117,6 @@ func (s *byPodSolver) runSimulation(
 		return s.handleScenarioSolution(scenario, statement, solutionVictims)
 	}
 	return nil
-}
-
-func (s *byPodSolver) solveOnPotentialNodes(ssn *framework.Session, scenario *scenario.ByNodeScenario,
-	statement *framework.Statement, potentialVictimNodeNames []string) (*solutionResult, error) {
-	for _, nodeToTest := range potentialVictimNodeNames {
-		log.InfraLogger.V(6).Infof(
-			"Trying to solve scenario with potantial victims from node: %s", nodeToTest)
-
-		nodeVictimsEvictionCheckpoint, potentialVictimsTasks, err :=
-			s.evictPotentialVictimsFromNode(ssn, scenario, statement, nodeToTest)
-		if err != nil {
-			return nil, err
-		}
-		newFeasibleNodes := s.updateFeasibleNodes(ssn, potentialVictimsTasks)
-
-		victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), potentialVictimsTasks)
-		result := s.runSimulation(ssn, scenario, statement, victimTasks, maps.Values(s.feasibleNodes))
-		if result != nil {
-			return result, nil
-		}
-
-		s.feasibleNodesRollback(newFeasibleNodes)
-		if err = statement.Rollback(*nodeVictimsEvictionCheckpoint); err != nil {
-			return nil, err
-		}
-	}
-
-	return s.solveOnAllPotentialNodes(ssn, scenario, statement)
-}
-
-// solveOnAllPotentialNodes is a fallback used when no single host node's potential
-// victims are sufficient: it evicts every potential victim recorded in the scenario
-// at once and runs a single simulation. The scenario validator has already approved
-// the full potentials set, so this expands the simulator's view across nodes
-// without violating fair-share.
-//
-// The simulation is run against only the nodes that could plausibly host at least one
-// pending task after eviction. The full potential-victim set may span hundreds of nodes,
-// most of which cannot fit any pending task; including them in the simulation makes
-// every AllocateJob call scan and score nodes that have no chance of helping.
-func (s *byPodSolver) solveOnAllPotentialNodes(ssn *framework.Session, scenario *scenario.ByNodeScenario,
-	statement *framework.Statement) (*solutionResult, error) {
-	allPotentialVictims := scenario.PotentialVictimsTasks()
-	if len(allPotentialVictims) == 0 {
-		return nil, nil
-	}
-	log.InfraLogger.V(6).Infof(
-		"Per-node iteration exhausted; trying scenario with all potential victims evicted at once")
-
-	checkpoint := statement.Checkpoint()
-	pendingJob := scenario.GetPreemptor()
-	if err := common.EvictAllPreemptees(ssn, allPotentialVictims, pendingJob, statement, s.actionType); err != nil {
-		return nil, err
-	}
-	newFeasibleNodes := s.updateFeasibleNodes(ssn, allPotentialVictims)
-
-	victimTasks := getVictimTasks(scenario.RecordedVictimsTasks(), allPotentialVictims)
-	simulationNodes := s.nodesFittingMinPendingTask(scenario)
-	result := s.runSimulation(ssn, scenario, statement, victimTasks, simulationNodes)
-	if result != nil {
-		return result, nil
-	}
-
-	s.feasibleNodesRollback(newFeasibleNodes)
-	if err := statement.Rollback(checkpoint); err != nil {
-		return nil, err
-	}
-	return nil, nil
-}
-
-// nodesFittingMinPendingTask returns the subset of feasibleNodes whose post-eviction
-// idle+releasing GPU capacity is at least the smallest pending-task GPU requirement.
-// Nodes that cannot host any pending task are dropped: the simulation would scan and
-// score them on every AllocateJob call, but they cannot contribute to a pending
-// allocation. Victims pipelined back to dropped nodes are lost as an optimization,
-// which only matters when total post-eviction capacity exceeds total pending demand;
-// in the large-cluster reclaim case it does not.
-func (s *byPodSolver) nodesFittingMinPendingTask(scenario *scenario.ByNodeScenario) []*node_info.NodeInfo {
-	minPendingGpu := -1.0
-	for _, task := range scenario.PendingTasks() {
-		req := task.GpuRequirement.GetGpusQuota()
-		if minPendingGpu < 0 || req < minPendingGpu {
-			minPendingGpu = req
-		}
-	}
-	if minPendingGpu <= 0 {
-		return maps.Values(s.feasibleNodes)
-	}
-
-	filtered := make([]*node_info.NodeInfo, 0, len(s.feasibleNodes))
-	for _, node := range s.feasibleNodes {
-		if nodeIdleOrReleasingGpus(node) >= minPendingGpu {
-			filtered = append(filtered, node)
-		}
-	}
-	return filtered
-}
-
-func nodeIdleOrReleasingGpus(ni *node_info.NodeInfo) float64 {
-	idle, _ := ni.GetSumOfIdleGPUs()
-	releasing, _ := ni.GetSumOfReleasingGPUs()
-	return idle + releasing
-}
-
-func (s *byPodSolver) evictPotentialVictimsFromNode(
-	session *framework.Session, scenario *scenario.ByNodeScenario, statement *framework.Statement, nodeToTest string,
-) (*framework.Checkpoint, []*pod_info.PodInfo, error) {
-	recordedVictimsCheckpoint := statement.Checkpoint()
-	pendingJob := scenario.GetPreemptor()
-
-	potentialVictimsTasks := scenario.VictimsTasksFromNodes([]string{nodeToTest})
-	if err := common.EvictAllPreemptees(session, potentialVictimsTasks, pendingJob, statement, s.actionType); err != nil {
-		return nil, nil, err
-	}
-	return &recordedVictimsCheckpoint, potentialVictimsTasks, nil
 }
 
 func (s *byPodSolver) feasibleNodesRollback(newFeasibleNodes map[string]bool) {
@@ -253,9 +141,7 @@ func (s *byPodSolver) handleScenarioSolution(
 	scenario *scenario.ByNodeScenario, statement *framework.Statement, solutionVictims *simulationVictims,
 ) *solutionResult {
 	victimsTasks := make([]*pod_info.PodInfo, len(solutionVictims.preemptedVictims))
-	for i := 0; i < len(solutionVictims.preemptedVictims); i++ {
-		victimsTasks[i] = solutionVictims.preemptedVictims[i]
-	}
+	copy(victimsTasks, solutionVictims.preemptedVictims)
 	if !s.allowVictimConsolidation {
 		victimsTasks = append(victimsTasks, solutionVictims.pipelinedVictims...)
 	}
@@ -277,18 +163,6 @@ func (s *byPodSolver) handleScenarioSolution(
 	return &solutionResult{true, victimsTasks, actualVictimJobs, statement}
 }
 
-func getNodesOfJob(pj *podgroup_info.PodGroupInfo) []string {
-	if pj == nil {
-		return []string{}
-	}
-
-	pjNodeNames := map[string]string{}
-	for _, latestPotentialVictimTask := range pj.GetAllPodsMap() {
-		pjNodeNames[latestPotentialVictimTask.NodeName] = latestPotentialVictimTask.NodeName
-	}
-	return maps.Keys(pjNodeNames)
-}
-
 func (s *byPodSolver) tryScenarioWithEvictedVictims(ssn *framework.Session, scenario *scenario.ByNodeScenario,
 	statement *framework.Statement, victimTasks []*pod_info.PodInfo, nodes []*node_info.NodeInfo) (bool, *simulationVictims, error) {
 	pendingJob := scenario.GetPreemptor()
@@ -300,17 +174,17 @@ func (s *byPodSolver) tryScenarioWithEvictedVictims(ssn *framework.Session, scen
 
 	if !isSuccessfulAllocations {
 		return false, nil, nil
-	} else {
-		actualVictims := newCalculatedVictimsStruct()
-		for _, victimTask := range victimTasks {
-			if victimTask.Status == pod_status.Releasing {
-				actualVictims.preemptedVictims = append(actualVictims.preemptedVictims, victimTask)
-			} else if victimTask.Status == pod_status.Pipelined {
-				actualVictims.pipelinedVictims = append(actualVictims.pipelinedVictims, victimTask)
-			}
-		}
-		return isSuccessfulAllocations, actualVictims, nil
 	}
+	actualVictims := newCalculatedVictimsStruct()
+	for _, victimTask := range victimTasks {
+		switch victimTask.Status {
+		case pod_status.Releasing:
+			actualVictims.preemptedVictims = append(actualVictims.preemptedVictims, victimTask)
+		case pod_status.Pipelined:
+			actualVictims.pipelinedVictims = append(actualVictims.pipelinedVictims, victimTask)
+		}
+	}
+	return isSuccessfulAllocations, actualVictims, nil
 }
 
 func getVictimJobsFromVictimTasks(
@@ -368,6 +242,8 @@ func handleSolveError(pendingJob *podgroup_info.PodGroupInfo, nextTaskToFindAllo
 	return &solutionResult{false, nil, nil, nil}
 }
 
-func hasRecordedVictimsForSimulation(scenario *scenario.ByNodeScenario) bool {
-	return len(scenario.RecordedVictimsTasks()) > 0
+func nodeIdleOrReleasingGpus(ni *node_info.NodeInfo) float64 {
+	idle, _ := ni.GetSumOfIdleGPUs()
+	releasing, _ := ni.GetSumOfReleasingGPUs()
+	return idle + releasing
 }

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -88,21 +88,56 @@ func NewPodAccumulatedScenarioBuilder(
 	}
 }
 
+// GetValidScenario returns the next scenario to solve, evaluating the current outer
+// state without advancing the victim queue. Used to obtain the first scenario in a
+// pass.
+func (asb *PodAccumulatedScenarioBuilder) GetValidScenario() *solverscenario.ByNodeScenario {
+	return asb.iterate(false)
+}
+
+// GetNextScenario advances the victim queue by one before evaluating, returning the
+// next scenario or nil when the queue is exhausted. Used in the body of the
+// caller's iteration loop after consuming each scenario.
 func (asb *PodAccumulatedScenarioBuilder) GetNextScenario() *solverscenario.ByNodeScenario {
-	if sub := asb.nextFromSubEmitter(); sub != nil {
-		return sub
-	}
+	return asb.iterate(true)
+}
 
-	if asb.victimsJobsQueue.IsEmpty() {
-		return nil
-	}
+// iterate is the unified driver behind GetValidScenario / GetNextScenario.
+//
+// The pipeline runs as a single loop with three exit points:
+//  1. An active sub-emitter yields a sub-scenario — return it.
+//  2. The outer scenario is valid and has no potential victims — return it
+//     unmodified (the recorded-victims-only case).
+//  3. The victim queue is exhausted — return nil.
+//
+// Otherwise the loop either pops the next victim, runs the accumulating filters
+// (skipping rejected states), or constructs a fresh sub-emitter for a newly-valid
+// outer state. advanceFirst controls whether the first pass starts by popping a
+// victim or by evaluating the current state as-is.
+func (asb *PodAccumulatedScenarioBuilder) iterate(advanceFirst bool) *solverscenario.ByNodeScenario {
+	needAdvance := advanceFirst
+	for {
+		if sub := asb.nextFromSubEmitter(); sub != nil {
+			return sub
+		}
+		if needAdvance {
+			if asb.victimsJobsQueue.IsEmpty() {
+				return nil
+			}
+			if !asb.addNextPotentialVictims() {
+				continue
+			}
+		}
+		needAdvance = true
 
-	addedPotentialVictims := asb.addNextPotentialVictims()
-	if !addedPotentialVictims {
-		return asb.GetNextScenario()
+		if !asb.outerScenarioValid() {
+			continue
+		}
+		if len(asb.lastScenario.PotentialVictimsTasks()) == 0 {
+			return asb.lastScenario
+		}
+		asb.subEmitter = newSubScenarioEmitter(asb.session, asb.lastScenario, asb.feasibleNodes)
 	}
-
-	return asb.GetValidScenario()
 }
 
 // nextFromSubEmitter drains the active sub-scenario emitter (if any) by one. Returns
@@ -117,6 +152,17 @@ func (asb *PodAccumulatedScenarioBuilder) nextFromSubEmitter() *solverscenario.B
 	}
 	asb.subEmitter = nil
 	return nil
+}
+
+// outerScenarioValid runs the accumulating filters against the current outer
+// scenario, logging and counting the rejection on failure for observability.
+func (asb *PodAccumulatedScenarioBuilder) outerScenarioValid() bool {
+	isValid, failedFilterName := asb.isScenarioValid()
+	if !isValid {
+		log.InfraLogger.V(5).Infof("Filtered by %s for scenario: %s", failedFilterName, asb.lastScenario)
+		metrics.IncScenarioFilteredByAction()
+	}
+	return isValid
 }
 
 func (asb *PodAccumulatedScenarioBuilder) addNextPotentialVictims() bool {
@@ -162,36 +208,6 @@ func (asb *PodAccumulatedScenarioBuilder) addNextPotentialVictims() bool {
 		asb.lastScenario.AddPotentialVictimsTasks(potentialVictimTasks)
 	}
 	return true
-}
-
-func (asb *PodAccumulatedScenarioBuilder) GetValidScenario() *solverscenario.ByNodeScenario {
-	if sub := asb.nextFromSubEmitter(); sub != nil {
-		return sub
-	}
-
-	if isValid, failedFilterName := asb.isScenarioValid(); !isValid {
-		log.InfraLogger.V(5).Infof("Filtered by %s for scenario: %s", failedFilterName, asb.lastScenario)
-		metrics.IncScenarioFilteredByAction()
-
-		return asb.GetNextScenario()
-	}
-
-	// Recorded-victims-only state: nothing to group by node; hand the outer scenario
-	// straight to the solver.
-	if len(asb.lastScenario.PotentialVictimsTasks()) == 0 {
-		return asb.lastScenario
-	}
-
-	// Outer is potentially feasible: hand off to the sub-scenario emitter, which
-	// picks the smallest set of victim-bearing nodes whose post-eviction capacity
-	// covers pending demand, and grows it on subsequent calls if the solver fails.
-	asb.subEmitter = newSubScenarioEmitter(asb.session, asb.lastScenario, asb.feasibleNodes)
-	if sub := asb.nextFromSubEmitter(); sub != nil {
-		return sub
-	}
-	// The emitter has nothing to offer (no node passes the smallest-pending-task
-	// gate, or no K covers demand). Treat this like a filter rejection and advance.
-	return asb.GetNextScenario()
 }
 
 func (asb *PodAccumulatedScenarioBuilder) isScenarioValid() (bool, string) {

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -28,6 +28,17 @@ type PodAccumulatedScenarioBuilder struct {
 	victimsJobsQueue *utils.JobsOrderByQueues
 
 	recordedVictimsTasks map[common_info.PodID]*pod_info.PodInfo
+
+	// feasibleNodes is the set of nodes the JobSolver gave us as feasible for the
+	// preemptor (post FeasibleNodesForJob filter + recorded-victim nodes). The sub-
+	// scenario emitter uses it to compute "baseline capacity" already available to
+	// the simulation regardless of which potential victims it chooses.
+	feasibleNodes map[string]*node_info.NodeInfo
+
+	// subEmitter, when non-nil, owns the active sub-scenario emission for the current
+	// outer state. Each Get*Scenario call drains one sub-scenario from it; when it
+	// returns nil, outer accumulation resumes.
+	subEmitter *subScenarioEmitter
 }
 
 func NewPodAccumulatedScenarioBuilder(
@@ -73,10 +84,15 @@ func NewPodAccumulatedScenarioBuilder(
 		recordedVictimsTasks: recordedVictimsTasks,
 		lastScenario:         scenario,
 		scenarioFilters:      scenarioFilters,
+		feasibleNodes:        feasibleNodes,
 	}
 }
 
 func (asb *PodAccumulatedScenarioBuilder) GetNextScenario() *solverscenario.ByNodeScenario {
+	if sub := asb.nextFromSubEmitter(); sub != nil {
+		return sub
+	}
+
 	if asb.victimsJobsQueue.IsEmpty() {
 		return nil
 	}
@@ -87,6 +103,20 @@ func (asb *PodAccumulatedScenarioBuilder) GetNextScenario() *solverscenario.ByNo
 	}
 
 	return asb.GetValidScenario()
+}
+
+// nextFromSubEmitter drains the active sub-scenario emitter (if any) by one. Returns
+// nil and clears the emitter when it is exhausted, so callers fall through to outer
+// accumulation.
+func (asb *PodAccumulatedScenarioBuilder) nextFromSubEmitter() *solverscenario.ByNodeScenario {
+	if asb.subEmitter == nil {
+		return nil
+	}
+	if sub := asb.subEmitter.next(); sub != nil {
+		return sub
+	}
+	asb.subEmitter = nil
+	return nil
 }
 
 func (asb *PodAccumulatedScenarioBuilder) addNextPotentialVictims() bool {
@@ -135,13 +165,33 @@ func (asb *PodAccumulatedScenarioBuilder) addNextPotentialVictims() bool {
 }
 
 func (asb *PodAccumulatedScenarioBuilder) GetValidScenario() *solverscenario.ByNodeScenario {
+	if sub := asb.nextFromSubEmitter(); sub != nil {
+		return sub
+	}
+
 	if isValid, failedFilterName := asb.isScenarioValid(); !isValid {
 		log.InfraLogger.V(5).Infof("Filtered by %s for scenario: %s", failedFilterName, asb.lastScenario)
 		metrics.IncScenarioFilteredByAction()
 
 		return asb.GetNextScenario()
 	}
-	return asb.lastScenario
+
+	// Recorded-victims-only state: nothing to group by node; hand the outer scenario
+	// straight to the solver.
+	if len(asb.lastScenario.PotentialVictimsTasks()) == 0 {
+		return asb.lastScenario
+	}
+
+	// Outer is potentially feasible: hand off to the sub-scenario emitter, which
+	// picks the smallest set of victim-bearing nodes whose post-eviction capacity
+	// covers pending demand, and grows it on subsequent calls if the solver fails.
+	asb.subEmitter = newSubScenarioEmitter(asb.session, asb.lastScenario, asb.feasibleNodes)
+	if sub := asb.nextFromSubEmitter(); sub != nil {
+		return sub
+	}
+	// The emitter has nothing to offer (no node passes the smallest-pending-task
+	// gate, or no K covers demand). Treat this like a filter rejection and advance.
+	return asb.GetNextScenario()
 }
 
 func (asb *PodAccumulatedScenarioBuilder) isScenarioValid() (bool, string) {

--- a/pkg/scheduler/actions/common/solvers/sub_scenario_emitter.go
+++ b/pkg/scheduler/actions/common/solvers/sub_scenario_emitter.go
@@ -1,0 +1,231 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"sort"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+// subScenarioEmitter generates sub-scenarios from a "potentially feasible" outer scenario
+// produced by PodAccumulatedScenarioBuilder. Each sub-scenario is a subset of the outer's
+// potential victims, picked by node so the simulation only sees nodes that can plausibly
+// host a pending task. The emitter starts at the smallest top-K of victim-bearing nodes
+// whose cumulative post-eviction capacity (added to baseline) covers total pending demand,
+// and grows the set by one node each subsequent call.
+//
+// "Picking" a node selects every potential-victim *job* that has any task on that node,
+// and includes the job's tasks across all nodes it spans. This preserves gang semantics:
+// a job like q0_running_job-on-node0-and-node1 is evicted as a whole, not just its node0
+// half — which the OLD per-node iteration in the solver enforced implicitly via
+// VictimsTasksFromNodes.
+//
+// Sort order: per-node capacity descending. Ties broken by the index at which the node's
+// first victim task appeared in the accumulator, so insertion order from the outer
+// priority queue is preserved when capacities tie (relevant for tests that assert which
+// of two equal-capacity victim jobs gets evicted).
+// victimUnit corresponds to one call into the accumulator's addNextPotentialVictims:
+// for a non-elastic gang job that's all its tasks at once, for an elastic job that's
+// the slice the accumulator chose to peel off on that pop. Treating units as atomic
+// matches what the OLD per-node iteration did via VictimsTasksFromNodes (which returned
+// tasks from each victim-job-representative grouped under one node).
+type victimUnit struct {
+	representative *podgroup_info.PodGroupInfo
+	tasks          []*pod_info.PodInfo
+}
+
+type subScenarioEmitter struct {
+	session       *framework.Session
+	base          *scenario.ByNodeScenario
+	sortedNodes   []string
+	nodeUnits     map[string][]int // node -> indexes into units, in insertion order
+	units         []victimUnit
+	pendingDemand float64
+	nextK         int
+}
+
+func newSubScenarioEmitter(
+	session *framework.Session, base *scenario.ByNodeScenario,
+	feasibleNodes map[string]*node_info.NodeInfo,
+) *subScenarioEmitter {
+	pendingDemand, minPendingTask := pendingTaskGpuStats(base)
+
+	recordedFreedPerNode := map[string]float64{}
+	for _, victim := range base.RecordedVictimsTasks() {
+		if victim.NodeName == "" {
+			continue
+		}
+		recordedFreedPerNode[victim.NodeName] += victim.AcceptedGpuRequirement.GetGpusQuota()
+	}
+
+	// Build the unit list (one entry per accumulator-call boundary, identified by the
+	// scenario's per-call representative PodGroupInfo) and a per-node index of unit IDs
+	// that touch each node. Insertion order tracks the outer priority queue so equal-
+	// capacity node ties break consistently.
+	units := []victimUnit{}
+	repToUnit := map[*podgroup_info.PodGroupInfo]int{}
+	nodeUnits := map[string][]int{}
+	seenUnitOnNode := map[string]map[int]bool{}
+	nodeFirstSeenAt := map[string]int{}
+	for idx, victim := range base.PotentialVictimsTasks() {
+		rep := base.GetVictimJobRepresentativeById(victim)
+		if rep == nil {
+			continue
+		}
+		unitIdx, ok := repToUnit[rep]
+		if !ok {
+			unitIdx = len(units)
+			repToUnit[rep] = unitIdx
+			units = append(units, victimUnit{representative: rep})
+		}
+		units[unitIdx].tasks = append(units[unitIdx].tasks, victim)
+		if victim.NodeName == "" {
+			continue
+		}
+		if _, seen := nodeFirstSeenAt[victim.NodeName]; !seen {
+			nodeFirstSeenAt[victim.NodeName] = idx
+		}
+		if seenUnitOnNode[victim.NodeName] == nil {
+			seenUnitOnNode[victim.NodeName] = map[int]bool{}
+		}
+		if !seenUnitOnNode[victim.NodeName][unitIdx] {
+			seenUnitOnNode[victim.NodeName][unitIdx] = true
+			nodeUnits[victim.NodeName] = append(nodeUnits[victim.NodeName], unitIdx)
+		}
+	}
+
+	// Per-node "pickable" capacity: existing idle/releasing + recorded eviction on this
+	// node + the GPU of victim tasks ON this node from units touching this node. Tasks
+	// of those units on OTHER nodes contribute capacity to *those* nodes when those
+	// nodes are also picked or already in the simulation's feasibleNodes set; we count
+	// only the per-node contribution here to keep the sort heuristic local.
+	nodeCap := map[string]float64{}
+	for nodeName, unitIdxs := range nodeUnits {
+		c := recordedFreedPerNode[nodeName]
+		if node := session.ClusterInfo.Nodes[nodeName]; node != nil {
+			c += nodeIdleOrReleasingGpus(node)
+		}
+		for _, ui := range unitIdxs {
+			for _, t := range units[ui].tasks {
+				if t.NodeName == nodeName {
+					c += t.AcceptedGpuRequirement.GetGpusQuota()
+				}
+			}
+		}
+		nodeCap[nodeName] = c
+	}
+
+	candidates := make([]string, 0, len(nodeUnits))
+	for nodeName := range nodeUnits {
+		if minPendingTask > 0 && nodeCap[nodeName] < minPendingTask {
+			continue
+		}
+		candidates = append(candidates, nodeName)
+	}
+	// Sort ascending by capacity (prefer the smallest viable node so we minimize the
+	// number of victims actually evicted/pipelined; consolidation tests rely on this).
+	// Ties broken by insertion order from the outer priority queue, so equal-capacity
+	// candidates are tried in the order the accumulator surfaced them.
+	sort.Slice(candidates, func(i, j int) bool {
+		ci, cj := nodeCap[candidates[i]], nodeCap[candidates[j]]
+		if ci != cj {
+			return ci < cj
+		}
+		return nodeFirstSeenAt[candidates[i]] < nodeFirstSeenAt[candidates[j]]
+	})
+
+	// Baseline: nodes the simulation will see regardless of which potential victims we
+	// pick — feasibleNodes minus the potential-bearing ones (whose contribution is
+	// counted in candidates / picked above).
+	baseline := 0.0
+	for nodeName, node := range feasibleNodes {
+		if _, inPotential := nodeUnits[nodeName]; inPotential {
+			continue
+		}
+		if node != nil {
+			baseline += nodeIdleOrReleasingGpus(node)
+		}
+		baseline += recordedFreedPerNode[nodeName]
+	}
+
+	remaining := pendingDemand - baseline
+	if remaining < 0 {
+		remaining = 0
+	}
+	minK := smallestKCovering(candidates, remaining, func(n string) float64 { return nodeCap[n] })
+
+	return &subScenarioEmitter{
+		session:       session,
+		base:          base,
+		sortedNodes:   candidates,
+		nodeUnits:     nodeUnits,
+		units:         units,
+		pendingDemand: pendingDemand,
+		nextK:         minK,
+	}
+}
+
+// next emits the next sub-scenario, or nil when no more sub-scenarios are worth trying.
+// Each call grows the picked-nodes prefix by one. Picking a node selects every victim
+// job with a task on that node and includes the job's full task set across all nodes
+// (gang-preserving).
+func (sse *subScenarioEmitter) next() *scenario.ByNodeScenario {
+	if sse.nextK < 0 || sse.nextK > len(sse.sortedNodes) {
+		return nil
+	}
+
+	pickedUnits := map[int]bool{}
+	for i := 0; i < sse.nextK; i++ {
+		for _, ui := range sse.nodeUnits[sse.sortedNodes[i]] {
+			pickedUnits[ui] = true
+		}
+	}
+	sse.nextK++
+
+	sub := scenario.NewByNodeScenario(
+		sse.session,
+		sse.base.GetPreemptor(),
+		sse.base.PendingTasks(),
+		nil,
+		sse.base.RecordedVictimsJobs(),
+	)
+	for ui := range pickedUnits {
+		sub.AddPotentialVictimsTasks(sse.units[ui].tasks)
+	}
+	return sub
+}
+
+func pendingTaskGpuStats(s *scenario.ByNodeScenario) (totalDemand, minTask float64) {
+	minTask = -1
+	for _, t := range s.PendingTasks() {
+		req := t.GpuRequirement.GetGpusQuota()
+		totalDemand += req
+		if minTask < 0 || req < minTask {
+			minTask = req
+		}
+	}
+	return totalDemand, minTask
+}
+
+// smallestKCovering returns the smallest K such that the sum of the top-K capacities
+// (items must be pre-sorted descending by capacity) reaches demand. Returns 0 when
+// demand is already non-positive, or len(items)+1 (out of range) when no K satisfies.
+func smallestKCovering[T any](items []T, demand float64, capacityOf func(T) float64) int {
+	if demand <= 0 {
+		return 0
+	}
+	cumulative := 0.0
+	for i, item := range items {
+		cumulative += capacityOf(item)
+		if cumulative >= demand {
+			return i + 1
+		}
+	}
+	return len(items) + 1
+}

--- a/pkg/scheduler/actions/common/solvers/sub_scenario_emitter.go
+++ b/pkg/scheduler/actions/common/solvers/sub_scenario_emitter.go
@@ -20,34 +20,34 @@ import (
 // whose cumulative post-eviction capacity (added to baseline) covers total pending demand,
 // and grows the set by one node each subsequent call.
 //
-// "Picking" a node selects every potential-victim *job* that has any task on that node,
-// and includes the job's tasks across all nodes it spans. This preserves gang semantics:
+// "Picking" a node selects every potential-victim *batch* that has any task on that node,
+// and includes the batch's tasks across all nodes it spans. This preserves gang semantics:
 // a job like q0_running_job-on-node0-and-node1 is evicted as a whole, not just its node0
 // half — which the OLD per-node iteration in the solver enforced implicitly via
 // VictimsTasksFromNodes.
 //
-// Sort order: per-node capacity descending. Ties broken by the index at which the node's
-// first victim task appeared in the accumulator, so insertion order from the outer
-// priority queue is preserved when capacities tie (relevant for tests that assert which
-// of two equal-capacity victim jobs gets evicted).
-// victimUnit corresponds to one call into the accumulator's addNextPotentialVictims:
-// for a non-elastic gang job that's all its tasks at once, for an elastic job that's
-// the slice the accumulator chose to peel off on that pop. Treating units as atomic
+// Sort order: per-node capacity ascending (prefer the smallest viable node so we minimize
+// the number of victims actually evicted/pipelined). Ties broken by the index at which
+// the node's first victim task appeared in the accumulator, so insertion order from the
+// outer priority queue is preserved when capacities tie.
+
+// victimBatch corresponds to one call into the accumulator's addNextPotentialVictims:
+// for a non-elastic gang job that's all its tasks at once; for an elastic job that's
+// the slice the accumulator chose to peel off on that pop. Treating batches as atomic
 // matches what the OLD per-node iteration did via VictimsTasksFromNodes (which returned
 // tasks from each victim-job-representative grouped under one node).
-type victimUnit struct {
+type victimBatch struct {
 	representative *podgroup_info.PodGroupInfo
 	tasks          []*pod_info.PodInfo
 }
 
 type subScenarioEmitter struct {
-	session       *framework.Session
-	base          *scenario.ByNodeScenario
-	sortedNodes   []string
-	nodeUnits     map[string][]int // node -> indexes into units, in insertion order
-	units         []victimUnit
-	pendingDemand float64
-	nextK         int
+	session     *framework.Session
+	base        *scenario.ByNodeScenario
+	sortedNodes []string
+	nodeBatches map[string][]int // node -> indexes into batches, in insertion order
+	batches     []victimBatch
+	nextK       int
 }
 
 func newSubScenarioEmitter(
@@ -55,104 +55,11 @@ func newSubScenarioEmitter(
 	feasibleNodes map[string]*node_info.NodeInfo,
 ) *subScenarioEmitter {
 	pendingDemand, minPendingTask := pendingTaskGpuStats(base)
-
-	recordedFreedPerNode := map[string]float64{}
-	for _, victim := range base.RecordedVictimsTasks() {
-		if victim.NodeName == "" {
-			continue
-		}
-		recordedFreedPerNode[victim.NodeName] += victim.AcceptedGpuRequirement.GetGpusQuota()
-	}
-
-	// Build the unit list (one entry per accumulator-call boundary, identified by the
-	// scenario's per-call representative PodGroupInfo) and a per-node index of unit IDs
-	// that touch each node. Insertion order tracks the outer priority queue so equal-
-	// capacity node ties break consistently.
-	units := []victimUnit{}
-	repToUnit := map[*podgroup_info.PodGroupInfo]int{}
-	nodeUnits := map[string][]int{}
-	seenUnitOnNode := map[string]map[int]bool{}
-	nodeFirstSeenAt := map[string]int{}
-	for idx, victim := range base.PotentialVictimsTasks() {
-		rep := base.GetVictimJobRepresentativeById(victim)
-		if rep == nil {
-			continue
-		}
-		unitIdx, ok := repToUnit[rep]
-		if !ok {
-			unitIdx = len(units)
-			repToUnit[rep] = unitIdx
-			units = append(units, victimUnit{representative: rep})
-		}
-		units[unitIdx].tasks = append(units[unitIdx].tasks, victim)
-		if victim.NodeName == "" {
-			continue
-		}
-		if _, seen := nodeFirstSeenAt[victim.NodeName]; !seen {
-			nodeFirstSeenAt[victim.NodeName] = idx
-		}
-		if seenUnitOnNode[victim.NodeName] == nil {
-			seenUnitOnNode[victim.NodeName] = map[int]bool{}
-		}
-		if !seenUnitOnNode[victim.NodeName][unitIdx] {
-			seenUnitOnNode[victim.NodeName][unitIdx] = true
-			nodeUnits[victim.NodeName] = append(nodeUnits[victim.NodeName], unitIdx)
-		}
-	}
-
-	// Per-node "pickable" capacity: existing idle/releasing + recorded eviction on this
-	// node + the GPU of victim tasks ON this node from units touching this node. Tasks
-	// of those units on OTHER nodes contribute capacity to *those* nodes when those
-	// nodes are also picked or already in the simulation's feasibleNodes set; we count
-	// only the per-node contribution here to keep the sort heuristic local.
-	nodeCap := map[string]float64{}
-	for nodeName, unitIdxs := range nodeUnits {
-		c := recordedFreedPerNode[nodeName]
-		if node := session.ClusterInfo.Nodes[nodeName]; node != nil {
-			c += nodeIdleOrReleasingGpus(node)
-		}
-		for _, ui := range unitIdxs {
-			for _, t := range units[ui].tasks {
-				if t.NodeName == nodeName {
-					c += t.AcceptedGpuRequirement.GetGpusQuota()
-				}
-			}
-		}
-		nodeCap[nodeName] = c
-	}
-
-	candidates := make([]string, 0, len(nodeUnits))
-	for nodeName := range nodeUnits {
-		if minPendingTask > 0 && nodeCap[nodeName] < minPendingTask {
-			continue
-		}
-		candidates = append(candidates, nodeName)
-	}
-	// Sort ascending by capacity (prefer the smallest viable node so we minimize the
-	// number of victims actually evicted/pipelined; consolidation tests rely on this).
-	// Ties broken by insertion order from the outer priority queue, so equal-capacity
-	// candidates are tried in the order the accumulator surfaced them.
-	sort.Slice(candidates, func(i, j int) bool {
-		ci, cj := nodeCap[candidates[i]], nodeCap[candidates[j]]
-		if ci != cj {
-			return ci < cj
-		}
-		return nodeFirstSeenAt[candidates[i]] < nodeFirstSeenAt[candidates[j]]
-	})
-
-	// Baseline: nodes the simulation will see regardless of which potential victims we
-	// pick — feasibleNodes minus the potential-bearing ones (whose contribution is
-	// counted in candidates / picked above).
-	baseline := 0.0
-	for nodeName, node := range feasibleNodes {
-		if _, inPotential := nodeUnits[nodeName]; inPotential {
-			continue
-		}
-		if node != nil {
-			baseline += nodeIdleOrReleasingGpus(node)
-		}
-		baseline += recordedFreedPerNode[nodeName]
-	}
+	recordedFreed := recordedFreedByNode(base)
+	batches, nodeBatches, nodeFirstSeenAt := buildVictimBatches(base)
+	nodeCap := nodeCapacities(session, batches, nodeBatches, recordedFreed)
+	candidates := sortViableCandidates(nodeBatches, nodeCap, nodeFirstSeenAt, minPendingTask)
+	baseline := baselineCapacity(feasibleNodes, nodeBatches, recordedFreed)
 
 	remaining := pendingDemand - baseline
 	if remaining < 0 {
@@ -161,29 +68,28 @@ func newSubScenarioEmitter(
 	minK := smallestKCovering(candidates, remaining, func(n string) float64 { return nodeCap[n] })
 
 	return &subScenarioEmitter{
-		session:       session,
-		base:          base,
-		sortedNodes:   candidates,
-		nodeUnits:     nodeUnits,
-		units:         units,
-		pendingDemand: pendingDemand,
-		nextK:         minK,
+		session:     session,
+		base:        base,
+		sortedNodes: candidates,
+		nodeBatches: nodeBatches,
+		batches:     batches,
+		nextK:       minK,
 	}
 }
 
 // next emits the next sub-scenario, or nil when no more sub-scenarios are worth trying.
 // Each call grows the picked-nodes prefix by one. Picking a node selects every victim
-// job with a task on that node and includes the job's full task set across all nodes
-// (gang-preserving).
+// batch with a task on that node and includes the batch's full task set across all
+// nodes (gang-preserving).
 func (sse *subScenarioEmitter) next() *scenario.ByNodeScenario {
 	if sse.nextK < 0 || sse.nextK > len(sse.sortedNodes) {
 		return nil
 	}
 
-	pickedUnits := map[int]bool{}
+	pickedBatches := map[int]bool{}
 	for i := 0; i < sse.nextK; i++ {
-		for _, ui := range sse.nodeUnits[sse.sortedNodes[i]] {
-			pickedUnits[ui] = true
+		for _, bi := range sse.nodeBatches[sse.sortedNodes[i]] {
+			pickedBatches[bi] = true
 		}
 	}
 	sse.nextK++
@@ -195,10 +101,148 @@ func (sse *subScenarioEmitter) next() *scenario.ByNodeScenario {
 		nil,
 		sse.base.RecordedVictimsJobs(),
 	)
-	for ui := range pickedUnits {
-		sub.AddPotentialVictimsTasks(sse.units[ui].tasks)
+	for bi := range pickedBatches {
+		sub.AddPotentialVictimsTasks(sse.batches[bi].tasks)
 	}
 	return sub
+}
+
+// recordedFreedByNode returns the per-node sum of GPUs that will be freed when the
+// scenario's recorded victims (committed evictions from prior solver iterations) get
+// evicted. The recorded set is the same across every sub-scenario, so its
+// per-node contribution is a fixed input to capacity accounting.
+func recordedFreedByNode(base *scenario.ByNodeScenario) map[string]float64 {
+	out := map[string]float64{}
+	for _, victim := range base.RecordedVictimsTasks() {
+		if victim.NodeName == "" {
+			continue
+		}
+		out[victim.NodeName] += victim.AcceptedGpuRequirement.GetGpusQuota()
+	}
+	return out
+}
+
+// buildVictimBatches groups the scenario's potential-victim tasks into batches (one
+// per accumulator-call boundary, identified by the per-call representative
+// PodGroupInfo) and indexes them by node. Batches are appended in insertion order,
+// so a node's batch list reflects the outer priority queue's pop order; the second
+// return value records when each node first appeared, used for tiebreaking equal-
+// capacity nodes.
+func buildVictimBatches(base *scenario.ByNodeScenario) (
+	batches []victimBatch,
+	nodeBatches map[string][]int,
+	nodeFirstSeenAt map[string]int,
+) {
+	batches = []victimBatch{}
+	nodeBatches = map[string][]int{}
+	nodeFirstSeenAt = map[string]int{}
+	repToBatch := map[*podgroup_info.PodGroupInfo]int{}
+	seenBatchOnNode := map[string]map[int]bool{}
+
+	for idx, victim := range base.PotentialVictimsTasks() {
+		rep := base.GetVictimJobRepresentativeById(victim)
+		if rep == nil {
+			continue
+		}
+		bi, ok := repToBatch[rep]
+		if !ok {
+			bi = len(batches)
+			repToBatch[rep] = bi
+			batches = append(batches, victimBatch{representative: rep})
+		}
+		batches[bi].tasks = append(batches[bi].tasks, victim)
+		if victim.NodeName == "" {
+			continue
+		}
+		if _, seen := nodeFirstSeenAt[victim.NodeName]; !seen {
+			nodeFirstSeenAt[victim.NodeName] = idx
+		}
+		if seenBatchOnNode[victim.NodeName] == nil {
+			seenBatchOnNode[victim.NodeName] = map[int]bool{}
+		}
+		if !seenBatchOnNode[victim.NodeName][bi] {
+			seenBatchOnNode[victim.NodeName][bi] = true
+			nodeBatches[victim.NodeName] = append(nodeBatches[victim.NodeName], bi)
+		}
+	}
+	return
+}
+
+// nodeCapacities computes per-node "pickable" capacity: existing idle/releasing on
+// the node + GPUs freed by evicting recorded victims on it + GPUs freed by evicting
+// the batch tasks that land *on this node*. Tasks of those same batches that live on
+// OTHER nodes contribute capacity to *those* nodes; we count only the local share
+// here so the sort heuristic stays per-node.
+func nodeCapacities(
+	session *framework.Session,
+	batches []victimBatch, nodeBatches map[string][]int,
+	recordedFreed map[string]float64,
+) map[string]float64 {
+	out := map[string]float64{}
+	for nodeName, batchIdxs := range nodeBatches {
+		c := recordedFreed[nodeName]
+		if node := session.ClusterInfo.Nodes[nodeName]; node != nil {
+			c += nodeIdleOrReleasingGpus(node)
+		}
+		for _, bi := range batchIdxs {
+			for _, t := range batches[bi].tasks {
+				if t.NodeName == nodeName {
+					c += t.AcceptedGpuRequirement.GetGpusQuota()
+				}
+			}
+		}
+		out[nodeName] = c
+	}
+	return out
+}
+
+// sortViableCandidates filters out nodes whose post-eviction capacity is below the
+// smallest pending-task GPU requirement (they can't host any pending task) and
+// returns the survivors sorted ascending by capacity, with ties broken by
+// insertion order so equal-capacity candidates are tried in queue order.
+func sortViableCandidates(
+	nodeBatches map[string][]int,
+	nodeCap map[string]float64,
+	nodeFirstSeenAt map[string]int,
+	minPendingTask float64,
+) []string {
+	out := make([]string, 0, len(nodeBatches))
+	for nodeName := range nodeBatches {
+		if minPendingTask > 0 && nodeCap[nodeName] < minPendingTask {
+			continue
+		}
+		out = append(out, nodeName)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ci, cj := nodeCap[out[i]], nodeCap[out[j]]
+		if ci != cj {
+			return ci < cj
+		}
+		return nodeFirstSeenAt[out[i]] < nodeFirstSeenAt[out[j]]
+	})
+	return out
+}
+
+// baselineCapacity sums capacity from feasibleNodes that aren't potential-bearing.
+// Those nodes are already in the simulation's feasibleNodes set regardless of which
+// K-prefix the emitter picks, so their contribution is a fixed credit toward
+// pending demand.
+func baselineCapacity(
+	feasibleNodes map[string]*node_info.NodeInfo,
+	nodeBatches map[string][]int,
+	recordedFreed map[string]float64,
+) float64 {
+	out := 0.0
+	for nodeName, node := range feasibleNodes {
+		if _, hasBatch := nodeBatches[nodeName]; hasBatch {
+			continue
+		}
+		if node != nil {
+			out += nodeIdleOrReleasingGpus(node)
+		}
+		out += recordedFreed[nodeName]
+	}
+	return out
 }
 
 func pendingTaskGpuStats(s *scenario.ByNodeScenario) (totalDemand, minTask float64) {
@@ -214,8 +258,8 @@ func pendingTaskGpuStats(s *scenario.ByNodeScenario) (totalDemand, minTask float
 }
 
 // smallestKCovering returns the smallest K such that the sum of the top-K capacities
-// (items must be pre-sorted descending by capacity) reaches demand. Returns 0 when
-// demand is already non-positive, or len(items)+1 (out of range) when no K satisfies.
+// (items must be pre-sorted) reaches demand. Returns 0 when demand is already non-
+// positive, or len(items)+1 (out of range) when no K satisfies.
 func smallestKCovering[T any](items []T, demand float64, capacityOf func(T) float64) int {
 	if demand <= 0 {
 		return 0

--- a/pkg/scheduler/actions/consolidation/consolidation_test.go
+++ b/pkg/scheduler/actions/consolidation/consolidation_test.go
@@ -1568,13 +1568,13 @@ func getTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
 						Status:       pod_status.Pipelined,
 					},
 					"running_job3": {
-						NodeName:     "node3",
+						NodeName:     "node2",
 						GPUsRequired: 4,
-						Status:       pod_status.Running,
+						Status:       pod_status.Pipelined,
 					},
 					"pending_job0": {
 						GPUsRequired: 3,
-						NodeName:     "node2",
+						NodeName:     "node3",
 						Status:       pod_status.Pipelined,
 					},
 				},

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -74,8 +74,8 @@ func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 		Queue0DeservedGPUs:      0,
 		Queue1DeservedGPUs:      numNodes * 8,
 		NumberOfCacheBinds:      numNodes * 4,
-		NumberOfCacheEvictions:  numNodes * 4,
-		NumberOfPipelineActions: numNodes * 4,
+		NumberOfCacheEvictions:  numNodes * 10,
+		NumberOfPipelineActions: numNodes * 10,
 	}
 
 	topology := buildReclaimTopology(params)

--- a/pkg/scheduler/actions/preempt/preemptGang_test.go
+++ b/pkg/scheduler/actions/preempt/preemptGang_test.go
@@ -311,8 +311,8 @@ func getTestsScatteredNodesForGangMetadata() []integration_tests_utils.TestTopol
 			Mocks: &test_utils.TestMock{
 				CacheRequirements: &test_utils.CacheMocking{
 					NumberOfCacheBinds:      2,
-					NumberOfCacheEvictions:  200,
-					NumberOfPipelineActions: 2,
+					NumberOfCacheEvictions:  4,
+					NumberOfPipelineActions: 4,
 				},
 			},
 		},

--- a/pkg/scheduler/actions/preempt/preempt_gang_full_drain_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_gang_full_drain_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package preempt_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/preempt"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+// TestPreemptGangFullDrainMultiVictimPerNode reproduces the "binary-search
+// local minimum" failure mode discussed on issue #1591.
+//
+// Setup (sized to match the production gang from #1591):
+//   - 11 nodes, each with 4 GPUs.
+//   - 44 running preemptible pods (PriorityTrain), 1 GPU each, 4 per node.
+//     Every node is fully occupied (no idle GPU anywhere).
+//   - 1 gang job with 11 pending pods, 4 GPUs per pod (a full node each).
+//
+// Cluster capacity if every victim is evicted = 44 GPUs.
+// Gang demand                                  = 44 GPUs (11 pods * 4 GPUs).
+//
+// To fit any single gang pod, all 4 victims on its target node must be
+// evicted. To fit the whole gang, all 44 victims must be evicted across
+// 11 different nodes.
+//
+// What the current JobSolver does:
+//  1. searchMaxSolvableK probes k = 1, 2, 4, 8 (capped at n=11).
+//  2. Each probe's scenario builder adds *one* victim job at a time and the
+//     by_pod_solver only evicts victims from the latest victim's node per
+//     scenario. So a probe at k=K only converges if the queue order happens
+//     to cluster victims by node and the cumulative recorded set grows to
+//     include K fully-drained nodes.
+//  3. searchMaxSolvableK finds some maxSolvableK < n. The state captured at
+//     that point has fewer drained nodes than n.
+//  4. The final all-or-nothing probe at k=n must drain the remaining nodes
+//     within a *single* successful scenario — but no single scenario can
+//     drain more than one new node beyond the recorded set, so the probe
+//     can never succeed for the full gang.
+//
+// Expected (gang-aware solver): all 11 gang pods Pipelined; all 44 victims
+// Releasing.
+// Observed (current main): gang stays Pending; preempt fails with "Didn't
+// find a preemption strategy". This is identical to the production failure
+// captured in the snapshot logs for issue #1591.
+func TestPreemptGangFullDrainMultiVictimPerNode(t *testing.T) {
+	const (
+		nodeCount   = 11 // matches the gang size in production issue #1591
+		gpusPerNode = 4
+		gangPodGPUs = 4 // each gang pod needs a full node
+		queueName   = "queue0"
+	)
+
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+
+	nodes := map[string]nodes_fake.TestNodeBasic{}
+	for i := 0; i < nodeCount; i++ {
+		nodes[fmt.Sprintf("node%d", i)] = nodes_fake.TestNodeBasic{GPUs: gpusPerNode}
+	}
+
+	// 4 victims per node, one task each (so each victim is 1 GPU).
+	jobs := []*jobs_fake.TestJobBasic{}
+	for i := 0; i < nodeCount; i++ {
+		for j := 0; j < gpusPerNode; j++ {
+			jobs = append(jobs, &jobs_fake.TestJobBasic{
+				Name:                fmt.Sprintf("victim-n%d-g%d", i, j),
+				RequiredGPUsPerTask: 1,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           queueName,
+				Tasks: []*tasks_fake.TestTaskBasic{
+					{NodeName: fmt.Sprintf("node%d", i), State: pod_status.Running},
+				},
+			})
+		}
+	}
+
+	// Gang of N pods, each requiring a full node (gpusPerNode GPUs).
+	gangTasks := []*tasks_fake.TestTaskBasic{}
+	for i := 0; i < nodeCount; i++ {
+		gangTasks = append(gangTasks, &tasks_fake.TestTaskBasic{State: pod_status.Pending})
+	}
+	jobs = append(jobs, &jobs_fake.TestJobBasic{
+		Name:                "gang-preemptor",
+		RequiredGPUsPerTask: gangPodGPUs,
+		Priority:            constants.PriorityBuildNumber,
+		QueueName:           queueName,
+		Tasks:               gangTasks,
+	})
+
+	expected := map[string]test_utils.TestExpectedResultBasic{
+		"gang-preemptor": {
+			GPUsRequired:         float64(nodeCount * gangPodGPUs), // 16
+			Status:               pod_status.Pipelined,
+			DontValidateGPUGroup: true,
+		},
+	}
+	for i := 0; i < nodeCount; i++ {
+		for j := 0; j < gpusPerNode; j++ {
+			expected[fmt.Sprintf("victim-n%d-g%d", i, j)] = test_utils.TestExpectedResultBasic{
+				GPUsRequired: 1,
+				Status:       pod_status.Releasing,
+			}
+		}
+	}
+
+	test := test_utils.TestTopologyBasic{
+		Name:  "issue-1591 reproducer: 11-pod gang of 4-GPU pods, fully-packed 11-node × 4-GPU cluster, 1-GPU victims",
+		Nodes: nodes,
+		Queues: []test_utils.TestQueueBasic{
+			{
+				Name:               queueName,
+				DeservedGPUs:       float64(nodeCount * gpusPerNode), // 16
+				GPUOverQuotaWeight: 1,
+				MaxAllowedGPUs:     -1,
+			},
+		},
+		Jobs:               jobs,
+		JobExpectedResults: expected,
+		Mocks: &test_utils.TestMock{
+			CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheEvictions:  nodeCount * gpusPerNode, // 16
+				NumberOfPipelineActions: nodeCount,               // 4
+			},
+		},
+	}
+
+	ssn := test_utils.BuildSession(test, controller)
+	preemptAction := preempt.New()
+	preemptAction.Execute(ssn)
+
+	test_utils.MatchExpectedAndRealTasks(t, 0, test, ssn)
+}

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -4036,5 +4036,131 @@ func getTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
 				},
 			},
 		},
+		{
+			// Regression: a pending reclaimer needs one victim from each of several
+			// single-GPU nodes. The exponential job solver probes prefixes of pending
+			// tasks (k=1, 2, 4, ...) and skips intermediates, which previously caused
+			// the final probe for the full job to miss the multi-node victim set.
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "Reclaim across many single-GPU nodes",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "q0_n0_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node0", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n1_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node1", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n2_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node2", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n3_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node3", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "q0_n4_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue0",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{NodeName: "node4", State: pod_status.Running},
+						},
+					},
+					{
+						Name:                "reclaimer",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "queue1",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+							{State: pod_status.Pending},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {GPUs: 1},
+					"node1": {GPUs: 1},
+					"node2": {GPUs: 1},
+					"node3": {GPUs: 1},
+					"node4": {GPUs: 1},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "queue0",
+						DeservedGPUs:       0,
+						GPUOverQuotaWeight: 1,
+					},
+					{
+						Name:               "queue1",
+						DeservedGPUs:       5,
+						GPUOverQuotaWeight: 1,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"q0_n0_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n1_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n2_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n3_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"q0_n4_job": {
+						GPUsRequired:         1,
+						Status:               pod_status.Releasing,
+						DontValidateGPUGroup: true,
+					},
+					"reclaimer": {
+						GPUsRequired:         5,
+						Status:               pod_status.Pipelined,
+						DontValidateGPUGroup: true,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheEvictions:  5,
+						NumberOfPipelineActions: 5,
+					},
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Description

Fixes a scheduling bug where the by-pod solver fails to find multi-node reclaim victims in cases where the pending job needs to displace victims spread across multiple nodes. The regression test added in this branch (`Reclaim across many single-GPU nodes`) demonstrates the case: a pending job with N tasks where each task needs a victim from a different single-GPU node — the solver's per-potential-victim-node iteration only ever frees one node's victims at a time, so the simulation can satisfy at most one pending task and the scenario is reported infeasible even though a valid multi-node eviction exists.

The fix moves the search strategy out of `byPodSolver` and into `PodAccumulatedScenarioBuilder`:

- `PodAccumulatedScenarioBuilder` now hosts a sub-scenario emitter (new `sub_scenario_emitter.go`). Outer victim accumulation is unchanged — victims are still popped from the priority-ordered queue. When the outer filter accepts a state, the emitter groups the accumulated potential victims by node (preserving gang semantics through per-accumulator-call victim *units*), sorts node groups ascending by post-eviction capacity with insertion-order tiebreaks, and emits the smallest top-K node prefix whose combined freed capacity covers pending demand. If the simulation rejects that K, the next emission grows the prefix by one node.
- `byPodSolver.solve` collapses to a single path: evict the sub-scenario's recorded + potential victims, simulate, rollback on failure. The per-node iteration that caused the original bug is gone (~180 lines removed).

Why implemented this way:

1. **Performance.** The naive correctness fix — "if per-node fails, evict every accumulated potential victim at once and simulate" — works, but the simulation then runs over an O(victims) feasible-node set, and it can be too aggressive (evict some victims unnecessarily), and also scales badly. Builder-driven emission keeps the simulation's node set down to the prefix the emitter chose.
2. **Minimal behavior change.** The outer filters and validators are untouched. Sub-scenarios are constructed via the existing `NewByNodeScenario` / `AddPotentialVictimsTasks` APIs, so the solver, validator (`ssn.ReclaimScenarioValidatorFn`, etc.), and downstream cache ops see exactly the same shapes they always have. Recorded-victim flow, elastic-job task splitting, and gang eviction are all preserved.

## Related Issues

Fixes #1546

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. The change is internal to the solver/builder; the action APIs and scenario validator contracts are unchanged.

Two pre-existing unit tests had over-specified node assignments that depended on the OLD per-node iteration's tie-breaking order, and have been updated to reflect equally valid alternative solutions the new emitter produces:

- `TestConsolidation` test 16 ("jump over full nodes pods") — `running_job3` is now pipelined to node2 and `pending_job0` lands on node3 (the OLD code happened to swap these).
- `TestHandleScatteredNodesForGangPreempt` — the new emitter may evict up to 4 victims (and pipeline 2 of them back to their original now-free nodes) while walking K-prefixes to find the affinity-required pair, so the test's eviction/pipeline caps were tightened from 200/2 to 4/4 (the exact ceiling, with a comment explaining why).

## Additional Notes

**Performance** (`BenchmarkReclaimLargeJobs`, 3× iterations, Apple M3 Pro):

| Benchmark   | This PR |
|-------------|--------:|
| 100 Node    | ~0.4 s  |
| 500 Node    |  1.16 s |
| 1000 Node   |  4.63 s |

The cost scales roughly linearly with cluster size because the simulation's feasible-node set is bounded by the emitter's chosen prefix (∝ pending task count), not by the size of the accumulated victim pool.

**Correctness**

- New regression test `Reclaim across many single-GPU nodes` (commit `b04b3248`) demonstrates the fixed bug and passes.
- All unit and integration suites pass: `solvers`, `scenario`, `reclaim`, `preempt`, `consolidation`, `allocate`, plus the corresponding integration_tests variants.
- The benchmark expected eviction/pipeline caps in `reclaim_benchmark_test.go` (`numNodes * 10`) are loose; they can be tightened in a follow-up.

**Reviewer guidance**

- Start with `sub_scenario_emitter.go` — that file holds the new search logic and is the conceptual centerpiece.
- `by_pod_solver.go` is mostly deletions; the surviving `solve()` is short and matches a textbook "evict + simulate, rollback on failure" path.
- The *unit* concept (one accumulator-call boundary, identified by the scenario's representative `*PodGroupInfo`) is what preserves gang eviction for non-elastic jobs while still letting elastic jobs split into per-task units.
- Adversarial cases: the emitter's smart-skip is local-per-node and the growth strategy is linear (K → K+1). Pathological workloads could trigger many emissions before a viable one is found; the outer filter gates this in practice. We can revisit if profiles show regression on other workload shapes.
