### PR TITLE
build: rebuild crd-upgrader image on alpine to shrink hook image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Breaking:** JobSet PodGroups no longer auto-calculate `minAvailable` from `parallelism × replicas`. The default is now 1. Use the `kai.scheduler/batch-min-member` annotation to set a custom value.
 - Bumped `k8s.io/*` module group from v0.34.x to v0.35.4, `k8s.io/kubernetes` to v1.35.4, and `sigs.k8s.io/controller-runtime` to v0.23.3, enabling KEP-4671 Workload API types. [#1466](https://github.com/kai-scheduler/KAI-Scheduler/issues/1466)
+- Rebuilt the `crd-upgrader` hook image on `gcr.io/distroless/static-debian12:nonroot` and removed the `apply-crds.sh` shell wrapper, invoking `kubectl` directly as the entrypoint. Image size drops from ~165 MB to ~59 MB uncompressed (~64% reduction), shrinking cold-pull latency on ephemeral CI runners. [#1404](https://github.com/kai-scheduler/KAI-Scheduler/issues/1404)
 
 ### Fixed
 - Fixed `additionalImagePullSecrets` in Config CR rendering as `map[name:...]` instead of plain strings by extracting `.name` from `global.imagePullSecrets` objects. Also propagated `global.imagePullSecrets` to all Helm hook jobs (`crd-upgrader`, `topology-migration`, `post-delete-cleanup`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Breaking:** JobSet PodGroups no longer auto-calculate `minAvailable` from `parallelism × replicas`. The default is now 1. Use the `kai.scheduler/batch-min-member` annotation to set a custom value.
 - Bumped `k8s.io/*` module group from v0.34.x to v0.35.4, `k8s.io/kubernetes` to v1.35.4, and `sigs.k8s.io/controller-runtime` to v0.23.3, enabling KEP-4671 Workload API types. [#1466](https://github.com/kai-scheduler/KAI-Scheduler/issues/1466)
-- Rebuilt the `crd-upgrader` hook image on `gcr.io/distroless/static-debian12:nonroot` and removed the `apply-crds.sh` shell wrapper, invoking `kubectl` directly as the entrypoint. Image size drops from ~165 MB to ~59 MB uncompressed (~64% reduction), shrinking cold-pull latency on ephemeral CI runners. [#1404](https://github.com/kai-scheduler/KAI-Scheduler/issues/1404)
+- Rebuilt the `crd-upgrader` hook image on `alpine:3.20` instead of `ubi9/ubi-minimal`. Image size drops from ~165 MB to ~67 MB uncompressed (~60% reduction), shrinking cold-pull latency on ephemeral CI runners. The image is also reused by the `topology-migration` and `post-delete` hook jobs as a generic `kubectl + bash` toolbox, so bash is preserved on the runtime image. [#1404](https://github.com/kai-scheduler/KAI-Scheduler/issues/1404)
 
 ### Fixed
 - Fixed `additionalImagePullSecrets` in Config CR rendering as `map[name:...]` instead of plain strings by extracting `.name` from `global.imagePullSecrets` objects. Also propagated `global.imagePullSecrets` to all Helm hook jobs (`crd-upgrader`, `topology-migration`, `post-delete-cleanup`)

--- a/deployments/crd-upgrader/Dockerfile
+++ b/deployments/crd-upgrader/Dockerfile
@@ -3,15 +3,20 @@
 
 ARG KUBECTL_VERSION=v1.35.0
 
-FROM curlimages/curl:8.11.1 AS kubectl-fetch
+FROM alpine:3.20 AS kubectl-fetch
 ARG TARGETARCH
 ARG KUBECTL_VERSION
-RUN curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+RUN apk add --no-cache curl \
+ && curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
  && chmod 0755 /tmp/kubectl
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM alpine:3.20
+RUN apk add --no-cache bash ca-certificates
 COPY --from=kubectl-fetch /tmp/kubectl /usr/bin/kubectl
 COPY deployments/kai-scheduler/crds /internal-crds
 COPY NOTICE /NOTICE
+COPY deployments/crd-upgrader/apply-crds.sh /apply-crds.sh
+RUN chmod 0755 /apply-crds.sh
+
 USER 65532:65532
-ENTRYPOINT ["/usr/bin/kubectl", "apply", "--server-side=true", "--force-conflicts", "-f", "/internal-crds"]
+CMD ["/apply-crds.sh"]

--- a/deployments/crd-upgrader/Dockerfile
+++ b/deployments/crd-upgrader/Dockerfile
@@ -1,18 +1,17 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+ARG KUBECTL_VERSION=v1.35.0
+
+FROM curlimages/curl:8.11.1 AS kubectl-fetch
 ARG TARGETARCH
-ENV TARGETARCH=$TARGETARCH
-RUN curl -o kubectl -L "https://dl.k8s.io/release/v1.35.0/bin/linux/$TARGETARCH/kubectl" \
-&& chmod +x kubectl && mv kubectl /usr/bin/kubectl
+ARG KUBECTL_VERSION
+RUN curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+ && chmod 0755 /tmp/kubectl
 
-
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=kubectl-fetch /tmp/kubectl /usr/bin/kubectl
 COPY deployments/kai-scheduler/crds /internal-crds
-COPY NOTICE .
-COPY deployments/crd-upgrader/apply-crds.sh /apply-crds.sh
-RUN chmod +x /apply-crds.sh
-
+COPY NOTICE /NOTICE
 USER 65532:65532
-
-CMD ["/apply-crds.sh"]
+ENTRYPOINT ["/usr/bin/kubectl", "apply", "--server-side=true", "--force-conflicts", "-f", "/internal-crds"]

--- a/deployments/crd-upgrader/Dockerfile
+++ b/deployments/crd-upgrader/Dockerfile
@@ -1,18 +1,13 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+FROM alpine:3.20
+ARG TARGETARCH
 ARG KUBECTL_VERSION=v1.35.0
 
-FROM alpine:3.20 AS kubectl-fetch
-ARG TARGETARCH
-ARG KUBECTL_VERSION
-RUN apk add --no-cache curl \
- && curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
- && chmod 0755 /tmp/kubectl
-
-FROM alpine:3.20
 RUN apk add --no-cache bash ca-certificates
-COPY --from=kubectl-fetch /tmp/kubectl /usr/bin/kubectl
+ADD --chmod=0755 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" /usr/bin/kubectl
+
 COPY deployments/kai-scheduler/crds /internal-crds
 COPY NOTICE /NOTICE
 COPY deployments/crd-upgrader/apply-crds.sh /apply-crds.sh

--- a/deployments/crd-upgrader/apply-crds.sh
+++ b/deployments/crd-upgrader/apply-crds.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Copyright 2025 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
-
-
-# Using --force-conflicts to claim ownership of the CRDs from helm
-kubectl apply --server-side=true --force-conflicts -f /internal-crds

--- a/deployments/crd-upgrader/apply-crds.sh
+++ b/deployments/crd-upgrader/apply-crds.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Using --force-conflicts to claim ownership of the CRDs from helm
+kubectl apply --server-side=true --force-conflicts -f /internal-crds


### PR DESCRIPTION
## Description

Rebuilds the `crd-upgrader` Helm hook image on `alpine:3.20` instead of `registry.access.redhat.com/ubi9/ubi-minimal`. The image is reused by three hook jobs as a generic `kubectl + bash` toolbox (see `values.yaml`: "using crd-upgrader image for kubectl availability"):

- `crd-upgrader` Job — runs `apply-crds.sh` (single `kubectl apply`)
- `topology-migration` Job — runs `/bin/bash /scripts/migrate-topologies.sh`
- `post-delete` Job — runs `/bin/sh -c "<inline kubectl>"`

So the image must keep a shell. Alpine + bash gives that for ~7 MB instead of ubi-minimal's ~105 MB.

### Size impact

| | Today (ubi-minimal + bash + kubectl) | This PR (alpine + bash + kubectl) |
|---|---|---|
| Uncompressed | ~165 MB | **~67 MB** |
| Reduction | — | **~60% / ~98 MB on the wire** |

Measured locally on `linux/amd64`:

```
docker image inspect kai-crd-upgrader:alpine-test -> 70,027,382 bytes (~66.8 MB)
```

Layer breakdown of the new image: ~58.6 MB `kubectl` v1.35.0 + ~5 MB alpine base + ~2 MB bash + ca-certificates + ~1 MB bundled CRDs + scripts.

### History of this PR

The first commit (`build(crd-upgrader): switch base to distroless/static, drop shell wrapper`) was an over-eager redesign — it removed the shell and made `kubectl` the entrypoint, dropping the image to ~59 MB. CI surfaced that this broke the `topology-migration` and `post-delete` jobs, which override the entrypoint with bash scripts via configmap. The follow-up commit restores the shell and keeps `apply-crds.sh` as the CMD, settling on alpine + bash for a still-substantial 60% reduction.

If we ever want to drive the image down to ~59 MB, the right path is to extract the `migrate-topologies.sh` and post-delete inline-kubectl logic into a small Go binary on `distroless/static` — but that is a separate, larger refactor.

### Behavior parity

Identical: `kubectl apply --server-side=true --force-conflicts -f /internal-crds` runs as the default CMD via `apply-crds.sh`. The chart templates that override the entrypoint (`topology-migration`, `post-delete`) keep working unchanged because `/bin/bash` and `/bin/sh` remain available in the image. `USER 65532:65532` is preserved.

The runtime services (scheduler, binder, operator, podgrouper, etc.) are unaffected — this only changes the install/upgrade-time hook image, which no operator or customer ever sees and which exits in seconds.

## Related Issues

Refs #1404 (image-size suggestion in the issue body)

Companion to #1534 (already merged), which addressed the chart-side items from the same issue (hook delete policy + per-component registry override). This PR is independent.

## Checklist

- [x] Self-reviewed
- [x] Image build verified locally (`docker buildx build --platform linux/amd64`)
- [x] Smoke tests: `bash --version` (5.2.26 confirmed), `kubectl version --client`, `apply-crds.sh` runs and reaches kubectl
- [x] CHANGELOG.md updated

## Breaking Changes

None for users. The Dockerfile is internal; the hook contract (apply CRDs, exit) is unchanged.

## Additional Notes

ubi9/ubi-minimal was originally chosen presumably for Red Hat ecosystem alignment. For long-running services that show up in customer environments (scheduler, binder, etc.) that alignment carries weight; for an install-time hook image that runs once and exits, alpine is a reasonable trade for a 60% size cut. Happy to revisit base choice in review.
