### PR TITLE
fix(operator): reconcile on Prometheus and ServiceMonitor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed `skipTopOwnerGrouper` not propagating per-type defaults (priority class and preemptibility) for skipped owners (e.g. `DynamoGraphDeployment`), causing PodGroup spec to retain stale values after defaults ConfigMap updates.
 - Fixed binder DRA detection on clusters where the upstream `DynamicResourceAllocation` feature gate does not reflect server-side DRA availability. The binder now probes the API server during init (matching the scheduler) so the DRA plugin is gated on the same authoritative decision. [#1481](https://github.com/kai-scheduler/KAI-Scheduler/issues/1481)
 - Suppressed noisy `Reconciler error` logs and `PodGrouperWarning` events on transient PodGroup update conflicts. The podgrouper now treats `IsConflict` errors as expected and silently requeues the reconcile instead of surfacing the apiserver's "object has been modified" message.
+- Fixed kai-operator not reconciling on Prometheus and ServiceMonitor changes. The Config controller now watches owned `Prometheus` and `ServiceMonitor` resources, so deletions and drift trigger reconciliation. CRD presence is checked at startup against the API server (the scheme-only check used previously could not detect missing CRDs), and the watch is registered only when the CRDs are installed. [#877](https://github.com/kai-scheduler/KAI-Scheduler/issues/877)
 
 ## [v0.14.0] - 2026-03-30
 

--- a/pkg/operator/operands/known_types/prometheus.go
+++ b/pkg/operator/operands/known_types/prometheus.go
@@ -26,23 +26,32 @@ func prometheusIndexer(object client.Object) []string {
 }
 
 func registerPrometheus() {
-	// Only register Prometheus collectable if CRD is available
-	// We'll check this at runtime during manager initialization
+	var prometheusCRDAvailable bool
 	collectable := &Collectable{
 		Collect: getCurrentPrometheusState,
 		InitWithManager: func(ctx context.Context, mgr manager.Manager) error {
-			// Try to register the indexer, but don't fail if the CRD is not available
 			log.FromContext(ctx).Info("Attempting to register Prometheus resource management")
-			err := mgr.GetFieldIndexer().IndexField(ctx, &monitoringv1.Prometheus{}, CollectableOwnerKey, prometheusIndexer)
+			available, err := crdAvailable(ctx, mgr, "prometheus")
 			if err != nil {
-				log.FromContext(ctx).Info("Prometheus CRD not available, skipping field indexer registration", "error", err)
-				return nil // Don't fail the test if CRD is not available
+				log.FromContext(ctx).Info("Failed to check Prometheus CRD availability, skipping registration", "error", err)
+				return nil
 			}
+			if !available {
+				log.FromContext(ctx).Info("Prometheus CRD not available, skipping registration")
+				return nil
+			}
+			if err := mgr.GetFieldIndexer().IndexField(ctx, &monitoringv1.Prometheus{}, CollectableOwnerKey, prometheusIndexer); err != nil {
+				return err
+			}
+			prometheusCRDAvailable = true
 			log.FromContext(ctx).Info("Successfully registered Prometheus resource management")
 			return nil
 		},
-		InitWithBuilder: func(builder *builder.Builder) *builder.Builder {
-			return builder
+		InitWithBuilder: func(b *builder.Builder) *builder.Builder {
+			if !prometheusCRDAvailable {
+				return b
+			}
+			return b.Owns(&monitoringv1.Prometheus{})
 		},
 		InitWithFakeClientBuilder: func(fakeClientBuilder *fake.ClientBuilder) {
 			fakeClientBuilder.WithIndex(&monitoringv1.Prometheus{}, CollectableOwnerKey, prometheusIndexer)
@@ -50,28 +59,49 @@ func registerPrometheus() {
 	}
 	SetupKAIConfigOwned(collectable)
 
-	// Register ServiceMonitor collectable if CRD is available
+	var serviceMonitorCRDAvailable bool
 	serviceMonitorCollectable := &Collectable{
 		Collect: getCurrentServiceMonitorState,
 		InitWithManager: func(ctx context.Context, mgr manager.Manager) error {
-			// Try to register the indexer, but don't fail if the CRD is not available
 			log.FromContext(ctx).Info("Attempting to register ServiceMonitor resource management")
-			err := mgr.GetFieldIndexer().IndexField(ctx, &monitoringv1.ServiceMonitor{}, CollectableOwnerKey, serviceMonitorIndexer)
+			available, err := crdAvailable(ctx, mgr, "serviceMonitor")
 			if err != nil {
-				log.FromContext(ctx).Info("ServiceMonitor CRD not available, skipping field indexer registration", "error", err)
-				return nil // Don't fail the test if CRD is not available
+				log.FromContext(ctx).Info("Failed to check ServiceMonitor CRD availability, skipping registration", "error", err)
+				return nil
 			}
+			if !available {
+				log.FromContext(ctx).Info("ServiceMonitor CRD not available, skipping registration")
+				return nil
+			}
+			if err := mgr.GetFieldIndexer().IndexField(ctx, &monitoringv1.ServiceMonitor{}, CollectableOwnerKey, serviceMonitorIndexer); err != nil {
+				return err
+			}
+			serviceMonitorCRDAvailable = true
 			log.FromContext(ctx).Info("Successfully registered ServiceMonitor resource management")
 			return nil
 		},
-		InitWithBuilder: func(builder *builder.Builder) *builder.Builder {
-			return builder
+		InitWithBuilder: func(b *builder.Builder) *builder.Builder {
+			if !serviceMonitorCRDAvailable {
+				return b
+			}
+			return b.Owns(&monitoringv1.ServiceMonitor{})
 		},
 		InitWithFakeClientBuilder: func(fakeClientBuilder *fake.ClientBuilder) {
 			fakeClientBuilder.WithIndex(&monitoringv1.ServiceMonitor{}, CollectableOwnerKey, serviceMonitorIndexer)
 		},
 	}
 	SetupKAIConfigOwned(serviceMonitorCollectable)
+}
+
+// crdAvailable performs a live API-server check for the given Prometheus-family CRD.
+// The manager scheme registers monitoringv1 unconditionally, so a scheme-only check
+// would falsely report availability on clusters without prometheus-operator installed.
+func crdAvailable(ctx context.Context, mgr manager.Manager, target string) (bool, error) {
+	tempClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return false, err
+	}
+	return common.CheckPrometheusCRDsAvailable(ctx, tempClient, target)
 }
 
 func getCurrentPrometheusState(ctx context.Context, runtimeClient client.Client, reconciler client.Object) (map[string]client.Object, error) {


### PR DESCRIPTION
## Description

The Config controller did not watch the owned `Prometheus` and `ServiceMonitor` resources, so deletions and out-of-band edits never enqueued a reconcile. Symptoms:

- Operator-managed Prometheus instances were not recreated after deletion.
- Drift on `Prometheus` / `ServiceMonitor` specs was not reverted.
- Status conditions on the `Config` went stale because reconciliation only ran on `Config` changes.

This PR registers the missing `.Owns(&monitoringv1.Prometheus{})` and `.Owns(&monitoringv1.ServiceMonitor{})` watches in `pkg/operator/operands/known_types/prometheus.go`.

The previous CRD-availability check relied on `GetFieldIndexer().IndexField` failing when the CRD was absent. That check could not actually detect a missing CRD because the `monitoringv1` scheme is registered unconditionally in `cmd/operator/app/app.go`. Without a real check, a bare `.Owns()` would crash the manager on clusters without prometheus-operator installed.

Replaced it with a live API-server check via `common.CheckPrometheusCRDsAvailable` (the same pattern used by `checkForClusterPolicy` for ClusterPolicy). Indexer registration and the new watch are both gated on actual CRD presence, so the operator still starts cleanly when prometheus-operator is not installed.

## Related Issues

Fixes #877

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed) — CHANGELOG entry added under Unreleased / Fixed

## Breaking Changes

None.

## Additional Notes

### Reviewer guidance

- The CRD check has to happen up-front because controller-runtime's `Owns()` sets up an informer at manager start; if the type's CRD isn't installed, the cache fails to sync and the manager dies.
- Since `InitWithBuilder` only receives a `*builder.Builder`, I capture availability in a closure variable set by `InitWithManager` (which runs first in `ConfigReconciler.SetupWithManager`).
- The runtime CRD check inside `getCurrentPrometheusState` / `getCurrentServiceMonitorState` is intentionally kept — `Collect` runs on every Config reconcile regardless of init outcome, and the runtime check protects the `List` call when the CRD is missing.

### Local verification

Repro from the issue against a kind cluster:

1. Install prometheus-operator CRDs **before** KAI:
   ```bash
   kubectl apply --server-side -f https://github.com/prometheus-operator/prometheus-operator/releases/latest/download/bundle.yaml
   ```
2. Apply a `Config` with `spec.prometheus.enabled: true`.
3. `kubectl delete prometheus.monitoring.coreos.com <name> -n <ns>` — the operator now recreates it.
4. Edit the Prometheus spec — the operator now reverts the drift.
5. Same for `ServiceMonitor`.

Also verified the no-CRD path: started the operator on a cluster without prometheus-operator installed; logs show `"Prometheus CRD not available, skipping registration"` and the manager starts cleanly.