### PR TITLE
feat(scheduler): Improve OrderedNodesByTask parallelization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/openshift/api v0.0.0-20250602203052-b29811a290c7
+	github.com/panjf2000/ants/v2 v2.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.88.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+L
 github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
 github.com/openshift/api v0.0.0-20250602203052-b29811a290c7 h1:dZ9uBd0Cw3+l1RGpYRkWdrRjM9yvfxrjW/uPHKUwtIQ=
 github.com/openshift/api v0.0.0-20250602203052-b29811a290c7/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
+github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
+github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -88,8 +88,9 @@ type Session struct {
 	SchedulerParams conf.SchedulerParams
 	mux             *http.ServeMux
 
-	k8sResourceStateCache sync.Map
-	nodeScoringPool       *ants.Pool
+	k8sResourceStateCache  sync.Map
+	nodeScoringPool        *ants.Pool
+	scoringPoolWorkerCount int
 }
 
 func (ssn *Session) Statement() *Statement {
@@ -237,15 +238,15 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 }
 
 // OrderedNodesByTask scores nodes for a task and returns them in order of their scores
-// The function is parallelized using multiple workers (up to GOMAXPROCS or number of nodes, whichever is smaller) to speed up the scoring process
+// The function is parallelized using multiple workers to speed up the scoring process
 func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_info.PodInfo) []*node_info.NodeInfo {
 	ssn.NodePreOrderFn(task, nodes)
 
-	numWorkers := max(min(runtime.GOMAXPROCS(0), len(nodes)), 1)
-	workerLocalScores := make([]map[float64][]*node_info.NodeInfo, numWorkers)
+	numWorkersToUseInParallel := min(ssn.scoringPoolWorkerCount, len(nodes))
+	workerLocalScores := make([]map[float64][]*node_info.NodeInfo, numWorkersToUseInParallel)
 
 	var wg sync.WaitGroup
-	chunkSize := (len(nodes) + numWorkers - 1) / numWorkers
+	chunkSize := (len(nodes) + numWorkersToUseInParallel - 1) / numWorkersToUseInParallel
 	scoreChunk := func(idx int) {
 		workerNodes := ssn.getWorkerNodes(nodes, idx, chunkSize)
 		if workerNodes == nil {
@@ -253,7 +254,7 @@ func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_in
 		}
 		workerLocalScores[idx] = ssn.scoreNodes(workerNodes, task)
 	}
-	for workerIdx := range numWorkers {
+	for workerIdx := range numWorkersToUseInParallel {
 		wg.Add(1)
 		idx := workerIdx
 		err := ssn.nodeScoringPool.Submit(func() {
@@ -261,9 +262,9 @@ func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_in
 			scoreChunk(idx)
 		})
 		if err != nil {
+			defer wg.Done()
 			log.InfraLogger.Errorf("Failed to submit node scoring task, running sequentially: %v", err)
 			scoreChunk(idx)
-			wg.Done()
 		}
 	}
 	wg.Wait()
@@ -376,11 +377,13 @@ func (ssn *Session) clear() {
 }
 
 func (ssn *Session) InitNodeScoringPool() error {
-	pool, err := ants.NewPool(runtime.GOMAXPROCS(0))
+	numWorkers := max(runtime.GOMAXPROCS(0), 1)
+	pool, err := ants.NewPool(numWorkers)
 	if err != nil {
 		return fmt.Errorf("failed to create node scoring pool: %w", err)
 	}
 	ssn.nodeScoringPool = pool
+	ssn.scoringPoolWorkerCount = numWorkers
 	runtime.SetFinalizer(ssn, func(s *Session) {
 		if s.nodeScoringPool != nil {
 			s.nodeScoringPool.Release()
@@ -434,6 +437,7 @@ func closeSession(ssn *Session) {
 
 	ssn.nodeScoringPool.Release()
 	ssn.nodeScoringPool = nil
+	ssn.scoringPoolWorkerCount = 0
 	ssn.clear()
 	stopCh := make(chan struct{})
 	ssn.Cache.WaitForWorkers(stopCh)

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -22,6 +22,7 @@ package framework
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -233,36 +234,61 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 	return true
 }
 
+// OrderedNodesByTask scores nodes for a task and returns them in order of their scores
+// The function is parallelized using multiple workers (up to GOMAXPROCS or number of nodes, whichever is smaller) to speed up the scoring process
 func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_info.PodInfo) []*node_info.NodeInfo {
-	var (
-		nodeScores = make(map[float64][]*node_info.NodeInfo)
-		mutex      sync.Mutex
-		wg         sync.WaitGroup
-	)
-
 	ssn.NodePreOrderFn(task, nodes)
 
-	for _, node := range nodes {
+	numWorkers := max(min(runtime.GOMAXPROCS(0), len(nodes)), 1)
+	workerLocalScores := make([]map[float64][]*node_info.NodeInfo, numWorkers)
+
+	var wg sync.WaitGroup
+	chunkSize := (len(nodes) + numWorkers - 1) / numWorkers
+	for workerIdx := range numWorkers {
 		wg.Add(1)
-		go func(node *node_info.NodeInfo) {
+		go func(workerIdx int) {
 			defer wg.Done()
-			score, err := ssn.NodeOrderFn(task, node)
-			if err != nil {
-				log.InfraLogger.Errorf("Error in Calculating Priority for the node:%v", err)
+			workerNodes := ssn.getWorkerNodes(nodes, workerIdx, chunkSize)
+			if workerNodes == nil {
 				return
 			}
-
-			mutex.Lock()
-			nodeScores[score] = append(nodeScores[score], node)
-			mutex.Unlock()
-
-			log.InfraLogger.V(5).Infof("Overall priority node score of node <%v> for task <%v/%v> is: %f",
-				node.Name, task.Namespace, task.Name, score)
-		}(node)
+			workerScores := ssn.scoreNodes(workerNodes, task)
+			workerLocalScores[workerIdx] = workerScores
+		}(workerIdx)
 	}
-
 	wg.Wait()
+
+	nodeScores := workerLocalScores[0]
+	for _, m := range workerLocalScores[1:] {
+		for score, ns := range m {
+			nodeScores[score] = append(nodeScores[score], ns...)
+		}
+	}
 	return sortNodesByScore(nodeScores)
+}
+
+func (ssn *Session) getWorkerNodes(nodes []*node_info.NodeInfo, workerIdx int, chunkSize int) []*node_info.NodeInfo {
+	start := workerIdx * chunkSize
+	end := min(start+chunkSize, len(nodes))
+	if start >= end {
+		return nil
+	}
+	return nodes[start:end]
+}
+
+func (ssn *Session) scoreNodes(nodes []*node_info.NodeInfo, task *pod_info.PodInfo) map[float64][]*node_info.NodeInfo {
+	workerScores := make(map[float64][]*node_info.NodeInfo)
+	for _, node := range nodes {
+		score, err := ssn.NodeOrderFn(task, node)
+		if err != nil {
+			log.InfraLogger.Errorf("Error in Calculating Priority for the node:%v", err)
+			continue
+		}
+		workerScores[score] = append(workerScores[score], node)
+		log.InfraLogger.V(5).Infof("Overall priority node score of node <%v> for task <%v/%v> is: %f",
+			node.Name, task.Namespace, task.Name, score)
+	}
+	return workerScores
 }
 
 func (ssn *Session) isTaskAllocatableOnNode(task *pod_info.PodInfo, job *podgroup_info.PodGroupInfo,

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -242,7 +242,7 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_info.PodInfo) []*node_info.NodeInfo {
 	ssn.NodePreOrderFn(task, nodes)
 
-	numWorkersToUseInParallel := min(ssn.scoringPoolWorkerCount, len(nodes))
+	numWorkersToUseInParallel := max(min(ssn.scoringPoolWorkerCount, len(nodes)), 1)
 	workerLocalScores := make([]map[float64][]*node_info.NodeInfo, numWorkersToUseInParallel)
 
 	var wg sync.WaitGroup

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/panjf2000/ants/v2"
 	"k8s.io/apimachinery/pkg/types"
 	ksf "k8s.io/kube-scheduler/framework"
 
@@ -88,6 +89,7 @@ type Session struct {
 	mux             *http.ServeMux
 
 	k8sResourceStateCache sync.Map
+	nodeScoringPool       *ants.Pool
 }
 
 func (ssn *Session) Statement() *Statement {
@@ -244,17 +246,25 @@ func (ssn *Session) OrderedNodesByTask(nodes []*node_info.NodeInfo, task *pod_in
 
 	var wg sync.WaitGroup
 	chunkSize := (len(nodes) + numWorkers - 1) / numWorkers
+	scoreChunk := func(idx int) {
+		workerNodes := ssn.getWorkerNodes(nodes, idx, chunkSize)
+		if workerNodes == nil {
+			return
+		}
+		workerLocalScores[idx] = ssn.scoreNodes(workerNodes, task)
+	}
 	for workerIdx := range numWorkers {
 		wg.Add(1)
-		go func(workerIdx int) {
+		idx := workerIdx
+		err := ssn.nodeScoringPool.Submit(func() {
 			defer wg.Done()
-			workerNodes := ssn.getWorkerNodes(nodes, workerIdx, chunkSize)
-			if workerNodes == nil {
-				return
-			}
-			workerScores := ssn.scoreNodes(workerNodes, task)
-			workerLocalScores[workerIdx] = workerScores
-		}(workerIdx)
+			scoreChunk(idx)
+		})
+		if err != nil {
+			log.InfraLogger.Errorf("Failed to submit node scoring task, running sequentially: %v", err)
+			scoreChunk(idx)
+			wg.Done()
+		}
 	}
 	wg.Wait()
 
@@ -365,6 +375,21 @@ func (ssn *Session) clear() {
 	ssn.JobOrderFns = nil
 }
 
+func (ssn *Session) InitNodeScoringPool() error {
+	pool, err := ants.NewPool(runtime.GOMAXPROCS(0))
+	if err != nil {
+		return fmt.Errorf("failed to create node scoring pool: %w", err)
+	}
+	ssn.nodeScoringPool = pool
+	runtime.SetFinalizer(ssn, func(s *Session) {
+		if s.nodeScoringPool != nil {
+			s.nodeScoringPool.Release()
+			s.nodeScoringPool = nil
+		}
+	})
+	return nil
+}
+
 func openSession(cache cache.Cache, sessionId string, schedulerParams conf.SchedulerParams, mux *http.ServeMux) (*Session, error) {
 	ssn := &Session{
 		ID:    sessionId,
@@ -376,6 +401,10 @@ func openSession(cache cache.Cache, sessionId string, schedulerParams conf.Sched
 		SchedulerParams:       schedulerParams,
 		mux:                   mux,
 		k8sResourceStateCache: sync.Map{},
+	}
+
+	if err := ssn.InitNodeScoringPool(); err != nil {
+		return nil, err
 	}
 
 	log.InfraLogger.V(2).Infof("Taking cluster snapshot ...")
@@ -403,6 +432,8 @@ func closeSession(ssn *Session) {
 		}
 	}
 
+	ssn.nodeScoringPool.Release()
+	ssn.nodeScoringPool = nil
 	ssn.clear()
 	stopCh := make(chan struct{})
 	ssn.Cache.WaitForWorkers(stopCh)

--- a/pkg/scheduler/test_utils/test_utils_builder.go
+++ b/pkg/scheduler/test_utils/test_utils_builder.go
@@ -76,6 +76,9 @@ func CreateFakeSession(schedulerConfig *TestSessionConfig,
 			QueueLabelKey: constants.DefaultQueueLabel,
 		},
 	}
+	if err := ssn.InitNodeScoringPool(); err != nil {
+		panic(err)
+	}
 	ssn.OverrideMaxNumberConsolidationPreemptees(-1)
 	ssn.OverrideAllowConsolidatingReclaim(true)
 	ssn.OverrideSchedulerName(schedulerName)


### PR DESCRIPTION
## Description

Improve OrderedNodesByTask parallelization - do not create a separate go routine for each node. Rather, have a pool of workers (based on the https://github.com/panjf2000/ants library) split the work between them

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
