### PR TITLE
fix(ci): keep scale tests dashboard from wiping benchmark history

### DIFF
--- a/.github/workflows/deploy-scale-tests-page.yaml
+++ b/.github/workflows/deploy-scale-tests-page.yaml
@@ -65,4 +65,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/scale-tests
           publish_branch: gh-pages
-          force_orphan: true
+          destination_dir: scale-tests

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Please open a [GitHub issue](https://github.com/kai-scheduler/KAI-scheduler/issu
 
 KAI Scheduler provides public dashboards for monitoring performance and scale testing:
 
-- **[Scale Tests Dashboard](https://kai-scheduler.github.io/KAI-Scheduler/)**: View historical results from scale tests that validate scheduler performance at large cluster sizes (hundreds to thousands of nodes). Tests run every 24 hours on dedicated infrastructure and measure scheduling performance, topology-aware scheduling, resource allocation, and system stability under load. The dashboard displays execution times, pass/fail status, detailed failure logs, and 30-day historical trends. See [scale tests documentation](docs/developer/scale-tests.md) for technical details.
+- **[Scale Tests Dashboard](https://kai-scheduler.github.io/KAI-Scheduler/scale-tests/)**: View historical results from scale tests that validate scheduler performance at large cluster sizes (hundreds to thousands of nodes). Tests run every 24 hours on dedicated infrastructure and measure scheduling performance, topology-aware scheduling, resource allocation, and system stability under load. The dashboard displays execution times, pass/fail status, detailed failure logs, and 30-day historical trends. See [scale tests documentation](docs/developer/scale-tests.md) for technical details.
 
 - **[Benchmarks Dashboard](https://kai-scheduler.github.io/KAI-Scheduler/dev/bench/)**: Track scheduler performance benchmarks across commits to the main branch. The dashboard shows per-commit benchmark history for core scheduler operations, with automatic alerts when performance regresses beyond thresholds.
 

--- a/docs/developer/scale-tests.md
+++ b/docs/developer/scale-tests.md
@@ -81,7 +81,7 @@ Minimal cluster requirements:
 
 - Tests run on dedicated infrastructure every 24 hours
 - Test results are stored in S3 and displayed on a public dashboard
-- Dashboard URL: [KAI Scheduler Scale Tests](https://kai-scheduler.github.io/KAI-Scheduler/) (update with actual URL after deployment)
+- Dashboard URL: [KAI Scheduler Scale Tests](https://kai-scheduler.github.io/KAI-Scheduler/scale-tests/) (update with actual URL after deployment)
 
 ## Results Dashboard
 

--- a/docs/developer/scale-tests.md
+++ b/docs/developer/scale-tests.md
@@ -81,7 +81,7 @@ Minimal cluster requirements:
 
 - Tests run on dedicated infrastructure every 24 hours
 - Test results are stored in S3 and displayed on a public dashboard
-- Dashboard URL: [KAI Scheduler Scale Tests](https://kai-scheduler.github.io/KAI-Scheduler/scale-tests/) (update with actual URL after deployment)
+- Dashboard URL: [KAI Scheduler Scale Tests](https://kai-scheduler.github.io/KAI-Scheduler/scale-tests/)
 
 ## Results Dashboard
 


### PR DESCRIPTION
## Description

The `Deploy Scale Tests Dashboard` workflow used `force_orphan: true`, which recreated `gh-pages` as a fresh orphan branch on every run and wiped the `dev/bench/` benchmark history published by `Benchmark History` (benchmark-main.yaml).

Switch the dashboard deploy to `destination_dir: scale-tests` so peaceiris/actions-gh-pages only manages files under that subdirectory, leaving `dev/bench/` (and any future siblings) untouched. The two workflows can now coexist on `gh-pages`.

URL change: dashboard moves from `https://kai-scheduler.github.io/KAI-Scheduler/` to `https://kai-scheduler.github.io/KAI-Scheduler/scale-tests/`. README and `docs/developer/scale-tests.md` updated to match.

Note: existing root-level dashboard files on `gh-pages` (`index.html`, `app.js`, etc.) will linger as orphans after this lands until manually cleaned. Harmless but stale — can be pruned by deleting the `gh-pages` branch and letting both workflows repopulate.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) — N/A, CI workflow change
- [x] Updated documentation (if needed)

## Breaking Changes

Public dashboard URL moves to `/scale-tests/` subpath.

## Additional Notes

CI-only change; no changelog entry per repo policy.