### PR TITLE
feat(ci): display commit hashes in scale test dashboard

### DIFF
--- a/docs/scale-tests/app.js
+++ b/docs/scale-tests/app.js
@@ -279,6 +279,13 @@ function renderRun(run, runIdx) {
   if (!specHtml) return '';
 
   const tsStr  = fmtDate(run.timestamp);
+  const commit = run.commit;
+  const commitHtml = commit
+    ? `<a href="https://github.com/kai-scheduler/KAI-Scheduler/commit/${esc(commit)}"
+         target="_blank"
+         class="commit-link"
+         title="${esc(commit)}">${esc(commit.substring(0, 8))}</a>`
+    : '<span class="commit-na">N/A</span>';
   const passed  = run.specs.filter(s => s.State === 'passed').length;
   const failed  = run.specs.filter(s => s.State === 'failed').length;
   const skipped = run.specs.filter(s => s.State === 'skipped' || s.State === 'pending').length;
@@ -292,6 +299,7 @@ function renderRun(run, runIdx) {
            aria-expanded="${autoOpen}" onkeydown="if(event.key==='Enter'||event.key===' ')toggleRun('${runId}')">
         <span class="chevron" aria-hidden="true">▶</span>
         <span class="run-ts">${esc(tsStr)}</span>
+        <span class="commit-display">${commitHtml}</span>
         <span class="run-desc">${esc(run.suite?.SuiteDescription || 'Scale Suite')}</span>
         <span class="run-dur">${esc(nsToHuman(run.suite?.RunTime))}</span>
         <div class="run-counts">
@@ -378,7 +386,7 @@ function processReport(reportJson, meta) {
   const specs   = (suite.SpecReports || []).filter(
     s => s.LeafNodeType === 'It' || s.State === 'failed'
   );
-  return { timestamp: meta.timestamp, path: meta.path, suite, specs };
+  return { timestamp: meta.timestamp, path: meta.path, commit: meta.commit, suite, specs };
 }
 
 async function init() {

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -152,6 +152,7 @@ function extractMetricsFromRuns(runs, config) {
         value: metric,
         legend: legend,
         testName: testName,
+        commit: run.commit,
       });
     });
   });
@@ -201,7 +202,7 @@ function createChart(canvasId, dataPoints, config) {
 
   const datasets = Object.entries(grouped).map(([legend, points], idx) => ({
     label: legend,
-    data: points.map(p => ({ x: p.timestamp, y: p.value })),
+    data: points.map(p => ({ x: p.timestamp, y: p.value, commit: p.commit })),
     borderColor: CHART_COLORS[idx % CHART_COLORS.length],
     backgroundColor: CHART_COLORS[idx % CHART_COLORS.length] + '20',
     borderWidth: 2,
@@ -243,13 +244,26 @@ function createChart(canvasId, dataPoints, config) {
           callbacks: {
             title: (items) => {
               if (items[0]) {
-                return new Date(items[0].parsed.x).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                });
+                const lines = [
+                  new Date(items[0].parsed.x).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })
+                ];
+
+                // Access commit from raw data
+                const datasetIndex = items[0].datasetIndex;
+                const dataIndex = items[0].dataIndex;
+                const rawData = items[0].chart.data.datasets[datasetIndex].data[dataIndex];
+
+                if (rawData.commit) {
+                  lines.push(`Commit: ${rawData.commit.substring(0, 8)}`);
+                }
+
+                return lines;
               }
               return '';
             },

--- a/docs/scale-tests/styles.css
+++ b/docs/scale-tests/styles.css
@@ -200,6 +200,30 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
 .run-dur  { color: var(--muted); font-size: 11px; font-family: monospace; white-space: nowrap; flex-shrink: 0; }
 .run-counts { margin-left: auto; display: flex; gap: 12px; font-size: 12px; flex-shrink: 0; align-items: center; }
 
+.commit-display {
+  font-size: 12px;
+  padding: 0 8px;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.commit-link {
+  font-family: monospace;
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.1s;
+}
+.commit-link:hover {
+  color: var(--text);
+  text-decoration: underline;
+}
+.commit-na {
+  font-family: monospace;
+  color: var(--muted);
+  opacity: 0.5;
+}
+
 .c-pass  { color: var(--pass); }
 .c-fail  { color: var(--fail); }
 .c-skip  { color: var(--skip); }


### PR DESCRIPTION
Add commit hash display to scale test dashboard in both the main test runs tab and the metrics tab tooltips. Commit hashes are shown as 8-character short hashes with clickable links to GitHub. The implementation is backward compatible with old runs that lack commit data (displays "N/A").

Changes:
- app.js: Extract and display commit hash in run headers
- metrics.js: Include commit hash in chart tooltip titles
- styles.css: Add styling for commit links and N/A display

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
