### PR TITLE
docs: example for external pod group

### DIFF
--- a/examples/external-podgroup/README.md
+++ b/examples/external-podgroup/README.md
@@ -1,0 +1,38 @@
+# External PodGroup Example: RayJob + batch/Job
+
+This example demonstrates how multiple independent workloads can be grouped
+into a single externally-created PodGroup for atomic scheduling.
+
+**Use case**: A post-training pipeline where a RayJob runs distributed training
+and a batch/Job runs evaluation. Both must be scheduled together or not at all.
+
+## Resources
+
+1. `podgroup.yaml` — The externally-created PodGroup (created first)
+2. `rayjob.yaml` — A RayJob whose pods reference the external PodGroup
+3. `batch-job.yaml` — A batch/Job whose pods reference the external PodGroup
+
+## Usage
+
+```bash
+# 1. Create the PodGroup first
+kubectl apply -f podgroup.yaml
+
+# 2. Create the workloads — their pods will join the existing PodGroup
+kubectl apply -f rayjob.yaml
+kubectl apply -f batch-job.yaml
+
+# 3. Watch scheduling events on the PodGroup
+kubectl describe podgroup post-training-pipeline -n default
+```
+
+## Important notes
+
+- The PodGroup must exist before the workloads are created.
+- All pods must have the `pod-group-name: <podgroup-name>` annotation.
+- All pods must use `schedulerName: kai-scheduler`.
+- The PodGroup's `spec.queue` must reference an existing KAI queue.
+- `spec.minMember` should reflect the total number of pods across all workloads
+  that must be schedulable before any pod is scheduled.
+- Without an `ownerReference`, the PodGroup is not garbage collected automatically.
+  Delete it manually when the pipeline completes.

--- a/examples/external-podgroup/batch-job.yaml
+++ b/examples/external-podgroup/batch-job.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Batch Job that references the same externally-created PodGroup.
+# Scheduled atomically together with the RayJob above.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-training-evaluation
+spec:
+  parallelism: 2
+  completions: 2
+  template:
+    metadata:
+      annotations:
+        pod-group-name: post-training-pipeline
+      labels:
+        kai.scheduler/queue: default-queue
+        kai.scheduler/subgroup-name: evaluation
+    spec:
+      schedulerName: kai-scheduler
+      restartPolicy: OnFailure
+      containers:
+        - name: eval
+          image: nvcr.io/nvidia/pytorch:24.01-py3
+          command: ["python", "-c", "print('Evaluation complete')"]
+          resources:
+            limits:
+              cpu: "1"
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "200m"

--- a/examples/external-podgroup/podgroup.yaml
+++ b/examples/external-podgroup/podgroup.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# External PodGroup for atomic scheduling of a post-training pipeline.
+# Created before the workloads so pods can reference it via the
+# "pod-group-name" annotation.
+
+apiVersion: scheduling.run.ai/v2alpha2
+kind: PodGroup
+metadata:
+  name: post-training-pipeline
+  namespace: default
+  labels:
+    kai.scheduler/queue: default-queue
+spec:
+  # Total pods: 1 Ray head + 2 Ray workers + 2 eval pods = 5
+  minMember: 5
+  queue: default-queue
+  priorityClassName: normal
+  # Require all pods to land in the same zone
+  topologyConstraint:
+    topology: "cluster-topology"
+    requiredTopologyLevel: "topology.kubernetes.io/zone"
+  subGroups:
+    - name: ray-head
+      minMember: 1
+    - name: ray-workers
+      minMember: 2
+      # Require Ray workers on the same rack for fast interconnect
+      topologyConstraint:
+        topology: "cluster-topology"
+        requiredTopologyLevel: "topology.kubernetes.io/rack"
+    - name: evaluation
+      minMember: 2

--- a/examples/external-podgroup/rayjob.yaml
+++ b/examples/external-podgroup/rayjob.yaml
@@ -1,0 +1,59 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# RayJob that references the externally-created PodGroup.
+# Pods are annotated with "pod-group-name" and "kai.scheduler/subgroup-name"
+# to join the shared PodGroup and appropriate SubGroups.
+
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: post-training-rayjob
+  labels:
+    kai.scheduler/queue: default-queue
+spec:
+  entrypoint: python /home/ray/train.py
+  rayClusterSpec:
+    rayVersion: '2.46.0'
+    headGroupSpec:
+      rayStartParams: {}
+      template:
+        metadata:
+          annotations:
+            pod-group-name: post-training-pipeline
+          labels:
+            kai.scheduler/subgroup-name: ray-head
+        spec:
+          schedulerName: kai-scheduler
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.46.0
+              resources:
+                limits:
+                  cpu: "1"
+                  nvidia.com/gpu: "1"
+                requests:
+                  cpu: "200m"
+    workerGroupSpecs:
+      - replicas: 2
+        minReplicas: 2
+        maxReplicas: 2
+        groupName: gpu-workers
+        rayStartParams: {}
+        template:
+          metadata:
+            annotations:
+              pod-group-name: post-training-pipeline
+            labels:
+              kai.scheduler/subgroup-name: ray-workers
+          spec:
+            schedulerName: kai-scheduler
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:2.46.0
+                resources:
+                  limits:
+                    cpu: "1"
+                    nvidia.com/gpu: "1"
+                  requests:
+                    cpu: "200m"


### PR DESCRIPTION
## Description

Example for external PodGroup that connects jobs from different sources to scheduler together as a gang.

## Related Issues

#1420