### PR TITLE
fix(scheduler): Add bindingRequests to the informer cache upon creation

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -321,9 +321,21 @@ func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName 
 		},
 	}
 
-	_, err := sc.kubeAiSchedulerClient.SchedulingV1alpha2().BindRequests(
+	createdBindRequest, err := sc.kubeAiSchedulerClient.SchedulingV1alpha2().BindRequests(
 		podInfo.Namespace).Create(context.TODO(), bindRequest, metav1.CreateOptions{})
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Expose scheduler-created BindRequests to the next snapshot before the informer watch catches up.
+	if err := sc.kubeAiSchedulerInformerFactory.Scheduling().V1alpha2().BindRequests().Informer().GetStore().Add(
+		createdBindRequest.DeepCopy(),
+	); err != nil {
+		log.InfraLogger.Warningf("Failed to add BindRequest <%s/%s> to informer store: %v",
+			createdBindRequest.Namespace, createdBindRequest.Name, err)
+	}
+
+	return nil
 }
 
 func (sc *SchedulerCache) getNodPoolName() string {


### PR DESCRIPTION
## Description

Add a copy of successfully created binding requests directly to the kubeAiSchedulerInformer cache to avoid cases like https://github.com/kai-scheduler/KAI-Scheduler/issues/1233

## Related Issues

Fixes #1233

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where bind requests created by the scheduler were not immediately visible to the scheduler's internal snapshot, ensuring more reliable request tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kai-scheduler/KAI-Scheduler/pull/1589)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->