### PR TITLE
Remove redundant ShouldCreatePodDisruptionBudget func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added support for configuring admission Pod Disruption Budget via Helm values (`admission.podDisruptionBudget`) [#1490](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490) [dttung2905](https://github.com/dttung2905)
 
 ### Changed
+- Removed redundant `PodDisruptionBudgetImplemented` guard from operator PDB creation helper [#1613](https://github.com/kai-scheduler/KAI-Scheduler/pull/1613) [dttung2905](https://github.com/dttung2905)
 
 ### Fixed
 

--- a/pkg/operator/operands/common/common.go
+++ b/pkg/operator/operands/common/common.go
@@ -179,10 +179,7 @@ func DeploymentForKAIConfig(
 	return deployment, nil
 }
 
-func ShouldCreatePodDisruptionBudget(serviceName string, replicas *int32, service *kaiv1common.Service) bool {
-	if !PodDisruptionBudgetImplemented(serviceName) {
-		return false
-	}
+func ShouldCreatePodDisruptionBudget(replicas *int32, service *kaiv1common.Service) bool {
 	if replicas == nil || *replicas <= 1 {
 		return false
 	}
@@ -200,7 +197,7 @@ func PodDisruptionBudgetForKAIConfig(
 	replicas *int32,
 	service *kaiv1common.Service,
 ) (client.Object, error) {
-	if !ShouldCreatePodDisruptionBudget(resourceName, replicas, service) {
+	if !ShouldCreatePodDisruptionBudget(replicas, service) {
 		return nil, nil
 	}
 

--- a/pkg/operator/operands/common/common_test.go
+++ b/pkg/operator/operands/common/common_test.go
@@ -512,26 +512,6 @@ var _ = Describe("PodDisruptionBudgetForKAIConfig", func() {
 		Expect(obj).To(BeNil())
 	})
 
-	It("does not create PDB for services without operator implementation", func() {
-		fakeKubeClient := fake.NewClientBuilder().Build()
-		service := &kaiv1common.Service{
-			PodDisruptionBudget: &kaiv1common.PodDisruptionBudget{
-				Enabled:        ptr.To(true),
-				MaxUnavailable: ptr.To(int32(1)),
-			},
-		}
-
-		obj, err := PodDisruptionBudgetForKAIConfig(
-			context.Background(),
-			fakeKubeClient,
-			"default",
-			"binder",
-			ptr.To(int32(2)),
-			service,
-		)
-		Expect(err).To(BeNil())
-		Expect(obj).To(BeNil())
-	})
 })
 
 var _ = Describe("PodDisruptionBudgetImplementedServices", func() {


### PR DESCRIPTION
Fixing redundant func ShouldCreatePodDisruptionBudget from this [comment](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490#discussion_r3271863340) from the maintainer

This is part of a bigger effort to implement PDB for relevant and key resources in kai. I will follow up with more PR but I'm just keeping this PR small for ease of review


## Description

<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
