### PR TITLE
Fix hardcoded namespace in post delete cleanup hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- Fixed post-delete cleanup hook hardcoding `kai-scheduler` namespace instead of Helm release namespace on `helm uninstall` [#1619](https://github.com/kai-scheduler/KAI-Scheduler/pull/1619) [dttung2905](https://github.com/dttung2905)
 
 ## [v0.15.0] - 2026-05-20
 

--- a/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
@@ -52,7 +52,7 @@ spec:
             - -c
             - |
               echo "Deleting deployments..."
-              kubectl -n kai-scheduler delete deployment --all --ignore-not-found=true
+              kubectl -n {{ .Release.Namespace }} delete deployment --all --ignore-not-found=true
 
               echo "Deleting kai-config..."
               kubectl delete Config kai-config --ignore-not-found

--- a/deployments/kai-scheduler/tests/post_delete_test.yaml
+++ b/deployments/kai-scheduler/tests/post_delete_test.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test post-delete cleanup hook
+templates:
+  - hooks/post/post-delete-job.yaml
+tests:
+  - it: should use release namespace in kubectl delete deployment command
+    release:
+      namespace: custom-ns
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl -n custom-ns delete deployment --all --ignore-not-found=true
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl -n kai-scheduler delete deployment
+
+  - it: should place the cleanup job in the release namespace
+    release:
+      namespace: custom-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: should not render when postCleanup is disabled
+    set:
+      postCleanup.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION


## Description

When KAI Scheduler is installed with Helm into a namespace other than `kai-scheduler`, the post-delete cleanup hook does not remove operator-managed Deployments from the install namespace on `helm uninstall`.

The post-delete Job template (`deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml`) correctly places the Job in the Helm release namespace:
https://github.com/kai-scheduler/KAI-Scheduler/blob/08625cfadb6e259a750edc7c6e6ab83631adc939/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml#L4-L8

However, the cleanup script inside the container hardcodes the target namespace:

https://github.com/kai-scheduler/KAI-Scheduler/blob/08625cfadb6e259a750edc7c6e6ab83631adc939/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml#L50-L60

Because `postCleanup.enabled` defaults to `true` in `values.yaml`, this hook runs on every uninstall unless explicitly disabled.

## Related Issues

Fixes https://github.com/kai-scheduler/KAI-Scheduler/issues/1618

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
