### PR TITLE
fix(scheduler): kai_pod_group_evicted_pods_total inflated by gang size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed scheduler nil-pointer panic in the preempt scenario builder when a (partial) job has no tasks to allocate (`NewIdleGpusFilter` dereferenced a nil scenario); added the missing nil-guard matching the sibling filters [#1664](https://github.com/kai-scheduler/KAI-Scheduler/issues/1664) [sam-huang1223](https://github.com/sam-huang1223)
 - Fixed default node-scale-adjuster image name (`node-scale-adjuster` → `nodescaleadjuster`) so it matches the image published to GHCR
 - Fixed duplicate GPU reservation pods being created for a single `gpu-group` on a node (each reserving a different physical GPU), which corrupted the scheduler's fractional-GPU accounting and left devices unschedulable. Reservation pods are now named deterministically per (node, gpu-group) and treat AlreadyExists as success, so concurrent or retried binds collide on one object instead of duplicating [#1673](https://github.com/kai-scheduler/KAI-Scheduler/issues/1673)
+- Fixed `kai_pod_group_evicted_pods_total` counter being inflated by gang size. The metric was incremented by `EvictionGangSize` (= N) on every per-pod eviction emit, so an N-pod gang eviction wrote N² to the counter instead of N (and a cross-PodGroup batch of size N inflated each PG's counter by `tasks_in_pg × N`). All eviction-emitting actions (preempt, reclaim, consolidation, stalegangeviction) were affected. [#1620](https://github.com/kai-scheduler/KAI-Scheduler/issues/1620)
 
 ## [v0.15.0] - 2026-05-20
 

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -123,7 +123,6 @@ func (su *defaultStatusUpdater) Evicted(
 		string(evictedPodGroup.UID),
 		nodepool,
 		evictionMetadata.Action,
-		evictionMetadata.EvictionGangSize,
 	)
 }
 

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -117,7 +117,7 @@ func (su *defaultStatusUpdater) Evicted(
 		message)
 
 	nodepool := utils.GetNodePoolNameFromLabels(evictedPodGroup.Labels, su.nodePoolLabelKey)
-	metrics.RecordPodGroupEvictedPods(
+	metrics.IncPodGroupEvictedPods(
 		evictedPodGroup.Name,
 		evictedPodGroup.Namespace,
 		string(evictedPodGroup.UID),

--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -5,14 +5,18 @@ package status_updater
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	faketesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -23,6 +27,7 @@ import (
 	enginev2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -820,4 +825,123 @@ func waitForIncrease(callCount *int) error {
 		return nil
 	}
 	return errors.New("update calls did not increase")
+}
+
+type annotatedEvent struct {
+	eventType   string
+	reason      string
+	message     string
+	annotations map[string]string
+}
+
+type annotationCapturingRecorder struct {
+	events []annotatedEvent
+}
+
+func (r *annotationCapturingRecorder) Event(_ runtime.Object, _, _, _ string) {}
+
+func (r *annotationCapturingRecorder) Eventf(_ runtime.Object, _, _, _ string, _ ...interface{}) {
+}
+
+func (r *annotationCapturingRecorder) AnnotatedEventf(_ runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.events = append(r.events, annotatedEvent{
+		eventType:   eventtype,
+		reason:      reason,
+		message:     fmt.Sprintf(messageFmt, args...),
+		annotations: annotations,
+	})
+}
+
+func newEvictionTestStatusUpdater() *defaultStatusUpdater {
+	kubeClient := fake.NewSimpleClientset()
+	kubeAiSchedClient := kubeaischedfake.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(100)
+	return New(kubeClient, kubeAiSchedClient, recorder, 1, false, nodePoolLabelKey)
+}
+
+func makeEvictionPodGroup(t *testing.T, suffix string) *enginev2alpha2.PodGroup {
+	tag := fmt.Sprintf("%s-%s", t.Name(), suffix)
+	return &enginev2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pg-" + tag,
+			Namespace: "ns-" + tag,
+			UID:       types.UID("uid-" + tag),
+		},
+	}
+}
+
+func getEvictedPodsCounterValue(t *testing.T, name, namespace, uid, nodepool, action string) (float64, bool) {
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != "pod_group_evicted_pods_total" {
+			continue
+		}
+		for _, m := range family.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["podgroup"] == name && labels["namespace"] == namespace &&
+				labels["uid"] == uid && labels["nodepool"] == nodepool && labels["action"] == action {
+				return m.GetCounter().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestEvicted_IncrementsCounterByOnePerCall(t *testing.T) {
+	tests := []struct {
+		name             string
+		callCount        int
+		evictionGangSize int
+	}{
+		{name: "one call, gang size 1", callCount: 1, evictionGangSize: 1},
+		{name: "one call, gang size 4", callCount: 1, evictionGangSize: 4},
+		{name: "four calls, gang size 4", callCount: 4, evictionGangSize: 4},
+		{name: "three calls, gang size 10", callCount: 3, evictionGangSize: 10},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pg := makeEvictionPodGroup(t, tc.name)
+			statusUpdater := newEvictionTestStatusUpdater()
+
+			for i := 0; i < tc.callCount; i++ {
+				statusUpdater.Evicted(pg, eviction_info.EvictionMetadata{
+					Action:           "preempt",
+					EvictionGangSize: tc.evictionGangSize,
+				}, "evicted")
+			}
+
+			value, found := getEvictedPodsCounterValue(t, pg.Name, pg.Namespace, string(pg.UID), "default", "preempt")
+			require.True(t, found, "counter sample was not emitted")
+			assert.Equal(t, float64(tc.callCount), value)
+		})
+	}
+}
+
+func TestEvicted_EmitsAnnotatedEventWithMetadata(t *testing.T) {
+	pg := makeEvictionPodGroup(t, "event")
+	recorder := &annotationCapturingRecorder{}
+	kubeClient := fake.NewSimpleClientset()
+	kubeAiSchedClient := kubeaischedfake.NewSimpleClientset()
+	statusUpdater := New(kubeClient, kubeAiSchedClient, recorder, 1, false, nodePoolLabelKey)
+
+	statusUpdater.Evicted(pg, eviction_info.EvictionMetadata{
+		Action:           "preempt",
+		EvictionGangSize: 5,
+		Preemptor:        &types.NamespacedName{Namespace: "preemptor-ns", Name: "preemptor"},
+	}, "pod evicted")
+
+	require.Len(t, recorder.events, 1)
+	event := recorder.events[0]
+	assert.Equal(t, v1.EventTypeNormal, event.eventType)
+	assert.Equal(t, "Evict", event.reason)
+	assert.Equal(t, "pod evicted", event.message)
+	assert.Equal(t, "5", event.annotations[evictionGangSize])
+	assert.Equal(t, "preempt", event.annotations[evictorActionType])
+	assert.Equal(t, "preemptor", event.annotations[evictorPodGroupNameAnnotations])
+	assert.Equal(t, "preemptor-ns", event.annotations[evictorPodGroupNamespaceAnnotations])
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -365,9 +365,9 @@ func RegisterPreemptionAttempts() {
 	preemptionAttempts.Inc()
 }
 
-// RecordPodGroupEvictedPods records the number of pods evicted for a pod group
-func RecordPodGroupEvictedPods(name, namespace, uid, nodepool, action string, count int) {
-	podGroupEvictedPodsTotal.WithLabelValues(name, namespace, uid, nodepool, action).Add(float64(count))
+// RecordPodGroupEvictedPods records a single pod eviction for a pod group.
+func RecordPodGroupEvictedPods(name, namespace, uid, nodepool, action string) {
+	podGroupEvictedPodsTotal.WithLabelValues(name, namespace, uid, nodepool, action).Inc()
 }
 
 func IncScenarioSearchJobs[A ~string](action A, result string, reducedBudget bool) {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -365,8 +365,8 @@ func RegisterPreemptionAttempts() {
 	preemptionAttempts.Inc()
 }
 
-// RecordPodGroupEvictedPods records a single pod eviction for a pod group.
-func RecordPodGroupEvictedPods(name, namespace, uid, nodepool, action string) {
+// IncPodGroupEvictedPods records a single pod eviction for a pod group.
+func IncPodGroupEvictedPods(name, namespace, uid, nodepool, action string) {
 	podGroupEvictedPodsTotal.WithLabelValues(name, namespace, uid, nodepool, action).Inc()
 }
 


### PR DESCRIPTION
## Description

`kai_pod_group_evicted_pods_total` was incremented by `EvictionGangSize` (= N) on every per-pod eviction emit. For an N-pod gang the counter grew by N² instead of N, and for batches spanning multiple PodGroups each PG inflated by `(its_tasks × batch_size)`. All eviction-emitting actions were affected: `preempt`, `reclaim`, `consolidation`, and `stalegangeviction`.

**Root cause** — `EvictionMetadata.EvictionGangSize` is informational (populates the per-pod event annotation `num-evicted-pods`), but was also passed as the `count` to `metrics.RecordPodGroupEvictedPods` at `pkg/scheduler/cache/status_updater/default_status_updater.go:126`. Each call to `defaultStatusUpdater.Evicted` represents exactly one pod evicted (the cache calls it per pod via `sc.evict`), so the counter should increment by 1, not by N. The const binding `evictionGangSize = "num-evicted-pods"` makes the original informational intent of the field clear.

**Fix** — drop the `count` parameter from `RecordPodGroupEvictedPods` and use `Inc()` so the API is structurally per-pod and the misuse vector is removed. Update the single caller. `EvictionGangSize` stays on `EvictionMetadata` (still used for the event annotation, line 107, unchanged).

Only one caller of the metric function exists, and only one implementation of the `StatusUpdater` interface — so fixing the boundary fixes every affected action with no further changes needed in `EvictAllPreemptees`, `stalegangeviction.handleStaleJob`, `Statement.Evict`, or `Cache.Evict`.

## Related Issues

Fixes #1620

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. `RecordPodGroupEvictedPods` is an internal scheduler-package function with a single caller; its signature change is internal.

## Additional Notes

### Tests added in `pkg/scheduler/cache/status_updater/default_status_updater_test.go`

1. **`TestEvicted_PodsCounter_GangSizeBug`** — verbatim from the issue. Simulates the `EvictAllPreemptees` loop: 4 `Evicted` calls each with `EvictionGangSize=4`. Pre-fix wrote 16, asserts == 4. Fails on `main`.
2. **`TestEvicted_PodsCounter_SinglePod`** — `EvictionGangSize=1`, regression guard for the case that was always correct (1²=1 masked the bug).
3. **`TestEvicted_PodsCounter_MultiplePodGroups`** — simulates `RecordedVictimsTasks()` flattening across PGs: 6 emits for PG-A and 4 for PG-B with `EvictionGangSize=10`. Pre-fix gave 60/40, asserts 6/4.
4. **`TestEvicted_PodsCounter_ActionLabelIsolation`** — two `Evicted` calls with different `Action` values; confirms the `action` label still partitions counters.
5. **`TestEvicted_EventAnnotationPreservesGangSize`** — verifies `num-evicted-pods=N` still appears on the per-pod event annotation, so the informational use of `EvictionGangSize` is preserved.

### Verification

- New tests pass; pre-fix `TestEvicted_PodsCounter_GangSizeBug` reproduces the exact 4→16 the issue describes.
- Full `pkg/scheduler/...`, `pkg/binder/...`, `pkg/operator/...`, `pkg/queuecontroller/...`, `pkg/podgrouper/...`, `pkg/podgroupcontroller/...`, `pkg/admission/...`, `pkg/env-tests/...` green under envtest.
- `make lint` clean (golangci-lint v2.11.3 via Docker).
- Helm chart tests pass.
- `CHANGELOG.md` updated under `Unreleased → Fixed`.