### PR TITLE
test: Do not run e2e tests on clusters with queues that do not have the e2e mark.

### DIFF
--- a/test/e2e/modules/context/context.go
+++ b/test/e2e/modules/context/context.go
@@ -46,6 +46,10 @@ func GetConnectivity(ctx context.Context, asserter gomega.Gomega) *TestContext {
 		asserter.Expect(err).NotTo(gomega.HaveOccurred(), "client-sets validation failure")
 	}
 
+	if err = runPreflight(ctx, controllerClient); err != nil {
+		asserter.Expect(err).NotTo(gomega.HaveOccurred(), "preflight check failed")
+	}
+
 	return &TestContext{
 		KubeConfig:           kubeConfig,
 		KubeClientset:        kubeClientset,

--- a/test/e2e/modules/context/preflight.go
+++ b/test/e2e/modules/context/preflight.go
@@ -16,9 +16,17 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/constant"
 )
 
+const (
+	defaultParentQueueName = "default-parent-queue"
+	defaultQueueName       = "default-queue"
+)
+
 // preflightOnce ensures the cluster guard runs at most once per process even
-// though GetConnectivity is invoked from every spec's BeforeEach.
-var preflightOnce sync.Once
+// though GetConnectivity is invoked from many different specs.
+var (
+	preflightOnce sync.Once
+	preflightErr  error
+)
 
 // runPreflight inspects the target cluster for Queues that were not created
 // by this e2e suite. The presence of any such Queue is a strong signal that
@@ -28,11 +36,10 @@ var preflightOnce sync.Once
 // Queues, etc.). There is no opt-in: the user must clean the conflicting
 // Queues themselves before re-running.
 func runPreflight(ctx goctx.Context, cli runtimeClient.Client) error {
-	var err error
 	preflightOnce.Do(func() {
-		err = checkForeignQueues(ctx, cli)
+		preflightErr = checkForeignQueues(ctx, cli)
 	})
-	return err
+	return preflightErr
 }
 
 func checkForeignQueues(ctx goctx.Context, cli runtimeClient.Client) error {
@@ -44,6 +51,10 @@ func checkForeignQueues(ctx goctx.Context, cli runtimeClient.Client) error {
 	var foreign []string
 	for _, q := range queues.Items {
 		if q.Labels[commonconstants.AppLabelName] == constant.EngineTestPodsApp {
+			continue
+		}
+		// The defaults are created by default on a fresh install. They shouldn't block an e2e test run.
+		if q.Name == defaultParentQueueName || q.Name == defaultQueueName {
 			continue
 		}
 		foreign = append(foreign, q.Name)

--- a/test/e2e/modules/context/preflight.go
+++ b/test/e2e/modules/context/preflight.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package context
+
+import (
+	goctx "context"
+	"fmt"
+	"sync"
+
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/constant"
+)
+
+// preflightOnce ensures the cluster guard runs at most once per process even
+// though GetConnectivity is invoked from every spec's BeforeEach.
+var preflightOnce sync.Once
+
+// runPreflight inspects the target cluster for Queues that were not created
+// by this e2e suite. The presence of any such Queue is a strong signal that
+// the kubeconfig points at a real cluster rather than a throwaway test
+// cluster, and continuing would mutate cluster-scoped state in ways that
+// survive process termination (operator-reconciled feature flags, leftover
+// Queues, etc.). There is no opt-in: the user must clean the conflicting
+// Queues themselves before re-running.
+func runPreflight(ctx goctx.Context, cli runtimeClient.Client) error {
+	var err error
+	preflightOnce.Do(func() {
+		err = checkForeignQueues(ctx, cli)
+	})
+	return err
+}
+
+func checkForeignQueues(ctx goctx.Context, cli runtimeClient.Client) error {
+	queues := &v2.QueueList{}
+	if err := cli.List(ctx, queues); err != nil {
+		return fmt.Errorf("preflight: failed to list Queues: %w", err)
+	}
+
+	var foreign []string
+	for _, q := range queues.Items {
+		if q.Labels[commonconstants.AppLabelName] == constant.EngineTestPodsApp {
+			continue
+		}
+		foreign = append(foreign, q.Name)
+	}
+	if len(foreign) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"preflight: refusing to run e2e tests: cluster already contains %d Queue(s) not labeled %s=%s: %v. "+
+			"This usually means the kubeconfig points at a real cluster rather than a test cluster. "+
+			"Delete the conflicting Queues (or switch contexts) before re-running",
+		len(foreign), commonconstants.AppLabelName, constant.EngineTestPodsApp, foreign,
+	)
+}

--- a/test/e2e/modules/context/preflight_test.go
+++ b/test/e2e/modules/context/preflight_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package context
+
+import (
+	goctx "context"
+	"strings"
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/constant"
+)
+
+func fakeClientWith(t *testing.T, queues ...*v2.Queue) *fakeClient.ClientBuilder {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v2.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	builder := fakeClient.NewClientBuilder().WithScheme(scheme)
+	for _, q := range queues {
+		builder = builder.WithObjects(q)
+	}
+	return builder
+}
+
+func queueObj(name string, labels map[string]string) *v2.Queue {
+	return &v2.Queue{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func TestCheckForeignQueuesEmpty(t *testing.T) {
+	cli := fakeClientWith(t).Build()
+	if err := checkForeignQueues(goctx.Background(), cli); err != nil {
+		t.Errorf("empty cluster should pass: %v", err)
+	}
+}
+
+func TestCheckForeignQueuesAllTestLabeled(t *testing.T) {
+	cli := fakeClientWith(t,
+		queueObj("leftover", map[string]string{commonconstants.AppLabelName: constant.EngineTestPodsApp}),
+	).Build()
+	if err := checkForeignQueues(goctx.Background(), cli); err != nil {
+		t.Errorf("test-labeled queues should pass: %v", err)
+	}
+}
+
+func TestCheckForeignQueuesUnlabeled(t *testing.T) {
+	cli := fakeClientWith(t, queueObj("prod", nil)).Build()
+	err := checkForeignQueues(goctx.Background(), cli)
+	if err == nil {
+		t.Fatal("unlabeled queue should fail preflight")
+	}
+	if !strings.Contains(err.Error(), "prod") {
+		t.Errorf("error should name offending queue, got %q", err.Error())
+	}
+}
+
+func TestCheckForeignQueuesWrongLabel(t *testing.T) {
+	cli := fakeClientWith(t,
+		queueObj("user", map[string]string{commonconstants.AppLabelName: "something-else"}),
+	).Build()
+	if err := checkForeignQueues(goctx.Background(), cli); err == nil {
+		t.Error("queue with non-test label should fail preflight")
+	}
+}
+
+func TestRunPreflightOnlyChecksOnce(t *testing.T) {
+	preflightOnce = sync.Once{}
+
+	cli := fakeClientWith(t).Build()
+	if err := runPreflight(goctx.Background(), cli); err != nil {
+		t.Fatalf("first call should pass empty cluster: %v", err)
+	}
+
+	// Even if the cluster acquires a foreign Queue after the first call,
+	// subsequent calls must skip the check (sync.Once semantics).
+	cli2 := fakeClientWith(t, queueObj("appeared-later", nil)).Build()
+	if err := runPreflight(goctx.Background(), cli2); err != nil {
+		t.Errorf("second call should be a no-op, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Do not run e2e tests on clusters with queues that do not have the e2e mark.

## Related Issues

Fixes #1623 

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
