### PR TITLE
fix(podgrouper): In the grpve podgroup plugin, do not set minMember=0 on middle level subgroups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fixed post-delete cleanup hook hardcoding `kai-scheduler` namespace instead of Helm release namespace on `helm uninstall` [#1619](https://github.com/kai-scheduler/KAI-Scheduler/pull/1619) [dttung2905](https://github.com/dttung2905)
 - Improved solver performance in some large reclaim scenarios [#1627](https://github.com/kai-scheduler/KAI-Scheduler/pull/1627) [itsomri](https://github.com/itsomri)
+- Grove grouper now sets `minSubGroup` (equal to the number of child SubGroups) instead of `minMember=0` on parent SubGroups generated from `topologyConstraintGroupConfigs` [#1639](https://github.com/kai-scheduler/KAI-Scheduler/issues/1639) [davidLif](https://github.com/davidLif)
 
 ## [v0.15.0] - 2026-05-20
 

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper.go
@@ -417,7 +417,7 @@ func parseGroupTopologyConfig(config map[string]interface{}, subGroupToParentMap
 
 	return &podgroup.SubGroupMetadata{
 		Name:                name,
-		MinAvailable:        0,
+		MinSubGroup:         ptr.To(int32(len(podGroupNames))),
 		Parent:              nil,
 		PodsReferences:      nil,
 		TopologyConstraints: topologyConstraint,

--- a/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/grove/grove_grouper_test.go
@@ -405,6 +405,8 @@ func TestGetPodGroupMetadata_WithTopologyHierarchy(t *testing.T) {
 	// Parent SubGroup
 	assert.Equal(t, "group1", metadata.SubGroups[0].Name)
 	assert.Equal(t, int32(0), metadata.SubGroups[0].MinAvailable)
+	assert.NotNil(t, metadata.SubGroups[0].MinSubGroup)
+	assert.Equal(t, int32(2), *metadata.SubGroups[0].MinSubGroup)
 	assert.Nil(t, metadata.SubGroups[0].Parent)
 	assert.NotNil(t, metadata.SubGroups[0].TopologyConstraints)
 	assert.Equal(t, "node", metadata.SubGroups[0].TopologyConstraints.PreferredTopologyLevel)
@@ -593,8 +595,12 @@ func TestGetPodGroupMetadata_MultipleParentGroups(t *testing.T) {
 	// Parents first
 	assert.Equal(t, "group1", metadata.SubGroups[0].Name)
 	assert.Equal(t, int32(0), metadata.SubGroups[0].MinAvailable)
+	assert.NotNil(t, metadata.SubGroups[0].MinSubGroup)
+	assert.Equal(t, int32(2), *metadata.SubGroups[0].MinSubGroup)
 	assert.Equal(t, "group2", metadata.SubGroups[1].Name)
 	assert.Equal(t, int32(0), metadata.SubGroups[1].MinAvailable)
+	assert.NotNil(t, metadata.SubGroups[1].MinSubGroup)
+	assert.Equal(t, int32(1), *metadata.SubGroups[1].MinSubGroup)
 
 	// Children
 	assert.Equal(t, "pg1", metadata.SubGroups[2].Name)
@@ -1906,6 +1912,8 @@ func TestGetPodGroupMetadata_ThreeLevelTopologyWithLeafVerification(t *testing.T
 	assert.Equal(t, "test-topology", metadata.SubGroups[0].TopologyConstraints.Topology)
 	assert.Nil(t, metadata.SubGroups[0].Parent)
 	assert.Equal(t, int32(0), metadata.SubGroups[0].MinAvailable)
+	assert.NotNil(t, metadata.SubGroups[0].MinSubGroup)
+	assert.Equal(t, int32(2), *metadata.SubGroups[0].MinSubGroup)
 
 	// Level 2: Verify Parent group2
 	assert.Equal(t, "group2", metadata.SubGroups[1].Name)
@@ -1915,6 +1923,8 @@ func TestGetPodGroupMetadata_ThreeLevelTopologyWithLeafVerification(t *testing.T
 	assert.Equal(t, "test-topology", metadata.SubGroups[1].TopologyConstraints.Topology)
 	assert.Nil(t, metadata.SubGroups[1].Parent)
 	assert.Equal(t, int32(0), metadata.SubGroups[1].MinAvailable)
+	assert.NotNil(t, metadata.SubGroups[1].MinSubGroup)
+	assert.Equal(t, int32(1), *metadata.SubGroups[1].MinSubGroup)
 
 	// Level 3 (LEAF): Verify Child pg1 under group1
 	assert.Equal(t, "pg1", metadata.SubGroups[2].Name)


### PR DESCRIPTION
## Description

Grove grouper now sets `minSubGroup` (equal to the number of child SubGroups) instead of `minMember=0` on parent SubGroups generated from `topologyConstraintGroupConfigs`

## Related Issues

Fixes #1639 

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
