### PR TITLE
fix(podgrouper): use time.Second for RequeueAfter on pod get error

### DIFF
--- a/pkg/podgrouper/pod_controller.go
+++ b/pkg/podgrouper/pod_controller.go
@@ -83,7 +83,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		logger.V(1).Error(err, "Failed to get pod", req.Namespace, req.Name)
 		return ctrl.Result{
 			Requeue:      true,
-			RequeueAfter: 1,
+			RequeueAfter: time.Second,
 		}, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

RequeueAfter is a time.Duration (nanoseconds), so the literal `1` was 1ns, not 1s, defeating the intended backoff. Use time.Second.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper time unit handling in pod reconciliation error retry logic, ensuring errors are correctly delayed before retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->