### PR TITLE
feat(chart): Fix wiring of `.Values.podgrouper.queueLabelKey` into `kai-config.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed post-delete cleanup hook hardcoding `kai-scheduler` namespace instead of Helm release namespace on `helm uninstall` [#1619](https://github.com/kai-scheduler/KAI-Scheduler/pull/1619) [dttung2905](https://github.com/dttung2905)
 - Improved solver performance in some large reclaim scenarios [#1627](https://github.com/kai-scheduler/KAI-Scheduler/pull/1627) [itsomri](https://github.com/itsomri)
 - Grove grouper now sets `minSubGroup` (equal to the number of child SubGroups) instead of `minMember=0` on parent SubGroups generated from `topologyConstraintGroupConfigs` [#1639](https://github.com/kai-scheduler/KAI-Scheduler/issues/1639) [davidLif](https://github.com/davidLif)
+- Fixed Helm chart not wiring `podgrouper.queueLabelKey` into `spec.global.queueLabelKey` on the Config CR, so custom queue label keys were ignored at install time [#1655](https://github.com/kai-scheduler/KAI-Scheduler/pull/1655) [dttung2905](https://github.com/dttung2905)
 
 ## [v0.15.0] - 2026-05-20
 

--- a/deployments/kai-scheduler/templates/kai-config.yaml
+++ b/deployments/kai-scheduler/templates/kai-config.yaml
@@ -53,6 +53,9 @@ spec:
     vpa:
       {{- toYaml .Values.global.vpa | nindent 6 }}
     {{- end }}
+    {{- if .Values.podgrouper.queueLabelKey }}
+    queueLabelKey: {{ .Values.podgrouper.queueLabelKey | quote }}
+    {{- end }}
 
   binder:
     service:

--- a/deployments/kai-scheduler/tests/enabled_test.yaml
+++ b/deployments/kai-scheduler/tests/enabled_test.yaml
@@ -11,6 +11,9 @@ tests:
   - it: should enable all services by default
     asserts:
       - equal:
+          path: spec.global.queueLabelKey
+          value: "kai.scheduler/queue"
+      - equal:
           path: spec.binder.service.enabled
           value: true
       - equal:
@@ -28,6 +31,17 @@ tests:
       - equal:
           path: spec.scheduler.service.enabled
           value: true
+
+  # ======================================
+  # Global queueLabelKey Tests
+  # ======================================
+  - it: should wire podgrouper.queueLabelKey into spec.global.queueLabelKey
+    set:
+      podgrouper.queueLabelKey: "runai/queue"
+    asserts:
+      - equal:
+          path: spec.global.queueLabelKey
+          value: "runai/queue"
 
   # ======================================
   # Binder Enabled Tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

Helm exposed `podgrouper.queueLabelKey` in `values.yaml`, but `kai-config.yaml` never wrote it into the Config CR. The operator reads `spec.global.queueLabelKey` (default kai.scheduler/queue) for podgrouper, admission webhooks, and scheduler, so custom values such as runai/queue were ignored at install time.

This PR wires podgrouper.queueLabelKey into `spec.global.queueLabelKey` on the Config resource rendered by Helm.

Changes:

- `deployments/kai-scheduler/templates/kai-config.yaml` — emit `spec.global.queueLabelKey` when `podgrouper.queueLabelKey` is set
- `deployments/kai-scheduler/tests/enabled_test.yaml` — assert default and custom values are rendered correctly
Example: with `podgrouper.queueLabelKey: "runai/queue"`, workloads must label pods with `runai/queue: <queue-name>` instead of `kai.scheduler/queue`.


## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
