### PR TITLE
fix(scheduler): guard nil scenario in preempt scenario builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Improved solver performance in some large reclaim scenarios [#1627](https://github.com/kai-scheduler/KAI-Scheduler/pull/1627) [itsomri](https://github.com/itsomri)
 - Grove grouper now sets `minSubGroup` (equal to the number of child SubGroups) instead of `minMember=0` on parent SubGroups generated from `topologyConstraintGroupConfigs` [#1639](https://github.com/kai-scheduler/KAI-Scheduler/issues/1639) [davidLif](https://github.com/davidLif)
 - Fixed Helm chart not wiring `podgrouper.queueLabelKey` into `spec.global.queueLabelKey` on the Config CR, so custom queue label keys were ignored at install time [#1655](https://github.com/kai-scheduler/KAI-Scheduler/pull/1655) [dttung2905](https://github.com/dttung2905)
+- Fixed scheduler nil-pointer panic in the preempt scenario builder when a (partial) job has no tasks to allocate (`NewIdleGpusFilter` dereferenced a nil scenario); added the missing nil-guard matching the sibling filters [#1664](https://github.com/kai-scheduler/KAI-Scheduler/issues/1664) [sam-huang1223](https://github.com/sam-huang1223)
 
 ## [v0.15.0] - 2026-05-20
 

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus.go
@@ -53,6 +53,9 @@ type AccumulatedIdleGpus struct {
 
 func NewIdleGpusFilter(
 	scenario *scenario.ByNodeScenario, nodeInfosMap map[string]*node_info.NodeInfo) *AccumulatedIdleGpus {
+	if scenario == nil {
+		return nil
+	}
 	idleGpusMap, relevantNodesSorted := createGpuMap(nodeInfosMap, len(scenario.PendingTasks()))
 
 	filter := &AccumulatedIdleGpus{

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus_test.go
@@ -1378,3 +1378,9 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 		})
 	}
 }
+
+func Test_NewIdleGpusFilter_NilScenario(t *testing.T) {
+	if filter := NewIdleGpusFilter(nil, map[string]*node_info.NodeInfo{}); filter != nil {
+		t.Fatalf("expected nil filter for nil scenario, got %#v", filter)
+	}
+}

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -115,6 +115,9 @@ func (asb *PodAccumulatedScenarioBuilder) GetNextScenario() *solverscenario.ByNo
 // outer state. advanceFirst controls whether the first pass starts by popping a
 // victim or by evaluating the current state as-is.
 func (asb *PodAccumulatedScenarioBuilder) iterate(advanceFirst bool) *solverscenario.ByNodeScenario {
+	if asb.lastScenario == nil {
+		return nil
+	}
 	needAdvance := advanceFirst
 	for {
 		if sub := asb.nextFromSubEmitter(); sub != nil {

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
@@ -284,6 +284,24 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 			Expect(numberOfGeneratedScenarios).To(Equal(len(potentialVictimsPerScenario)))
 		})
 	})
+
+	Context("preemptor with no tasks to allocate - nil scenario", func() {
+		BeforeEach(func() {
+			ssn, _ = initializeSession(0, 0)
+			submitQueue := createQueue("team-a")
+			ssn.ClusterInfo.Queues[submitQueue.UID] = submitQueue
+			// Running tasks are not allocatable, so the job has no tasks to allocate.
+			reclaimerJob, _ = createJobWithTasks(1, 1, "team-a", v1.PodRunning, []v1.ResourceRequirements{})
+			recordedVictimsJobs := []*podgroup_info.PodGroupInfo{}
+			victimsQueue := utils.GetVictimsQueue(ssn, nil)
+
+			scenarioBuilder = NewPodAccumulatedScenarioBuilder(ssn, reclaimerJob, recordedVictimsJobs, victimsQueue, ssn.ClusterInfo.Nodes)
+		})
+		It("does not panic and yields no scenario", func() {
+			Expect(scenarioBuilder.GetValidScenario()).To(BeNil())
+			Expect(scenarioBuilder.GetNextScenario()).To(BeNil())
+		})
+	})
 })
 
 func initializeSession(jobsCount, tasksPerJob int) (*framework.Session, []*pod_info.PodInfo) {


### PR DESCRIPTION
## Description
The `preempt` scenario builder can construct a `nil` scenario when the (partial) job has no tasks to allocate, and `NewIdleGpusFilter` dereferences it → nil-pointer panic that crash-loops the scheduler under leader election. This adds the missing nil-guards, matching the sibling filters that already handle this.

Two minimal guards:
- `NewIdleGpusFilter` returns `nil` for a nil scenario (like `NewNodeAffinitiesFilter` / `NewTopologyAwareIdleGpusFilter`).
- `PodAccumulatedScenarioBuilder.iterate` returns `nil` when there is no scenario, so the builder emits nothing instead of dereferencing a nil `lastScenario`.

## Related Issues
Fixes #1664

## Testing
Frank about what is and isn't covered:

**Tested (deterministic):**
- `Test_NewIdleGpusFilter_NilScenario` — the filter returns nil for a nil scenario instead of dereferencing it.
- `pod_scenario_builder_test.go` — a preemptor whose `GetTasksToAllocate` is empty no longer panics during construction/iteration and yields no scenario.
- Both tests were confirmed to **fail without the source fix** (reverting just the source reproduces the exact `nil pointer dereference` from the panic) and pass with it.
- Real-state replay: a real cluster snapshot replayed through `snapshot-tool` (full allocate/reclaim/preempt cycle) behaves identically with and without the fix → no behavior change.

**Not tested, and why:**
- The exact live trigger is not reproduced offline. It is a rare, transient, order-sensitive state in the preempt scenario search (a partial job that resolves to zero allocatable tasks). Replaying a snapshot captured during an active crash window, with the same binary version, did **not** reproduce it (0/40 runs). A point-in-time snapshot cannot capture the cross-cycle evolution that produces the trigger, and Go's randomized map-iteration order varies the search path per run. Verification is therefore at the crash **site** (deterministic) rather than the upstream trigger path; the stack trace identifies that site unambiguously.

**Behavior preservation:** the guards fire only when `scenario == nil` — a case where preemption was already a no-op (nothing to place). No non-nil path changes.

## Breaking Changes
None.

## Additional Notes
Observed on v0.14.2; the same nil-able `scenario` → `NewIdleGpusFilter` path is present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
