### PR TITLE
feat: Numa plugin info objects

### DIFF
--- a/deployments/kai-scheduler/templates/rbac/scheduler.yaml
+++ b/deployments/kai-scheduler/templates/rbac/scheduler.yaml
@@ -137,3 +137,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - get
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang/glog v1.2.5
 	github.com/google/go-cmp v0.7.0
 	github.com/grafana/pyroscope-go v1.2.8
+	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
 	github.com/kubeflow/mpi-operator v0.6.0
 	github.com/kubeflow/training-operator v1.9.3
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2E
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2 h1:uAwqOtyrFYggq3pVf3hs1XKkBxrQ8dkgjWz3LCLJsiY=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2/go.mod h1:LBzS4n6GX1C69tzSd5EibZ9cGOXFuHP7GxEMDYVe1sM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/hack/update-client.sh
+++ b/hack/update-client.sh
@@ -2,6 +2,9 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+# kube_codegen installs tools from the module cache, which has no VCS metadata.
+export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"
+
 # Creating an import file got code-generator
 
 cat <<EOF > generate-dep.go

--- a/pkg/common/feature_gates/feature_gates.go
+++ b/pkg/common/feature_gates/feature_gates.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	minimalSupportedVersion = "v1beta1"
+
+	nodeResourceTopologyGroup = "topology.node.k8s.io"
 )
 
 // dynamicResourcesEnabled is the process-wide decision on whether DRA is usable,
@@ -41,6 +43,39 @@ func DynamicResourcesEnabled() bool {
 // SetDRAFeatureGate (which requires a discovery client).
 func SetDynamicResourcesEnabledForTest(enabled bool) {
 	dynamicResourcesEnabled.Store(enabled)
+}
+
+var nodeResourceTopologyEnabled atomic.Bool
+
+func SetNodeResourceTopologyFeatureGate(discoveryClient discovery.DiscoveryInterface) {
+	nodeResourceTopologyEnabled.Store(IsNodeResourceTopologyEnabled(discoveryClient))
+}
+
+func NodeResourceTopologyEnabled() bool {
+	return nodeResourceTopologyEnabled.Load()
+}
+
+func SetNodeResourceTopologyEnabledForTest(enabled bool) {
+	nodeResourceTopologyEnabled.Store(enabled)
+}
+
+// IsNodeResourceTopologyEnabled reports whether the cluster serves the
+// topology.node.k8s.io API group (the NodeResourceTopology CRD).
+func IsNodeResourceTopologyEnabled(discoveryClient discovery.DiscoveryInterface) bool {
+	logger := log.Log.WithName("feature-gates")
+
+	serverGroups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		logger.Error(err, "Failed to get server groups")
+		return false
+	}
+
+	for _, group := range serverGroups.Groups {
+		if group.Name == nodeResourceTopologyGroup {
+			return true
+		}
+	}
+	return false
 }
 
 func IsDynamicResourcesEnabled(discoveryClient discovery.DiscoveryInterface) bool {

--- a/pkg/scheduler/api/node_info/node_info.go
+++ b/pkg/scheduler/api/node_info/node_info.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"go.uber.org/multierr"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
@@ -85,6 +86,8 @@ type NodeInfo struct {
 
 	// HasDRAGPUs indicates GPUs were added via DRA ResourceSlices. Temporary fix - remove when device-plugin pods are supported on DRA nodes.
 	HasDRAGPUs bool
+
+	NodeResourceTopology *nrtv1alpha2.NodeResourceTopology
 
 	PodAffinityInfo pod_affinity.NodePodAffinityInfo
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	nrtclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
+	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,6 +85,7 @@ type SchedulerCacheParams struct {
 	RestrictNodeScheduling      bool
 	KubeClient                  kubernetes.Interface
 	KAISchedulerClient          kubeaischedulerver.Interface
+	NRTClient                   nrtclientset.Interface
 	UsageDBParams               *usageapi.UsageParams
 	UsageDBClient               usageapi.Interface
 	DetailedFitErrors           bool
@@ -101,6 +104,7 @@ type SchedulerCache struct {
 	kubeAiSchedulerClient          kubeaischedulerver.Interface
 	informerFactory                informers.SharedInformerFactory
 	kubeAiSchedulerInformerFactory kubeaischedulerinfo.SharedInformerFactory
+	nrtInformerFactory             nrtinformers.SharedInformerFactory
 	podLister                      listv1.PodLister
 	podGroupLister                 enginelisters.PodGroupLister
 	clusterInfo                    *cluster_info.ClusterInfo
@@ -155,6 +159,11 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCac
 	sc.kubeAiSchedulerInformerFactory = kubeaischedulerinfo.NewSharedInformerFactory(sc.kubeAiSchedulerClient, 0)
 
 	featuregates.SetDRAFeatureGate(schedulerCacheParams.DiscoveryClient)
+	featuregates.SetNodeResourceTopologyFeatureGate(schedulerCacheParams.DiscoveryClient)
+	if featuregates.NodeResourceTopologyEnabled() && schedulerCacheParams.NRTClient != nil {
+		sc.nrtInformerFactory = nrtinformers.NewSharedInformerFactory(schedulerCacheParams.NRTClient, 0)
+	}
+
 	sc.internalPlugins = k8splugins.InitializeInternalPlugins(sc.kubeClient, sc.informerFactory, sc.SnapshotSharedLister())
 
 	sc.podLister = sc.informerFactory.Core().V1().Pods().Lister()
@@ -167,7 +176,7 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCac
 			&schedulerCacheParams.UsageDBParams.WaitTimeout.Duration)
 	}
 
-	clusterInfo, err := cluster_info.New(sc.informerFactory, sc.kubeAiSchedulerInformerFactory, sc.usageLister, sc.schedulingNodePoolParams,
+	clusterInfo, err := cluster_info.New(sc.informerFactory, sc.kubeAiSchedulerInformerFactory, sc.nrtInformerFactory, sc.usageLister, sc.schedulingNodePoolParams,
 		sc.restrictNodeScheduling, &sc.K8sClusterPodAffinityInfo, sc.scheduleCSIStorage, sc.fullHierarchyFairness, sc.StatusUpdater, sc.stuckInReleasingThreshold)
 
 	if err != nil {
@@ -198,6 +207,9 @@ func (sc *SchedulerCache) Snapshot() (*api.ClusterInfo, error) {
 func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	sc.informerFactory.Start(stopCh)
 	sc.kubeAiSchedulerInformerFactory.Start(stopCh)
+	if sc.nrtInformerFactory != nil {
+		sc.nrtInformerFactory.Start(stopCh)
+	}
 	sc.StatusUpdater.Run(stopCh)
 
 	if sc.usageLister != nil {
@@ -208,6 +220,9 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 func (sc *SchedulerCache) WaitForCacheSync(stopCh <-chan struct{}) {
 	sc.informerFactory.WaitForCacheSync(stopCh)
 	sc.kubeAiSchedulerInformerFactory.WaitForCacheSync(stopCh)
+	if sc.nrtInformerFactory != nil {
+		sc.nrtInformerFactory.WaitForCacheSync(stopCh)
+	}
 
 	if sc.usageLister != nil {
 		sc.usageLister.WaitForCacheSync(stopCh)
@@ -450,5 +465,5 @@ func (sc *SchedulerCache) GetDataLister() data_lister.DataLister {
 		log.InfraLogger.Errorf("Failed to get label selector: %v", err)
 		return nil
 	}
-	return data_lister.New(sc.informerFactory, sc.kubeAiSchedulerInformerFactory, sc.usageLister, selector)
+	return data_lister.New(sc.informerFactory, sc.kubeAiSchedulerInformerFactory, sc.nrtInformerFactory, sc.usageLister, selector)
 }

--- a/pkg/scheduler/cache/cluster_info/cluster_info.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -79,6 +80,7 @@ const (
 func New(
 	informerFactory informers.SharedInformerFactory,
 	kubeAiSchedulerInformerFactory kubeAiSchedulerinfo.SharedInformerFactory,
+	nrtInformerFactory nrtinformers.SharedInformerFactory,
 	usageLister *usagedb.UsageLister,
 	nodePoolParams *conf.SchedulingNodePoolParams,
 	restrictNodeScheduling bool,
@@ -106,7 +108,7 @@ func New(
 	}
 
 	return &ClusterInfo{
-		dataLister:                data_lister.New(informerFactory, kubeAiSchedulerInformerFactory, usageLister, nodePoolSelector),
+		dataLister:                data_lister.New(informerFactory, kubeAiSchedulerInformerFactory, nrtInformerFactory, usageLister, nodePoolSelector),
 		nodePoolParams:            nodePoolParams,
 		restrictNodeScheduling:    restrictNodeScheduling,
 		clusterPodAffinityInfo:    clusterPodAffinityInfo,
@@ -268,7 +270,26 @@ func (c *ClusterInfo) snapshotNodes(
 	}
 
 	c.populateDRAGPUs(resultNodes)
+	c.populateNodeResourceTopologies(resultNodes)
 	return resultNodes, minGPUMemory, nil
+}
+
+// populateNodeResourceTopologies attaches each node's NodeResourceTopology object to the corresponding NodeInfo.
+// It is a no-op when the NodeResourceTopology CRD is not served by the cluster.
+func (c *ClusterInfo) populateNodeResourceTopologies(nodes map[string]*node_info.NodeInfo) {
+	nrts, err := c.dataLister.ListNodeResourceTopologies()
+	if err != nil {
+		log.InfraLogger.V(6).Infof("Failed to list NodeResourceTopologies: %v", err)
+		return
+	}
+
+	for _, nrt := range nrts {
+		nodeInfo, found := nodes[nrt.Name]
+		if !found {
+			continue
+		}
+		nodeInfo.NodeResourceTopology = nrt
+	}
 }
 
 // populateDRAGPUs counts GPUs from DRA ResourceSlices for nodes that don't have extended resources.

--- a/pkg/scheduler/cache/cluster_info/cluster_info_test.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -2311,6 +2312,7 @@ func TestSnapshotWithListerErrors(t *testing.T) {
 	for name, test := range tests {
 		t.Logf("Running test: %s", name)
 		dl := data_lister.NewMockDataLister(ctrl)
+		dl.EXPECT().ListNodeResourceTopologies().Return(nil, nil).AnyTimes()
 		clusterInfo := newClusterInfoTests(t,
 			clusterInfoTestParams{
 				kubeObjects:         []runtime.Object{},
@@ -2338,7 +2340,7 @@ func TestNewClusterInfoErrorPartitionSelector(t *testing.T) {
 		NodePoolLabelKey:   "@!A",
 		NodePoolLabelValue: "!@#",
 	}
-	_, err := New(informerFactory, kubeAiSchedulerInformerFactory, nil, params, false, clusterPodAffinityInfo, false, true, nil, 0)
+	_, err := New(informerFactory, kubeAiSchedulerInformerFactory, nil, nil, params, false, clusterPodAffinityInfo, false, true, nil, 0)
 
 	assert.NotNil(t, err)
 }
@@ -2368,7 +2370,7 @@ func TestNewClusterInfoAddIndexerFails(t *testing.T) {
 	clusterPodAffinityInfo.EXPECT().UpdateNodeAffinity(gomock.Any()).AnyTimes()
 	clusterPodAffinityInfo.EXPECT().AddNode(gomock.Any(), gomock.Any()).AnyTimes()
 
-	_, err = New(informerFactory, kubeAiSchedulerInformerFactory, nil, nil, false,
+	_, err = New(informerFactory, kubeAiSchedulerInformerFactory, nil, nil, nil, false,
 		clusterPodAffinityInfo, false, true, nil, 0)
 	assert.NotNil(t, err, "Expected error for conflicting indexers")
 }
@@ -2406,7 +2408,7 @@ func newClusterInfoTestsInner(t *testing.T, kubeObjects, kaiSchedulerObjects []r
 	fakeUsageClient.SetResourceUsage(clusterUsage, clusterUsageErr)
 	usageLister := usagedb.NewUsageLister(&fakeUsageClient, ptr.To(10*time.Microsecond), ptr.To(10*time.Second), ptr.To(10*time.Second))
 
-	clusterInfo, _ := New(informerFactory, kubeAiSchedulerInformerFactory, usageLister, nodePoolParams, false,
+	clusterInfo, _ := New(informerFactory, kubeAiSchedulerInformerFactory, nil, usageLister, nodePoolParams, false,
 		clusterPodAffinityInfo, true, fullHierarchyFairness, nil, 0)
 
 	stopCh := context.Background().Done()
@@ -2584,6 +2586,7 @@ func TestSnapshotNodesWithDRAGPUs(t *testing.T) {
 			mockLister := data_lister.NewMockDataLister(ctrl)
 			mockLister.EXPECT().ListNodes().Return(test.nodes, nil)
 			mockLister.EXPECT().ListResourceSlicesByNode().Return(slicesByNode, nil)
+			mockLister.EXPECT().ListNodeResourceTopologies().Return(nil, nil).AnyTimes()
 
 			clusterPodAffinityInfo := pod_affinity.NewMockClusterPodAffinityInfo(ctrl)
 			clusterPodAffinityInfo.EXPECT().UpdateNodeAffinity(gomock.Any()).AnyTimes()
@@ -2611,6 +2614,44 @@ func TestSnapshotNodesWithDRAGPUs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSnapshotNodesWithNodeResourceTopology(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nodes := []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
+	}
+	nrts := []*nrtv1alpha2.NodeResourceTopology{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+		// Unmatched NRT object: must be ignored, not attached to any node.
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-missing"}},
+	}
+
+	mockLister := data_lister.NewMockDataLister(ctrl)
+	mockLister.EXPECT().ListNodes().Return(nodes, nil)
+	mockLister.EXPECT().ListResourceSlicesByNode().Return(map[string][]*resourceapi.ResourceSlice{}, nil)
+	mockLister.EXPECT().ListNodeResourceTopologies().Return(nrts, nil)
+
+	clusterPodAffinityInfo := pod_affinity.NewMockClusterPodAffinityInfo(ctrl)
+	clusterPodAffinityInfo.EXPECT().UpdateNodeAffinity(gomock.Any()).AnyTimes()
+	clusterPodAffinityInfo.EXPECT().AddNode(gomock.Any(), gomock.Any()).AnyTimes()
+
+	ci := &ClusterInfo{
+		dataLister:             mockLister,
+		nodePoolParams:         &conf.SchedulingNodePoolParams{},
+		nodePoolSelector:       labels.Everything(),
+		clusterPodAffinityInfo: clusterPodAffinityInfo,
+	}
+
+	result, _, err := ci.snapshotNodes(clusterPodAffinityInfo, resource_info.NewResourceVectorMap())
+	assert.NoError(t, err)
+
+	assert.NotNil(t, result["node-a"].NodeResourceTopology, "NRT should be attached to node-a")
+	assert.Equal(t, "node-a", result["node-a"].NodeResourceTopology.Name)
+	assert.Nil(t, result["node-b"].NodeResourceTopology, "node-b has no NRT object")
 }
 
 func createTestResourceSlice(name, nodeName, driver string, deviceCount int) *resourceapi.ResourceSlice {

--- a/pkg/scheduler/cache/cluster_info/data_lister/data_lister_mock.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/data_lister_mock.go
@@ -12,9 +12,9 @@ package data_lister
 import (
 	reflect "reflect"
 
-	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	v1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	v1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
-	v1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	v1alpha20 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
 	v2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	queue_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
@@ -65,10 +65,10 @@ func (mr *MockDataListerMockRecorder) GetPriorityClassByName(name any) *gomock.C
 }
 
 // ListBindRequests mocks base method.
-func (m *MockDataLister) ListBindRequests() ([]*v1alpha2.BindRequest, error) {
+func (m *MockDataLister) ListBindRequests() ([]*v1alpha20.BindRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBindRequests")
-	ret0, _ := ret[0].([]*v1alpha2.BindRequest)
+	ret0, _ := ret[0].([]*v1alpha20.BindRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -137,6 +137,21 @@ func (m *MockDataLister) ListDeviceClasses() ([]*v10.DeviceClass, error) {
 func (mr *MockDataListerMockRecorder) ListDeviceClasses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeviceClasses", reflect.TypeOf((*MockDataLister)(nil).ListDeviceClasses))
+}
+
+// ListNodeResourceTopologies mocks base method.
+func (m *MockDataLister) ListNodeResourceTopologies() ([]*v1alpha2.NodeResourceTopology, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodeResourceTopologies")
+	ret0, _ := ret[0].([]*v1alpha2.NodeResourceTopology)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodeResourceTopologies indicates an expected call of ListNodeResourceTopologies.
+func (mr *MockDataListerMockRecorder) ListNodeResourceTopologies() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResourceTopologies", reflect.TypeOf((*MockDataLister)(nil).ListNodeResourceTopologies))
 }
 
 // ListNodes mocks base method.
@@ -347,19 +362,4 @@ func (m *MockDataLister) ListTopologies() ([]*v1alpha1.Topology, error) {
 func (mr *MockDataListerMockRecorder) ListTopologies() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTopologies", reflect.TypeOf((*MockDataLister)(nil).ListTopologies))
-}
-
-// ListNodeResourceTopologies mocks base method.
-func (m *MockDataLister) ListNodeResourceTopologies() ([]*nrtv1alpha2.NodeResourceTopology, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodeResourceTopologies")
-	ret0, _ := ret[0].([]*nrtv1alpha2.NodeResourceTopology)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodeResourceTopologies indicates an expected call of ListNodeResourceTopologies.
-func (mr *MockDataListerMockRecorder) ListNodeResourceTopologies() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResourceTopologies", reflect.TypeOf((*MockDataLister)(nil).ListNodeResourceTopologies))
 }

--- a/pkg/scheduler/cache/cluster_info/data_lister/data_lister_mock.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/data_lister_mock.go
@@ -12,6 +12,7 @@ package data_lister
 import (
 	reflect "reflect"
 
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	v1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	v1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
@@ -346,4 +347,19 @@ func (m *MockDataLister) ListTopologies() ([]*v1alpha1.Topology, error) {
 func (mr *MockDataListerMockRecorder) ListTopologies() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTopologies", reflect.TypeOf((*MockDataLister)(nil).ListTopologies))
+}
+
+// ListNodeResourceTopologies mocks base method.
+func (m *MockDataLister) ListNodeResourceTopologies() ([]*nrtv1alpha2.NodeResourceTopology, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodeResourceTopologies")
+	ret0, _ := ret[0].([]*nrtv1alpha2.NodeResourceTopology)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodeResourceTopologies indicates an expected call of ListNodeResourceTopologies.
+func (mr *MockDataListerMockRecorder) ListNodeResourceTopologies() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResourceTopologies", reflect.TypeOf((*MockDataLister)(nil).ListNodeResourceTopologies))
 }

--- a/pkg/scheduler/cache/cluster_info/data_lister/interface.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/interface.go
@@ -4,6 +4,7 @@
 package data_lister
 
 import (
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	scheduling "k8s.io/api/scheduling/v1"
@@ -32,8 +33,8 @@ type DataLister interface {
 	ListBindRequests() ([]*schedulingv1alpha2.BindRequest, error)
 	ListConfigMaps() ([]*v1.ConfigMap, error)
 	ListTopologies() ([]*kaiv1alpha1.Topology, error)
+	ListNodeResourceTopologies() ([]*nrtv1alpha2.NodeResourceTopology, error)
 	ListResourceUsage() (*queue_info.ClusterUsage, error)
-	// ListResourceSlicesByNode returns ResourceSlices grouped by node name.
 	ListResourceSlicesByNode() (map[string][]*resourceapi.ResourceSlice, error)
 	ListResourceClaims() ([]*resourceapi.ResourceClaim, error)
 	ListResourceSlices() ([]*resourceapi.ResourceSlice, error)

--- a/pkg/scheduler/cache/cluster_info/data_lister/kubernetes_lister.go
+++ b/pkg/scheduler/cache/cluster_info/data_lister/kubernetes_lister.go
@@ -6,6 +6,9 @@ package data_lister
 import (
 	"fmt"
 
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	nrtinformers "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/informers/externalversions"
+	nrtlisters "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/listers/topology/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	v14 "k8s.io/api/scheduling/v1"
@@ -53,6 +56,8 @@ type k8sLister struct {
 
 	kaiTopologyLister kaiv1alpha1Listers.TopologyLister
 
+	nrtLister nrtlisters.NodeResourceTopologyLister
+
 	resourceSliceLister resourcev1.ResourceSliceLister
 	resourceClaimLister resourcev1.ResourceClaimLister
 	deviceClassLister   resourcev1.DeviceClassLister
@@ -66,6 +71,7 @@ var _ DataLister = &k8sLister{}
 
 func New(
 	informerFactory informers.SharedInformerFactory, kubeAiSchedulerInformerFactory kubeAiSchedulerInfo.SharedInformerFactory,
+	nrtInformerFactory nrtinformers.SharedInformerFactory,
 	usageLister *usagedb.UsageLister,
 	partitionSelector labels.Selector,
 ) *k8sLister {
@@ -95,6 +101,10 @@ func New(
 		lister.resourceSliceLister = informerFactory.Resource().V1().ResourceSlices().Lister()
 		lister.resourceClaimLister = informerFactory.Resource().V1().ResourceClaims().Lister()
 		lister.deviceClassLister = informerFactory.Resource().V1().DeviceClasses().Lister()
+	}
+
+	if nrtInformerFactory != nil {
+		lister.nrtLister = nrtInformerFactory.Topology().V1alpha2().NodeResourceTopologies().Lister()
 	}
 
 	return lister
@@ -190,6 +200,15 @@ func (k *k8sLister) ListConfigMaps() ([]*v1.ConfigMap, error) {
 
 func (k *k8sLister) ListTopologies() ([]*kaiv1alpha1.Topology, error) {
 	return k.kaiTopologyLister.List(labels.Everything())
+}
+
+// +kubebuilder:rbac:groups="topology.node.k8s.io",resources=noderesourcetopologies,verbs=get;list;watch
+
+func (k *k8sLister) ListNodeResourceTopologies() ([]*nrtv1alpha2.NodeResourceTopology, error) {
+	if k.nrtLister == nil {
+		return nil, nil
+	}
+	return k.nrtLister.List(labels.Everything())
 }
 
 // +kubebuilder:rbac:groups="resource.k8s.io",resources=resourceslices,verbs=get;list;watch

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"time"
 
+	nrtclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -58,6 +59,11 @@ func NewScheduler(
 ) (*Scheduler, error) {
 	kubeClient, kubeAiSchedulerClient := newClients(config)
 
+	nrtClient, err := nrtclientset.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create NodeResourceTopology client: %v", err)
+	}
+
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create discovery client: %v", err)
@@ -76,6 +82,7 @@ func NewScheduler(
 	schedulerCacheParams := &schedcache.SchedulerCacheParams{
 		KubeClient:                  kubeClient,
 		KAISchedulerClient:          kubeAiSchedulerClient,
+		NRTClient:                   nrtClient,
 		UsageDBParams:               usageDBParams,
 		UsageDBClient:               usageDBClient,
 		SchedulerName:               schedulerParams.SchedulerName,


### PR DESCRIPTION
## Description

This PR adds the info objects and relevant listers for NUMA topology awareness based on NodeResourceTopology. No behavior changes.

## Related Issues

Phase 0 of #1598

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
