### PR TITLE
refactor(scheduler): source GPU annotation constants from common package

### DIFF
--- a/pkg/scheduler/api/common_info/test_utils.go
+++ b/pkg/scheduler/api/common_info/test_utils.go
@@ -28,11 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 const FakePogGroupId = "12345678"
-const GPUFraction = "gpu-fraction"
 
 func BuildNode(name string, alloc v1.ResourceList) *v1.Node {
 	return &v1.Node{
@@ -80,7 +80,7 @@ func BuildPod(namespace, name, nodeName string, phase v1.PodPhase, req v1.Resour
 			if pod.Annotations == nil {
 				pod.Annotations = map[string]string{}
 			}
-			pod.Annotations[GPUFraction] = gpuRequest.AsDec().String()
+			pod.Annotations[commonconstants.GpuFraction] = gpuRequest.AsDec().String()
 		}
 	}
 

--- a/pkg/scheduler/api/node_info/node_info_benchmark_test.go
+++ b/pkg/scheduler/api/node_info/node_info_benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_affinity"
@@ -248,7 +249,7 @@ func createTaskFractionalGPU() *pod_info.PodInfo {
 			Name:      "frac-gpu-task",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common_info.GPUFraction: "0.25",
+				commonconstants.GpuFraction: "0.25",
 			},
 		},
 		Spec: v1.PodSpec{
@@ -299,8 +300,8 @@ func createTaskGPUMemory() *pod_info.PodInfo {
 			Name:      "gpu-memory-task",
 			Namespace: "default",
 			Annotations: map[string]string{
-				pod_info.GpuMemoryAnnotationName: "40000",
-				common_info.GPUFraction:          "0.5",
+				commonconstants.GpuMemory:   "40000",
+				commonconstants.GpuFraction: "0.5",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/pkg/scheduler/api/node_info/node_info_test.go
+++ b/pkg/scheduler/api/node_info/node_info_test.go
@@ -993,7 +993,7 @@ func TestNodeInfo_isTaskAllocatableOnNonAllocatedResources(t *testing.T) {
 							Namespace: "n1",
 							Annotations: map[string]string{
 								commonconstants.PodGroupAnnotationForPod: "pg1",
-								pod_info.GpuMemoryAnnotationName:         "1500",
+								commonconstants.GpuMemory:                "1500",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -1039,7 +1039,7 @@ func TestNodeInfo_isTaskAllocatableOnNonAllocatedResources(t *testing.T) {
 							Namespace: "n1",
 							Annotations: map[string]string{
 								commonconstants.PodGroupAnnotationForPod: "pg1",
-								pod_info.GpuMemoryAnnotationName:         "1000",
+								commonconstants.GpuMemory:                "1000",
 							},
 						},
 						Spec: v1.PodSpec{

--- a/pkg/scheduler/api/pod_info/pod_info.go
+++ b/pkg/scheduler/api/pod_info/pod_info.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	GpuMemoryAnnotationName            = "gpu-memory"
 	GPUGroup                           = "runai-gpu-group"
 	ReceivedResourceTypeAnnotationName = "received-resource-type"
 	WholeGpuIndicator                  = "-2"
@@ -501,13 +500,13 @@ func (pi *PodInfo) updatePodAdditionalFields(bindRequest *bindrequest_info.BindR
 		}
 	}
 
-	gpuMemory, err := strconv.ParseInt(pi.Pod.Annotations[GpuMemoryAnnotationName], 10, 64)
+	gpuMemory, err := strconv.ParseInt(pi.Pod.Annotations[commonconstants.GpuMemory], 10, 64)
 	if err == nil && gpuMemory > 0 {
 		pi.GpuRequirement = *resource_info.NewGpuResourceRequirementWithGpus(0, gpuMemory)
 		pi.ResourceRequestType = RequestTypeGpuMemory
 	}
 
-	gpuFractionString := pi.Pod.Annotations[common_info.GPUFraction]
+	gpuFractionString := pi.Pod.Annotations[commonconstants.GpuFraction]
 	gpuFraction, GPUFractionErr := strconv.ParseFloat(gpuFractionString, 64)
 	if !(gpuFraction <= 0 || gpuFraction > 1 || GPUFractionErr != nil) {
 		pi.GpuRequirement = *resource_info.NewGpuResourceRequirementWithGpus(gpuFraction, 0)

--- a/pkg/scheduler/api/pod_info/pod_info_benchmark_test.go
+++ b/pkg/scheduler/api/pod_info/pod_info_benchmark_test.go
@@ -84,7 +84,7 @@ func createPodInfoWithGPU() *PodInfo {
 			Name:      "gpu-pod",
 			Namespace: "default",
 			Annotations: map[string]string{
-				common_info.GPUFraction: "0.5",
+				constants.GpuFraction: "0.5",
 			},
 			Labels: map[string]string{
 				GPUGroup: "group-1",
@@ -119,7 +119,7 @@ func createPodInfoWithMultipleGPUs() *PodInfo {
 			Namespace: "default",
 			Annotations: map[string]string{
 				constants.GpuFractionsNumDevices: "3",
-				common_info.GPUFraction:          "0.5",
+				constants.GpuFraction:            "0.5",
 			},
 			Labels: map[string]string{
 				constants.MultiGpuGroupLabelPrefix + "gpu-group-0": "group-0",

--- a/pkg/scheduler/api/pod_info/pod_info_test.go
+++ b/pkg/scheduler/api/pod_info/pod_info_test.go
@@ -414,7 +414,7 @@ func TestPodInfo_updatePodAdditionalFields(t *testing.T) {
 					nil,
 					map[string]string{},
 					map[string]string{
-						GpuMemoryAnnotationName: "1024",
+						commonconstants.GpuMemory: "1024",
 					}),
 			},
 			expected{
@@ -438,7 +438,7 @@ func TestPodInfo_updatePodAdditionalFields(t *testing.T) {
 					nil,
 					map[string]string{},
 					map[string]string{
-						GpuMemoryAnnotationName:                "1024",
+						commonconstants.GpuMemory:              "1024",
 						commonconstants.GpuFractionsNumDevices: "2",
 					}),
 			},
@@ -463,7 +463,7 @@ func TestPodInfo_updatePodAdditionalFields(t *testing.T) {
 					nil,
 					map[string]string{},
 					map[string]string{
-						common_info.GPUFraction: "0.5",
+						commonconstants.GpuFraction: "0.5",
 					}),
 			},
 			expected{
@@ -487,7 +487,7 @@ func TestPodInfo_updatePodAdditionalFields(t *testing.T) {
 					nil,
 					map[string]string{},
 					map[string]string{
-						common_info.GPUFraction: "0.5",
+						commonconstants.GpuFraction: "0.5",
 					}),
 				bindingRequest: &bindrequest_info.BindRequestInfo{
 					BindRequest: &schedulingv1alpha2.BindRequest{
@@ -519,7 +519,7 @@ func TestPodInfo_updatePodAdditionalFields(t *testing.T) {
 					nil,
 					map[string]string{},
 					map[string]string{
-						common_info.GPUFraction:                "0.5",
+						commonconstants.GpuFraction:            "0.5",
 						commonconstants.GpuFractionsNumDevices: "3",
 					}),
 			},

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -18,7 +18,6 @@ import (
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/resources"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
@@ -258,7 +257,7 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 						Namespace: "n1",
 						Annotations: map[string]string{
 							commonconstants.PodGroupAnnotationForPod: "pg1",
-							common_info.GPUFraction:                  "0.5",
+							commonconstants.GpuFraction:              "0.5",
 						},
 					},
 					Spec: v1.PodSpec{

--- a/pkg/scheduler/test_utils/tasks_fake/tasks.go
+++ b/pkg/scheduler/test_utils/tasks_fake/tasks.go
@@ -13,7 +13,6 @@ import (
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/resources"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 )
@@ -67,8 +66,8 @@ func BuildPod(
 				return baseLabels
 			}(),
 			Annotations: map[string]string{
-				common_info.GPUFraction:                  gpuFraction,
-				pod_info.GpuMemoryAnnotationName:         gpuMemory,
+				commonconstants.GpuFraction:              gpuFraction,
+				commonconstants.GpuMemory:                gpuMemory,
 				commonconstants.PodGroupAnnotationForPod: jobName,
 			},
 		},


### PR DESCRIPTION
## Description

Replace the locally-defined GPUFraction (common_info) and GpuMemoryAnnotationName (pod_info) constants with the shared commonconstants.GpuFraction and commonconstants.GpuMemory, removing the duplicate definitions and pointing all call sites at the single source.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
