### PR TITLE
fix(scheduler): count GPU-memory requests toward queue capacity

### DIFF
--- a/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
@@ -77,7 +77,7 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 					},
 				},
 				// 3 tasks × 40 MiB ≈ 120 MiB, each gpu in the unitests is 100 MiB,
-				// so the required 2.4 GPU-equivalents exceeds the queue's deserved quota of 1.
+				// so the required 1.2 GPU-equivalents exceeds the queue's deserved quota of 1.
 				// A non-preemptible job must not exceed deserved quota, so the
 				// job-level capacity check blocks it (same as for fraction requests).
 				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
@@ -131,7 +131,7 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 					},
 				},
 				// 3 tasks × 40 MiB ≈ 120 MiB, each gpu in the unitests is 100 MiB,
-				// so the required 2.4 GPU-equivalents exceeds the queue's hard limit (MaxAllowed) of 1.
+				// so the required 1.2 GPU-equivalents exceeds the queue's hard limit (MaxAllowed) of 1.
 				// Even a preemptible job cannot exceed the limit, so the
 				// job-level capacity check blocks it (same as for fraction requests).
 				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{

--- a/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
@@ -76,8 +76,9 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 						DeservedGPUs: 1,
 					},
 				},
-				// 3 tasks × 40 MiB ≈ 2.4 GPU-equivalents exceeds the queue's deserved
-				// quota of 1. A non-preemptible job must not exceed deserved quota, so the
+				// 3 tasks × 40 MiB ≈ 120 MiB, each gpu in the unitests is 100 MiB,
+				// so the required 2.4 GPU-equivalents exceeds the queue's deserved quota of 1.
+				// A non-preemptible job must not exceed deserved quota, so the
 				// job-level capacity check blocks it (same as for fraction requests).
 				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
 					"pending_job-0": {
@@ -129,8 +130,9 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 						MaxAllowedGPUs: 1,
 					},
 				},
-				// 3 tasks × 40 MiB ≈ 2.4 GPU-equivalents exceeds the queue's hard limit
-				// (MaxAllowed) of 1. Even a preemptible job cannot exceed the limit, so the
+				// 3 tasks × 40 MiB ≈ 120 MiB, each gpu in the unitests is 100 MiB,
+				// so the required 2.4 GPU-equivalents exceeds the queue's hard limit (MaxAllowed) of 1.
+				// Even a preemptible job cannot exceed the limit, so the
 				// job-level capacity check blocks it (same as for fraction requests).
 				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
 					"pending_job-0": {

--- a/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
+++ b/pkg/scheduler/actions/allocate/allocateGpuMemory_test.go
@@ -76,16 +76,18 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 						DeservedGPUs: 1,
 					},
 				},
+				// 3 tasks × 40 MiB ≈ 2.4 GPU-equivalents exceeds the queue's deserved
+				// quota of 1. A non-preemptible job must not exceed deserved quota, so the
+				// job-level capacity check blocks it (same as for fraction requests).
 				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
 					"pending_job-0": {
 						Status:       pod_status.Pending,
-						GPUsAccepted: 0.8,
-						GPUGroups:    []string{"0"},
+						GPUsAccepted: 0,
 					},
 				},
 				Mocks: &test_utils.TestMock{
 					CacheRequirements: &test_utils.CacheMocking{
-						NumberOfCacheBinds: 5,
+						NumberOfCacheBinds: 0,
 					},
 				},
 			},
@@ -127,16 +129,18 @@ func getMemoryGPUTestsMetadata() []integration_tests_utils.TestTopologyMetadata 
 						MaxAllowedGPUs: 1,
 					},
 				},
+				// 3 tasks × 40 MiB ≈ 2.4 GPU-equivalents exceeds the queue's hard limit
+				// (MaxAllowed) of 1. Even a preemptible job cannot exceed the limit, so the
+				// job-level capacity check blocks it (same as for fraction requests).
 				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
 					"pending_job-0": {
 						Status:       pod_status.Pending,
-						GPUsAccepted: 0.8,
-						GPUGroups:    []string{"0"},
+						GPUsAccepted: 0,
 					},
 				},
 				Mocks: &test_utils.TestMock{
 					CacheRequirements: &test_utils.CacheMocking{
-						NumberOfCacheBinds: 5,
+						NumberOfCacheBinds: 0,
 					},
 				},
 			},

--- a/pkg/scheduler/actions/common/allocate.go
+++ b/pkg/scheduler/actions/common/allocate.go
@@ -192,7 +192,7 @@ func allocateTask(ssn *framework.Session, stmt *framework.Statement, nodes []*no
 }
 
 func allocateTaskToNode(ssn *framework.Session, stmt *framework.Statement, task *pod_info.PodInfo, node *node_info.NodeInfo, isPipelineOnly bool) bool {
-	if task.IsFractionRequest() || task.IsMemoryRequest() {
+	if task.IsFractionRequest() || task.IsGpuMemoryRequest() {
 		return gpu_sharing.AllocateFractionalGPUTaskToNode(ssn, stmt, task, node, isPipelineOnly)
 	}
 

--- a/pkg/scheduler/api/node_info/node_info.go
+++ b/pkg/scheduler/api/node_info/node_info.go
@@ -153,7 +153,7 @@ func (ni *NodeInfo) NonAllocatedResource(resourceType v1.ResourceName) float64 {
 
 func (ni *NodeInfo) IsTaskAllocatable(task *pod_info.PodInfo) bool {
 	if isBestEffortJob := task.GpuRequirement.IsEmpty() && task.ResReqVector.IsZero() &&
-		(len(task.GetAllStorageClaims()) == 0) && !task.IsMemoryRequest(); isBestEffortJob {
+		(len(task.GetAllStorageClaims()) == 0) && !task.IsGpuMemoryRequest(); isBestEffortJob {
 		return true
 	}
 

--- a/pkg/scheduler/api/pod_info/pod_info.go
+++ b/pkg/scheduler/api/pod_info/pod_info.go
@@ -333,7 +333,7 @@ func (pi *PodInfo) IsMigCandidate() bool {
 	return pi.ResourceRequestType == RequestTypeMigInstance
 }
 
-func (pi *PodInfo) IsMemoryRequest() bool {
+func (pi *PodInfo) IsGpuMemoryRequest() bool {
 	return pi.ResourceRequestType == RequestTypeGpuMemory
 }
 
@@ -342,7 +342,7 @@ func (pi *PodInfo) IsRegularGPURequest() bool {
 }
 
 func (pi *PodInfo) IsSharedGPURequest() bool {
-	return pi.IsFractionRequest() || pi.IsMemoryRequest()
+	return pi.IsFractionRequest() || pi.IsGpuMemoryRequest()
 }
 
 func (pi *PodInfo) IsSharedGPUAllocation() bool {
@@ -355,7 +355,7 @@ func (pi *PodInfo) IsCPUOnlyRequest() bool {
 
 func (pi *PodInfo) IsRequireAnyKindOfGPU() bool {
 	return pi.GpuRequirement.GPUs() > 0 || pi.GpuRequirement.GetDraGpusCount() > 0 ||
-		pi.IsMemoryRequest() || pi.IsMigProfileRequest()
+		pi.IsGpuMemoryRequest() || pi.IsMigProfileRequest()
 }
 
 func (pi *PodInfo) GetSchedulingConstraintsSignature() common_info.SchedulingConstraintsSignature {

--- a/pkg/scheduler/api/podgroup_info/allocation_info.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info.go
@@ -170,7 +170,7 @@ func GetTasksToAllocateInitResourceVector(
 	for _, task := range GetTasksToAllocate(podGroupInfo, subGroupOrderFn, taskOrderFn, isRealAllocation) {
 		if task.ShouldAllocate(isRealAllocation) {
 			result.Add(task.ResReqVector)
-			if task.IsMemoryRequest() && minNodeGPUMemory > 0 {
+			if task.IsGpuMemoryRequest() && minNodeGPUMemory > 0 {
 				result.Set(gpuIdx, result.Get(gpuIdx)+task.GpuRequirement.GpuMemoryAsGpuFraction(minNodeGPUMemory))
 			}
 		}

--- a/pkg/scheduler/api/podgroup_info/allocation_info.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info.go
@@ -171,9 +171,7 @@ func GetTasksToAllocateInitResourceVector(
 		if task.ShouldAllocate(isRealAllocation) {
 			result.Add(task.ResReqVector)
 			if task.IsMemoryRequest() && minNodeGPUMemory > 0 {
-				additionalGpuFraction := float64(task.GpuRequirement.GetNumOfGpuDevices()) *
-					(float64(task.GpuRequirement.GpuMemory()) / float64(minNodeGPUMemory))
-				result.Set(gpuIdx, result.Get(gpuIdx)+additionalGpuFraction)
+				result.Set(gpuIdx, result.Get(gpuIdx)+task.GpuRequirement.GpuMemoryAsGpuFraction(minNodeGPUMemory))
 			}
 		}
 	}

--- a/pkg/scheduler/api/resource_info/gpu_resource_requirment.go
+++ b/pkg/scheduler/api/resource_info/gpu_resource_requirment.go
@@ -224,6 +224,16 @@ func (g *GpuResourceRequirement) GPUs() float64 {
 	return getExtendedResourceGpus(g.portion, g.count)
 }
 
+// GpuMemoryAsGpuFraction converts a GPU-memory request into an equivalent whole-GPU
+// quota amount using gpuDeviceMemory as the per-device memory basis. Returns 0 for
+// non-memory requests or non-positive gpuDeviceMemory.
+func (g *GpuResourceRequirement) GpuMemoryAsGpuFraction(gpuDeviceMemory int64) float64 {
+	if g.gpuMemory <= 0 || gpuDeviceMemory <= 0 {
+		return 0
+	}
+	return float64(g.count) * (float64(g.gpuMemory) / float64(gpuDeviceMemory))
+}
+
 func (g *GpuResourceRequirement) GetNumOfGpuDevices() int64 {
 	return g.count
 }

--- a/pkg/scheduler/api/resource_info/gpu_resource_requirment_test.go
+++ b/pkg/scheduler/api/resource_info/gpu_resource_requirment_test.go
@@ -44,6 +44,25 @@ var _ = Describe("GpuResourceRequirement mechanism", func() {
 		})
 	})
 
+	Context("GpuMemoryAsGpuFraction", func() {
+		It("converts memory to an equivalent gpu fraction", func() {
+			gpuResource := NewGpuResourceRequirementWithGpus(0, 50)
+			Expect(gpuResource.GpuMemoryAsGpuFraction(100)).To(Equal(0.5))
+		})
+		It("scales by the number of devices", func() {
+			gpuResource := NewGpuResourceRequirementWithMultiFraction(2, 0, 50)
+			Expect(gpuResource.GpuMemoryAsGpuFraction(100)).To(Equal(1.0))
+		})
+		It("returns 0 for a non-memory request", func() {
+			gpuResource := NewGpuResourceRequirementWithGpus(0.5, 0)
+			Expect(gpuResource.GpuMemoryAsGpuFraction(100)).To(Equal(float64(0)))
+		})
+		It("returns 0 when the device memory basis is non-positive", func() {
+			gpuResource := NewGpuResourceRequirementWithGpus(0, 50)
+			Expect(gpuResource.GpuMemoryAsGpuFraction(0)).To(Equal(float64(0)))
+		})
+	})
+
 	Context("SetMaxResource", func() {
 		It("Supported Resources", func() {
 			gpuResource1 := newGpuResourceRequirementWithValues(5, 0, map[v1.ResourceName]int64{

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy.go
@@ -72,11 +72,12 @@ func getRequiredQuota(tasksToAllocate []*pod_info.PodInfo, minNodeGPUMemory int6
 	quota := rs.EmptyResourceQuantities()
 	for _, pod := range tasksToAllocate {
 		quantities := utils.QuantifyVector(pod.ResReqVector, pod.VectorMap)
-		quota[rs.GpuResource] += quantities[rs.GpuResource]
 		quota[rs.CpuResource] += quantities[rs.CpuResource]
 		quota[rs.MemoryResource] += quantities[rs.MemoryResource]
-		if pod.IsMemoryRequest() {
+		if pod.IsGpuMemoryRequest() {
 			quota[rs.GpuResource] += pod.GpuRequirement.GpuMemoryAsGpuFraction(minNodeGPUMemory)
+		} else {
+			quota[rs.GpuResource] += quantities[rs.GpuResource]
 		}
 	}
 	return quota

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy.go
@@ -18,16 +18,17 @@ import (
 type capacityCheckFn func(requestedShare rs.ResourceQuantities, job *podgroup_info.PodGroupInfo) *api.SchedulableResult
 
 type CapacityPolicy struct {
-	queues map[common_info.QueueID]*rs.QueueAttributes
+	queues           map[common_info.QueueID]*rs.QueueAttributes
+	minNodeGPUMemory int64
 }
 
-func New(queues map[common_info.QueueID]*rs.QueueAttributes) *CapacityPolicy {
-	return &CapacityPolicy{queues}
+func New(queues map[common_info.QueueID]*rs.QueueAttributes, minNodeGPUMemory int64) *CapacityPolicy {
+	return &CapacityPolicy{queues, minNodeGPUMemory}
 }
 
 func (cp *CapacityPolicy) IsJobOverQueueCapacity(job *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo) *api.SchedulableResult {
-	requestedShareQuantities := getRequiredQuota(tasksToAllocate)
+	requestedShareQuantities := getRequiredQuota(tasksToAllocate, cp.minNodeGPUMemory)
 
 	checkFns := []capacityCheckFn{cp.resultsOverLimit, cp.resultsWithNonPreemptibleOverQuota}
 	return cp.isJobOverCapacity(requestedShareQuantities, job, checkFns)
@@ -36,7 +37,7 @@ func (cp *CapacityPolicy) IsJobOverQueueCapacity(job *podgroup_info.PodGroupInfo
 func (cp *CapacityPolicy) IsNonPreemptibleJobOverQuota(job *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo) *api.SchedulableResult {
 
-	requestedShareQuantities := getRequiredQuota(tasksToAllocate)
+	requestedShareQuantities := getRequiredQuota(tasksToAllocate, cp.minNodeGPUMemory)
 
 	checkFns := []capacityCheckFn{cp.resultsWithNonPreemptibleOverQuota}
 	return cp.isJobOverCapacity(requestedShareQuantities, job, checkFns)
@@ -67,13 +68,16 @@ func (cp *CapacityPolicy) isJobOverCapacity(requestedShare rs.ResourceQuantities
 	return Schedulable()
 }
 
-func getRequiredQuota(tasksToAllocate []*pod_info.PodInfo) rs.ResourceQuantities {
+func getRequiredQuota(tasksToAllocate []*pod_info.PodInfo, minNodeGPUMemory int64) rs.ResourceQuantities {
 	quota := rs.EmptyResourceQuantities()
 	for _, pod := range tasksToAllocate {
 		quantities := utils.QuantifyVector(pod.ResReqVector, pod.VectorMap)
 		quota[rs.GpuResource] += quantities[rs.GpuResource]
 		quota[rs.CpuResource] += quantities[rs.CpuResource]
 		quota[rs.MemoryResource] += quantities[rs.MemoryResource]
+		if pod.IsMemoryRequest() {
+			quota[rs.GpuResource] += pod.GpuRequirement.GpuMemoryAsGpuFraction(minNodeGPUMemory)
+		}
 	}
 	return quota
 }

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
@@ -32,6 +32,210 @@ var _ = Describe("Capacity Policy Check", func() {
 				job            *podgroup_info.PodGroupInfo
 				expectedResult bool
 			}{
+				"limited queues - gpu memory request over limit": {
+					queues: map[common_info.QueueID]*rs.QueueAttributes{
+						"top-queue": {
+							UID:               "top-queue",
+							Name:              "top-queue",
+							ParentQueue:       "",
+							ChildQueues:       []common_info.QueueID{"mid-queue"},
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 3,
+									Allocated:  3,
+								},
+							},
+						},
+						"mid-queue": {
+							UID:               "mid-queue",
+							Name:              "mid-queue",
+							ParentQueue:       "top-queue",
+							ChildQueues:       []common_info.QueueID{"leaf-queue"},
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 3,
+									Allocated:  3,
+								},
+							},
+						},
+						"leaf-queue": {
+							UID:               "leaf-queue",
+							Name:              "leaf-queue",
+							ParentQueue:       "mid-queue",
+							ChildQueues:       nil,
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 3,
+									Allocated:  3,
+								},
+							},
+						},
+					},
+					job: &podgroup_info.PodGroupInfo{
+						Name:           "job-a",
+						Namespace:      "team-a",
+						Queue:          "leaf-queue",
+						Preemptibility: v2alpha2.Preemptible,
+						JobFitErrors:   make([]common_info.JobFitError, 0),
+						PodSets: map[string]*subgroup_info.PodSet{
+							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
+									"task-a": {
+										UID:                 "task-a",
+										Job:                 "job-a",
+										Name:                "task-a",
+										Namespace:           "team-a",
+										Status:              pod_status.Pending,
+										ResourceRequestType: pod_info.RequestTypeGpuMemory,
+										GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(0, node_info.DefaultGpuMemory/2),
+										ResReqVector:        resource_info.NewResourceRequirementsWithGpus(0).ToVector(testVectorMap),
+										VectorMap:           testVectorMap,
+									},
+								}),
+						},
+					},
+					expectedResult: false,
+				},
+				"limited queues - gpu memory request below limit": {
+					queues: map[common_info.QueueID]*rs.QueueAttributes{
+						"top-queue": {
+							UID:               "top-queue",
+							Name:              "top-queue",
+							ParentQueue:       "",
+							ChildQueues:       []common_info.QueueID{"mid-queue"},
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 3,
+									Allocated:  2,
+								},
+							},
+						},
+						"mid-queue": {
+							UID:               "mid-queue",
+							Name:              "mid-queue",
+							ParentQueue:       "top-queue",
+							ChildQueues:       []common_info.QueueID{"leaf-queue"},
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 3,
+									Allocated:  2,
+								},
+							},
+						},
+						"leaf-queue": {
+							UID:               "leaf-queue",
+							Name:              "leaf-queue",
+							ParentQueue:       "mid-queue",
+							ChildQueues:       nil,
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed: 3,
+									Allocated:  2,
+								},
+							},
+						},
+					},
+					job: &podgroup_info.PodGroupInfo{
+						Name:           "job-a",
+						Namespace:      "team-a",
+						Queue:          "leaf-queue",
+						Preemptibility: v2alpha2.Preemptible,
+						JobFitErrors:   make([]common_info.JobFitError, 0),
+						PodSets: map[string]*subgroup_info.PodSet{
+							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
+									"task-a": {
+										UID:                 "task-a",
+										Job:                 "job-a",
+										Name:                "task-a",
+										Namespace:           "team-a",
+										Status:              pod_status.Pending,
+										ResourceRequestType: pod_info.RequestTypeGpuMemory,
+										GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(0, node_info.DefaultGpuMemory/2),
+										ResReqVector:        resource_info.NewResourceRequirementsWithGpus(0).ToVector(testVectorMap),
+										VectorMap:           testVectorMap,
+									},
+								}),
+						},
+					},
+					expectedResult: true,
+				},
+				"unlimited queues - non preemptible gpu memory request over quota": {
+					queues: map[common_info.QueueID]*rs.QueueAttributes{
+						"top-queue": {
+							UID:               "top-queue",
+							Name:              "top-queue",
+							ParentQueue:       "",
+							ChildQueues:       []common_info.QueueID{"mid-queue"},
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed:              commonconstants.UnlimitedResourceQuantity,
+									AllocatedNotPreemptible: 3,
+									Deserved:                3,
+								},
+							},
+						},
+						"mid-queue": {
+							UID:               "mid-queue",
+							Name:              "mid-queue",
+							ParentQueue:       "top-queue",
+							ChildQueues:       []common_info.QueueID{"leaf-queue"},
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed:              commonconstants.UnlimitedResourceQuantity,
+									AllocatedNotPreemptible: 3,
+									Deserved:                3,
+								},
+							},
+						},
+						"leaf-queue": {
+							UID:               "leaf-queue",
+							Name:              "leaf-queue",
+							ParentQueue:       "mid-queue",
+							ChildQueues:       nil,
+							CreationTimestamp: metav1.Time{},
+							QueueResourceShare: rs.QueueResourceShare{
+								GPU: rs.ResourceShare{
+									MaxAllowed:              commonconstants.UnlimitedResourceQuantity,
+									AllocatedNotPreemptible: 3,
+									Deserved:                3,
+								},
+							},
+						},
+					},
+					job: &podgroup_info.PodGroupInfo{
+						Name:           "job-a",
+						Namespace:      "team-a",
+						Queue:          "leaf-queue",
+						Preemptibility: v2alpha2.NonPreemptible,
+						JobFitErrors:   make([]common_info.JobFitError, 0),
+						PodSets: map[string]*subgroup_info.PodSet{
+							podgroup_info.DefaultSubGroup: subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, 1, nil).
+								WithPodInfos(map[common_info.PodID]*pod_info.PodInfo{
+									"task-a": {
+										UID:                 "task-a",
+										Job:                 "job-a",
+										Name:                "task-a",
+										Namespace:           "team-a",
+										Status:              pod_status.Pending,
+										ResourceRequestType: pod_info.RequestTypeGpuMemory,
+										GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(0, node_info.DefaultGpuMemory/2),
+										ResReqVector:        resource_info.NewResourceRequirementsWithGpus(0).ToVector(testVectorMap),
+										VectorMap:           testVectorMap,
+									},
+								}),
+						},
+					},
+					expectedResult: false,
+				},
 				"limited queues - results below limit": {
 					queues: map[common_info.QueueID]*rs.QueueAttributes{
 						"top-queue": {
@@ -169,7 +373,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					tasksToAllocate := podgroup_info.GetTasksToAllocate(testData.job, dummyTasksLessThen,
 						dummyTasksLessThen, true)
 					result := capacityPolicy.IsJobOverQueueCapacity(testData.job, tasksToAllocate)
@@ -328,7 +532,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					tasksToAllocate := podgroup_info.GetTasksToAllocate(testData.job, dummyTasksLessThen,
 						dummyTasksLessThen, true)
 					result := capacityPolicy.IsJobOverQueueCapacity(testData.job, tasksToAllocate)
@@ -490,7 +694,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					tasksToAllocate := podgroup_info.GetTasksToAllocate(testData.job, dummyTasksLessThen,
 						dummyTasksLessThen, true)
 					result := capacityPolicy.IsNonPreemptibleJobOverQuota(testData.job, tasksToAllocate)
@@ -1090,7 +1294,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					result := capacityPolicy.IsTaskAllocationOnNodeOverCapacity(testData.job.GetAllPodsMap()["task-a"],
 						testData.job, testData.node)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
@@ -1153,7 +1357,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					result := capacityPolicy.IsTaskAllocationOnNodeOverCapacity(testData.job.GetAllPodsMap()["task-a"],
 						testData.job, testData.node)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
@@ -1215,7 +1419,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					result := capacityPolicy.IsTaskAllocationOnNodeOverCapacity(testData.job.GetAllPodsMap()["task-a"],
 						testData.job, testData.node)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))

--- a/pkg/scheduler/plugins/proportion/capacity_policy/max_allowed_check_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/max_allowed_check_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	rs "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/resource_share"
 )
@@ -438,7 +439,7 @@ var _ = Describe("Max Allowed Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					result := capacityPolicy.resultsOverLimit(testData.requestedShare, testData.job)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
 					if testData.expectedDetails != nil {

--- a/pkg/scheduler/plugins/proportion/capacity_policy/quota_check_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/quota_check_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	rs "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/resource_share"
 )
@@ -326,7 +327,7 @@ var _ = Describe("Quota Policy Check", func() {
 				testName := name
 				testData := data
 				It(testName, func() {
-					capacityPolicy := New(testData.queues)
+					capacityPolicy := New(testData.queues, node_info.DefaultGpuMemory)
 					result := capacityPolicy.resultsWithNonPreemptibleOverQuota(testData.requestedShare,
 						testData.job)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -102,7 +102,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	pp.taskOrderFunc = ssn.TaskOrderFn
 	pp.minNodeGPUMemory = ssn.ClusterInfo.MinNodeGPUMemory
 	pp.reclaimablePlugin = rec.New(pp.relcaimerSaturationMultiplier)
-	capacityPolicy := cp.New(pp.queues)
+	capacityPolicy := cp.New(pp.queues, pp.minNodeGPUMemory)
 	ssn.AddQueueOrderFn(pp.queueOrder)
 	ssn.AddCanReclaimResourcesFn(pp.CanReclaimResourcesFn)
 	ssn.AddReclaimScenarioValidatorFn(pp.reclaimableFn)
@@ -363,7 +363,7 @@ func (pp *proportionPlugin) updateQueuesCurrentResourceUsage(ssn *framework.Sess
 					resources := utils.QuantifyVector(t.ResReqVector, t.VectorMap)
 					if t.IsMemoryRequest() {
 						resources.Add(rs.ResourceQuantities{
-							rs.GpuResource: float64(t.GpuRequirement.GetNumOfGpuDevices()) * (float64(t.GpuRequirement.GpuMemory()) / float64(ssn.ClusterInfo.MinNodeGPUMemory)),
+							rs.GpuResource: t.GpuRequirement.GpuMemoryAsGpuFraction(ssn.ClusterInfo.MinNodeGPUMemory),
 						})
 					}
 					pp.updateQueuesResourceUsageForPendingJob(job.Queue, resources)

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -361,7 +361,7 @@ func (pp *proportionPlugin) updateQueuesCurrentResourceUsage(ssn *framework.Sess
 			} else if status == pod_status.Pending {
 				for _, t := range tasks {
 					resources := utils.QuantifyVector(t.ResReqVector, t.VectorMap)
-					if t.IsMemoryRequest() {
+					if t.IsGpuMemoryRequest() {
 						resources.Add(rs.ResourceQuantities{
 							rs.GpuResource: t.GpuRequirement.GpuMemoryAsGpuFraction(ssn.ClusterInfo.MinNodeGPUMemory),
 						})


### PR DESCRIPTION
## Description

GPU-memory requests (the gpu-memory annotation) were not converted to their whole-GPU equivalent when computing a job's requested quota in the proportion capacity policy, letting such jobs bypass queue MaxAllowed and non-preemptible Deserved limits.

Add GpuResourceRequirement.GpuMemoryAsGpuFraction to centralize the memory-to-GPU-fraction conversion, thread the cluster's minNodeGPUMemory into the CapacityPolicy, and include the converted amount in getRequiredQuota so over-quota GPU-memory jobs are blocked at the job-level capacity check, matching the behavior for fraction requests.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
