### PR TITLE
test(scheduler): add unschedulable reclaim benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ BENCH_OUTPUT ?= benchmark-results.txt
 # pkg/scheduler/actions/reclaim is excluded from the default benchmark sweep
 # because some reclaim benchmarks require -benchtime=1x and only a curated subset
 # should run in CI.
-BENCH_SPECIAL_PACKAGES := ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/integration_tests/reclaim
+BENCH_SPECIAL_PACKAGES := ./pkg/scheduler/actions/reclaim
 BENCH_SPECIAL_REGEX := '^BenchmarkReclaim(WithMissingPVCJobs|UnschedulableDistributedJob_(10|50|100)Node)$$'
 
 .PHONY: benchstat

--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,10 @@ $(KUSTOMIZE): $(LOCALBIN)
 BENCHSTAT ?= $(LOCALBIN)/benchstat
 BENCH_OUTPUT ?= benchmark-results.txt
 # pkg/scheduler/actions/reclaim is excluded from the default benchmark sweep
-# because BenchmarkReclaimWithMissingPVCJobs requires -benchtime=1x. Add any
-# new reclaim-package benchmarks to a dedicated benchmark phase, or move them
-# out of that package, so they are not skipped by make benchmark.
-BENCH_SPECIAL_PACKAGES := ./pkg/scheduler/actions/reclaim
-BENCH_SPECIAL_REGEX := '^BenchmarkReclaimWithMissingPVCJobs$$'
+# because some reclaim benchmarks require -benchtime=1x and only a curated subset
+# should run in CI.
+BENCH_SPECIAL_PACKAGES := ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/integration_tests/reclaim
+BENCH_SPECIAL_REGEX := '^BenchmarkReclaim(WithMissingPVCJobs|UnschedulableDistributedJob_(10|50|100)Node)$$'
 
 .PHONY: benchstat
 benchstat: $(BENCHSTAT)

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -20,6 +20,20 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
 
+type VeryLargeJobReclaimParams struct {
+	NumNodes                int
+	GPUsPerNode             int
+	NumJobs                 int
+	GPUsPerTask             int
+	VeryLargeJobGPUsPerTask int
+	VeryLargeJobTasks       int
+	Queue0DeservedGPUs      int
+	Queue1DeservedGPUs      int
+	NumberOfCacheBinds      int
+	NumberOfCacheEvictions  int
+	NumberOfPipelineActions int
+}
+
 func init() {
 	test_utils.InitTestingInfrastructure()
 }
@@ -68,6 +82,22 @@ func TestUnschedulableDistributedReclaimTopology(t *testing.T) {
 	}
 }
 
+type unschedulableDistributedReclaimParams struct {
+	NumNodes                int
+	GPUsPerNode             int
+	PodsPerDistributedJob   int
+	RunningJobsPerNode      int
+	Queue0DeservedGPUs      int
+	Queue1DeservedGPUs      int
+	NumberOfCacheBinds      int
+	NumberOfCacheEvictions  int
+	NumberOfPipelineActions int
+}
+
+const (
+	unschedulableDistributedJobName = "unschedulable-distributed-job"
+)
+
 func BenchmarkReclaimLargeJobs_10Node(b *testing.B) {
 	benchmarkReclaimLargeJobs(b, 10)
 }
@@ -91,60 +121,6 @@ func BenchmarkReclaimLargeJobs_500Node(b *testing.B) {
 func BenchmarkReclaimLargeJobs_1000Node(b *testing.B) {
 	benchmarkReclaimLargeJobs(b, 1000)
 }
-
-func BenchmarkReclaimUnschedulableDistributedJob_10Node(b *testing.B) {
-	benchmarkReclaimUnschedulableDistributedJob(b, 10)
-}
-
-func BenchmarkReclaimUnschedulableDistributedJob_50Node(b *testing.B) {
-	benchmarkReclaimUnschedulableDistributedJob(b, 50)
-}
-
-func BenchmarkReclaimUnschedulableDistributedJob_100Node(b *testing.B) {
-	benchmarkReclaimUnschedulableDistributedJob(b, 100)
-}
-
-func BenchmarkReclaimUnschedulableDistributedJob_200Node(b *testing.B) {
-	benchmarkReclaimUnschedulableDistributedJob(b, 200)
-}
-
-func BenchmarkReclaimUnschedulableDistributedJob_500Node(b *testing.B) {
-	benchmarkReclaimUnschedulableDistributedJob(b, 500)
-}
-
-func BenchmarkReclaimUnschedulableDistributedJob_1000Node(b *testing.B) {
-	benchmarkReclaimUnschedulableDistributedJob(b, 1000)
-}
-
-type VeryLargeJobReclaimParams struct {
-	NumNodes                int
-	GPUsPerNode             int
-	NumJobs                 int
-	GPUsPerTask             int
-	VeryLargeJobGPUsPerTask int
-	VeryLargeJobTasks       int
-	Queue0DeservedGPUs      int
-	Queue1DeservedGPUs      int
-	NumberOfCacheBinds      int
-	NumberOfCacheEvictions  int
-	NumberOfPipelineActions int
-}
-
-type unschedulableDistributedReclaimParams struct {
-	NumNodes                int
-	GPUsPerNode             int
-	PodsPerDistributedJob   int
-	RunningJobsPerNode      int
-	Queue0DeservedGPUs      int
-	Queue1DeservedGPUs      int
-	NumberOfCacheBinds      int
-	NumberOfCacheEvictions  int
-	NumberOfPipelineActions int
-}
-
-const (
-	unschedulableDistributedJobName = "unschedulable-distributed-job"
-)
 
 func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 	defer gock.Off()
@@ -171,34 +147,6 @@ func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 		action := reclaim.New()
 		action.Execute(ssn)
 		ctrl.Finish()
-	}
-}
-
-func benchmarkReclaimUnschedulableDistributedJob(b *testing.B, numNodes int) {
-	defer gock.Off()
-
-	topology := buildUnschedulableDistributedReclaimTopology(defaultUnschedulableDistributedReclaimParams(numNodes))
-	action := reclaim.New()
-
-	for b.Loop() {
-		ctrl := gomock.NewController(b)
-		ssn := test_utils.BuildSession(topology, ctrl)
-		action.Execute(ssn)
-		ctrl.Finish()
-	}
-}
-
-func defaultUnschedulableDistributedReclaimParams(numNodes int) unschedulableDistributedReclaimParams {
-	return unschedulableDistributedReclaimParams{
-		NumNodes:                numNodes,
-		GPUsPerNode:             8,
-		PodsPerDistributedJob:   10,
-		RunningJobsPerNode:      8,
-		Queue0DeservedGPUs:      (numNodes * 8) - (10 * 8) + 1,
-		Queue1DeservedGPUs:      10 * 8,
-		NumberOfCacheBinds:      0,
-		NumberOfCacheEvictions:  0,
-		NumberOfPipelineActions: 0,
 	}
 }
 
@@ -263,6 +211,20 @@ func buildReclaimTopology(params VeryLargeJobReclaimParams) test_utils.TestTopol
 				NumberOfPipelineActions: params.NumberOfPipelineActions,
 			},
 		},
+	}
+}
+
+func defaultUnschedulableDistributedReclaimParams(numNodes int) unschedulableDistributedReclaimParams {
+	return unschedulableDistributedReclaimParams{
+		NumNodes:                numNodes,
+		GPUsPerNode:             8,
+		PodsPerDistributedJob:   10,
+		RunningJobsPerNode:      8,
+		Queue0DeservedGPUs:      (numNodes * 8) - (10 * 8) + 1,
+		Queue1DeservedGPUs:      10 * 8,
+		NumberOfCacheBinds:      0,
+		NumberOfCacheEvictions:  0,
+		NumberOfPipelineActions: 0,
 	}
 }
 

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/h2non/gock.v1"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
@@ -21,6 +22,50 @@ import (
 
 func init() {
 	test_utils.InitTestingInfrastructure()
+}
+
+func TestUnschedulableDistributedReclaimTopology(t *testing.T) {
+	defer gock.Off()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	params := defaultUnschedulableDistributedReclaimParams(10)
+	topology := buildUnschedulableDistributedReclaimTopology(params)
+
+	ssn := test_utils.BuildSession(topology, ctrl)
+	onJobSolutionStartCalls := 0
+	ssn.AddOnJobSolutionStartFn(func() {
+		onJobSolutionStartCalls++
+	})
+
+	action := reclaim.New()
+	action.Execute(ssn)
+
+	job := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID(unschedulableDistributedJobName)]
+	if job == nil {
+		t.Fatalf("expected distributed job %q in session", unschedulableDistributedJobName)
+	}
+
+	if onJobSolutionStartCalls == 0 {
+		t.Fatalf("expected reclaim to attempt solving for the distributed job")
+	}
+
+	if len(job.PodStatusIndex[pod_status.Pending]) != params.PodsPerDistributedJob {
+		t.Fatalf("expected %d pending distributed-job tasks, got %d",
+			params.PodsPerDistributedJob, len(job.PodStatusIndex[pod_status.Pending]))
+	}
+
+	for _, clusterJob := range ssn.ClusterInfo.PodGroupInfos {
+		if len(clusterJob.PodStatusIndex[pod_status.Releasing]) != 0 {
+			t.Fatalf("expected no committed reclaimees, found %d releasing tasks on job %q",
+				len(clusterJob.PodStatusIndex[pod_status.Releasing]), clusterJob.Name)
+		}
+		if len(clusterJob.PodStatusIndex[pod_status.Pipelined]) != 0 {
+			t.Fatalf("expected no pipelined tasks after failed reclaim, found %d on job %q",
+				len(clusterJob.PodStatusIndex[pod_status.Pipelined]), clusterJob.Name)
+		}
+	}
 }
 
 func BenchmarkReclaimLargeJobs_10Node(b *testing.B) {
@@ -47,6 +92,30 @@ func BenchmarkReclaimLargeJobs_1000Node(b *testing.B) {
 	benchmarkReclaimLargeJobs(b, 1000)
 }
 
+func BenchmarkReclaimUnschedulableDistributedJob_10Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 10)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_50Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 50)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_100Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 100)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_200Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 200)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_500Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 500)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_1000Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 1000)
+}
+
 type VeryLargeJobReclaimParams struct {
 	NumNodes                int
 	GPUsPerNode             int
@@ -60,6 +129,22 @@ type VeryLargeJobReclaimParams struct {
 	NumberOfCacheEvictions  int
 	NumberOfPipelineActions int
 }
+
+type unschedulableDistributedReclaimParams struct {
+	NumNodes                int
+	GPUsPerNode             int
+	PodsPerDistributedJob   int
+	RunningJobsPerNode      int
+	Queue0DeservedGPUs      int
+	Queue1DeservedGPUs      int
+	NumberOfCacheBinds      int
+	NumberOfCacheEvictions  int
+	NumberOfPipelineActions int
+}
+
+const (
+	unschedulableDistributedJobName = "unschedulable-distributed-job"
+)
 
 func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 	defer gock.Off()
@@ -86,6 +171,34 @@ func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 		action := reclaim.New()
 		action.Execute(ssn)
 		ctrl.Finish()
+	}
+}
+
+func benchmarkReclaimUnschedulableDistributedJob(b *testing.B, numNodes int) {
+	defer gock.Off()
+
+	topology := buildUnschedulableDistributedReclaimTopology(defaultUnschedulableDistributedReclaimParams(numNodes))
+	action := reclaim.New()
+
+	for b.Loop() {
+		ctrl := gomock.NewController(b)
+		ssn := test_utils.BuildSession(topology, ctrl)
+		action.Execute(ssn)
+		ctrl.Finish()
+	}
+}
+
+func defaultUnschedulableDistributedReclaimParams(numNodes int) unschedulableDistributedReclaimParams {
+	return unschedulableDistributedReclaimParams{
+		NumNodes:                numNodes,
+		GPUsPerNode:             8,
+		PodsPerDistributedJob:   10,
+		RunningJobsPerNode:      8,
+		Queue0DeservedGPUs:      (numNodes * 8) - (10 * 8) + 1,
+		Queue1DeservedGPUs:      10 * 8,
+		NumberOfCacheBinds:      0,
+		NumberOfCacheEvictions:  0,
+		NumberOfPipelineActions: 0,
 	}
 }
 
@@ -151,4 +264,82 @@ func buildReclaimTopology(params VeryLargeJobReclaimParams) test_utils.TestTopol
 			},
 		},
 	}
+}
+
+func buildUnschedulableDistributedReclaimTopology(
+	params unschedulableDistributedReclaimParams,
+) test_utils.TestTopologyBasic {
+	return test_utils.TestTopologyBasic{
+		Name:  "unschedulable distributed reclaim benchmark",
+		Nodes: buildUnschedulableDistributedReclaimNodes(params),
+		Jobs:  buildUnschedulableDistributedReclaimJobs(params),
+		Queues: []test_utils.TestQueueBasic{
+			{
+				Name:               "queue-0",
+				DeservedGPUs:       float64(params.Queue0DeservedGPUs),
+				GPUOverQuotaWeight: 0,
+			},
+			{
+				Name:               "queue-1",
+				DeservedGPUs:       float64(params.Queue1DeservedGPUs),
+				GPUOverQuotaWeight: 0,
+			},
+		},
+		Mocks: &test_utils.TestMock{
+			CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds:      params.NumberOfCacheBinds,
+				NumberOfCacheEvictions:  params.NumberOfCacheEvictions,
+				NumberOfPipelineActions: params.NumberOfPipelineActions,
+			},
+		},
+	}
+}
+
+func buildUnschedulableDistributedReclaimNodes(
+	params unschedulableDistributedReclaimParams,
+) map[string]nodes_fake.TestNodeBasic {
+	nodes := make(map[string]nodes_fake.TestNodeBasic, params.NumNodes)
+	for i := 0; i < params.NumNodes; i++ {
+		nodes[fmt.Sprintf("node%d", i)] = nodes_fake.TestNodeBasic{
+			GPUs: params.GPUsPerNode,
+		}
+	}
+	return nodes
+}
+
+func buildUnschedulableDistributedReclaimJobs(
+	params unschedulableDistributedReclaimParams,
+) []*jobs_fake.TestJobBasic {
+	runningJobCount := params.NumNodes * params.RunningJobsPerNode
+	jobs := make([]*jobs_fake.TestJobBasic, 0, runningJobCount+1)
+	for i := 0; i < runningJobCount; i++ {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("running-job-%d", i),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           "queue-0",
+			Tasks: []*tasks_fake.TestTaskBasic{
+				{
+					NodeName: fmt.Sprintf("node%d", i%params.NumNodes),
+					State:    pod_status.Running,
+				},
+			},
+		})
+	}
+
+	distributedJob := &jobs_fake.TestJobBasic{
+		Name:                unschedulableDistributedJobName,
+		RequiredGPUsPerTask: float64(params.GPUsPerNode),
+		Priority:            constants.PriorityTrainNumber,
+		QueueName:           "queue-1",
+		Tasks:               make([]*tasks_fake.TestTaskBasic, params.PodsPerDistributedJob),
+	}
+	for i := 0; i < params.PodsPerDistributedJob; i++ {
+		distributedJob.Tasks[i] = &tasks_fake.TestTaskBasic{
+			State: pod_status.Pending,
+		}
+	}
+
+	jobs = append(jobs, distributedJob)
+	return jobs
 }

--- a/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+type unschedulableDistributedReclaimBenchmarkParams struct {
+	NumNodes              int
+	GPUsPerNode           int
+	PodsPerDistributedJob int
+	RunningJobsPerNode    int
+	Queue0DeservedGPUs    int
+	Queue1DeservedGPUs    int
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_10Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 10)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_50Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 50)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_100Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 100)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_200Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 200)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_500Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 500)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_1000Node(b *testing.B) {
+	benchmarkReclaimUnschedulableDistributedJob(b, 1000)
+}
+
+func benchmarkReclaimUnschedulableDistributedJob(b *testing.B, numNodes int) {
+	defer gock.Off()
+
+	test_utils.InitTestingInfrastructure()
+	topology := buildUnschedulableDistributedReclaimBenchmarkTopology(
+		defaultUnschedulableDistributedReclaimBenchmarkParams(numNodes),
+	)
+	action := reclaim.New()
+
+	for b.Loop() {
+		controller := NewController(b)
+		ssn := test_utils.BuildSession(topology, controller)
+		action.Execute(ssn)
+		controller.Finish()
+	}
+}
+
+func defaultUnschedulableDistributedReclaimBenchmarkParams(numNodes int) unschedulableDistributedReclaimBenchmarkParams {
+	return unschedulableDistributedReclaimBenchmarkParams{
+		NumNodes:              numNodes,
+		GPUsPerNode:           8,
+		PodsPerDistributedJob: 10,
+		RunningJobsPerNode:    8,
+		Queue0DeservedGPUs:    (numNodes * 8) - (10 * 8) + 1,
+		Queue1DeservedGPUs:    10 * 8,
+	}
+}
+
+func buildUnschedulableDistributedReclaimBenchmarkTopology(
+	params unschedulableDistributedReclaimBenchmarkParams,
+) test_utils.TestTopologyBasic {
+	nodes := make(map[string]nodes_fake.TestNodeBasic, params.NumNodes)
+	for i := 0; i < params.NumNodes; i++ {
+		nodes[fmt.Sprintf("node%d", i)] = nodes_fake.TestNodeBasic{
+			GPUs: params.GPUsPerNode,
+		}
+	}
+
+	totalRunningJobs := params.NumNodes * params.RunningJobsPerNode
+	jobs := make([]*jobs_fake.TestJobBasic, 0, totalRunningJobs+1)
+	for i := 0; i < totalRunningJobs; i++ {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("running-job-%d", i),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           "queue-0",
+			Tasks: []*tasks_fake.TestTaskBasic{
+				{
+					NodeName: fmt.Sprintf("node%d", i%params.NumNodes),
+					State:    pod_status.Running,
+				},
+			},
+		})
+	}
+
+	distributedTasks := make([]*tasks_fake.TestTaskBasic, params.PodsPerDistributedJob)
+	for i := 0; i < params.PodsPerDistributedJob; i++ {
+		distributedTasks[i] = &tasks_fake.TestTaskBasic{State: pod_status.Pending}
+	}
+
+	jobs = append(jobs, &jobs_fake.TestJobBasic{
+		Name:                "unschedulable-distributed-job",
+		RequiredGPUsPerTask: 8,
+		Priority:            constants.PriorityTrainNumber,
+		QueueName:           "queue-1",
+		Tasks:               distributedTasks,
+	})
+
+	return test_utils.TestTopologyBasic{
+		Name:  "unschedulable distributed reclaim benchmark",
+		Jobs:  jobs,
+		Nodes: nodes,
+		Queues: []test_utils.TestQueueBasic{
+			{
+				Name:               "queue-0",
+				DeservedGPUs:       float64(params.Queue0DeservedGPUs),
+				GPUOverQuotaWeight: 0,
+			},
+			{
+				Name:               "queue-1",
+				DeservedGPUs:       float64(params.Queue1DeservedGPUs),
+				GPUOverQuotaWeight: 0,
+			},
+		},
+		Mocks: &test_utils.TestMock{
+			CacheRequirements: &test_utils.CacheMocking{},
+		},
+	}
+}


### PR DESCRIPTION
## Description

Adds unschedulable distributed reclaim benchmarks that mirror the scale-test reclaim scenario and wires a curated reclaim benchmark subset into `make benchmark`.

The reclaim benchmark target now runs:
- `BenchmarkReclaimWithMissingPVCJobs`
- `BenchmarkReclaimUnschedulableDistributedJob_10Node`
- `BenchmarkReclaimUnschedulableDistributedJob_50Node`
- `BenchmarkReclaimUnschedulableDistributedJob_100Node`

The larger unschedulable variants stay out of CI for now because they are not practical on current `main`.

## Related Issues

Related to #1660 

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

The new benchmark topology is intended to match the unschedulable distributed reclaim scale-test shape, not the existing very-large-job reclaim benchmark.
