### PR TITLE
refactor(api): remove never-populated PodGroup status fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated Go toolchain and base build images to v1.26.3.
 - **Breaking:** The podgroup produced for JobSet is now produces as a single PodGroup per JobSet with a two-level SubGroup hierarchy (one parent SubGroup per `replicatedJob`, one leaf SubGroup per replica) regardless of `startupPolicyOrder`. The `kai.scheduler/batch-min-member` annotation on the JobSet now overrides the root `minSubGroup`; the same annotation on `replicatedJobs[].template.metadata.annotations` overrides the leaf `minMember` (defaulting to `template.spec.parallelism`). [#1617](https://github.com/kai-scheduler/KAI-Scheduler/pull/1617) [davidLif](https://github.com/davidLif)
 
+### Removed
+- Removed the never-populated `status.phase`, `status.running`, `status.succeeded`, `status.failed`, and `status.pending` fields (and the `PodGroupPhase` type) from the `PodGroup` (`scheduling.run.ai/v2alpha2`) schema. No controller ever wrote them; use `status.resourcesStatus` and `status.schedulingConditions` to determine PodGroup liveness. [#1650](https://github.com/kai-scheduler/KAI-Scheduler/issues/1650) [david-gang](https://github.com/david-gang)
+
 ### Fixed
 - Fixed post-delete cleanup hook hardcoding `kai-scheduler` namespace instead of Helm release namespace on `helm uninstall` [#1619](https://github.com/kai-scheduler/KAI-Scheduler/pull/1619) [dttung2905](https://github.com/dttung2905)
 - Improved solver performance in some large reclaim scenarios [#1627](https://github.com/kai-scheduler/KAI-Scheduler/pull/1627) [itsomri](https://github.com/itsomri)

--- a/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
@@ -212,17 +212,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              failed:
-                description: The number of pods which reached phase Failed.
-                format: int32
-                type: integer
-              pending:
-                description: The number of pods which reached phase Pending.
-                format: int32
-                type: integer
-              phase:
-                description: Current phase of PodGroup.
-                type: string
               resourcesStatus:
                 description: Status of resources related to pods connected to this
                   pod group.
@@ -261,10 +250,6 @@ spec:
                       by all running and pending jobs in queue and child queues
                     type: object
                 type: object
-              running:
-                description: The number of actively running pods.
-                format: int32
-                type: integer
               schedulingConditions:
                 description: The scheduling conditions of PodGroup.
                 items:
@@ -410,10 +395,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              succeeded:
-                description: The number of pods which reached phase Succeeded.
-                format: int32
-                type: integer
             type: object
         type: object
     served: true

--- a/pkg/apis/scheduling/v2alpha2/podgroup_types.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_types.go
@@ -140,28 +140,9 @@ type SubGroup struct {
 
 // PodGroupStatus defines the observed state of PodGroup
 type PodGroupStatus struct {
-	// Current phase of PodGroup.
-	Phase PodGroupPhase `json:"phase,omitempty" protobuf:"bytes,1,opt,name=phase"`
-
 	// The conditions of PodGroup.
 	// +optional
 	Conditions []PodGroupCondition `json:"conditions,omitempty" protobuf:"bytes,2,opt,name=conditions"`
-
-	// The number of actively running pods.
-	// +optional
-	Running int32 `json:"running,omitempty" protobuf:"varint,3,opt,name=running"`
-
-	// The number of pods which reached phase Succeeded.
-	// +optional
-	Succeeded int32 `json:"succeeded,omitempty" protobuf:"varint,4,opt,name=succeeded"`
-
-	// The number of pods which reached phase Failed.
-	// +optional
-	Failed int32 `json:"failed,omitempty" protobuf:"varint,5,opt,name=failed"`
-
-	// The number of pods which reached phase Pending.
-	// +optional
-	Pending int32 `json:"pending,omitempty" protobuf:"varint,6,opt,name=pending"`
 
 	// The scheduling conditions of PodGroup.
 	// +optional
@@ -171,9 +152,6 @@ type PodGroupStatus struct {
 	// +optional
 	ResourcesStatus PodGroupResourcesStatus `json:"resourcesStatus,omitempty" protobuf:"bytes,8,opt,name=resourcesStatus"`
 }
-
-// PodGroupPhase is the phase of a pod group at the current time.
-type PodGroupPhase string
 
 type PodGroupConditionType string
 

--- a/pkg/env-tests/scheduler_test.go
+++ b/pkg/env-tests/scheduler_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Scheduler", Ordered, func() {
 			var podgroup schedulingv2alpha2.PodGroup
 			Expect(ctrlClient.Get(ctx, client.ObjectKey{Name: "test-podgroup", Namespace: testNamespace.Name}, &podgroup)).
 				To(Succeed(), "Failed to get test podgroup")
-			podgroup.Status.Pending = 42
+			podgroup.Status.Conditions = []schedulingv2alpha2.PodGroupCondition{{Type: "test"}}
 			err = ctrlClient.Status().Update(ctx, &podgroup)
 			Expect(err).To(HaveOccurred(), "Expected to fail to update podgroup status")
 

--- a/pkg/podgroupcontroller/controllers/patcher/pod_group_test.go
+++ b/pkg/podgroupcontroller/controllers/patcher/pod_group_test.go
@@ -80,7 +80,7 @@ func TestShouldUpdatePodGroupStatus(t *testing.T) {
 			args{
 				podGroup: &v2alpha2.PodGroup{
 					Status: v2alpha2.PodGroupStatus{
-						Running: 3,
+						Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 						ResourcesStatus: v2alpha2.PodGroupResourcesStatus{
 							Requested: map[v1.ResourceName]resource.Quantity{
 								"cpu": resource.MustParse("1"),
@@ -130,7 +130,7 @@ func TestUpdatePodGroupStatus(t *testing.T) {
 						Name:      "m1",
 					},
 					Status: v2alpha2.PodGroupStatus{
-						Phase: v2alpha2.PodGroupPhase("p1"),
+						Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 					},
 				},
 				&metadata.PodGroupMetadata{
@@ -141,7 +141,7 @@ func TestUpdatePodGroupStatus(t *testing.T) {
 			},
 			false,
 			&v2alpha2.PodGroupStatus{
-				Phase: v2alpha2.PodGroupPhase("p1"),
+				Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 				ResourcesStatus: v2alpha2.PodGroupResourcesStatus{
 					Requested: map[v1.ResourceName]resource.Quantity{
 						"cpu": resource.MustParse("1"),
@@ -158,7 +158,7 @@ func TestUpdatePodGroupStatus(t *testing.T) {
 						Name:      "m1",
 					},
 					Status: v2alpha2.PodGroupStatus{
-						Phase: v2alpha2.PodGroupPhase("p1"),
+						Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 					},
 				},
 				&metadata.PodGroupMetadata{
@@ -174,7 +174,7 @@ func TestUpdatePodGroupStatus(t *testing.T) {
 			},
 			false,
 			&v2alpha2.PodGroupStatus{
-				Phase: v2alpha2.PodGroupPhase("p1"),
+				Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 				ResourcesStatus: v2alpha2.PodGroupResourcesStatus{
 					Requested: map[v1.ResourceName]resource.Quantity{
 						"cpu": resource.MustParse("1"),
@@ -195,7 +195,7 @@ func TestUpdatePodGroupStatus(t *testing.T) {
 						Name:      "m1",
 					},
 					Status: v2alpha2.PodGroupStatus{
-						Phase: v2alpha2.PodGroupPhase("p1"),
+						Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 					},
 				},
 				&metadata.PodGroupMetadata{
@@ -211,7 +211,7 @@ func TestUpdatePodGroupStatus(t *testing.T) {
 			},
 			false,
 			&v2alpha2.PodGroupStatus{
-				Phase: v2alpha2.PodGroupPhase("p1"),
+				Conditions: []v2alpha2.PodGroupCondition{{Type: "c1"}},
 				ResourcesStatus: v2alpha2.PodGroupResourcesStatus{
 					Requested: map[v1.ResourceName]resource.Quantity{
 						"cpu": resource.MustParse("1"),

--- a/pkg/queuecontroller/controllers/suite_test.go
+++ b/pkg/queuecontroller/controllers/suite_test.go
@@ -245,7 +245,6 @@ var _ = Describe("QueueController", Ordered, func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "pod-group-2", Namespace: "default"}, createdPodGroup2)).Should(Succeed())
 
 			createdPodGroup1.Status = v2alpha2.PodGroupStatus{
-				Running: 1,
 				ResourcesStatus: v2alpha2.PodGroupResourcesStatus{
 					Allocated: v1.ResourceList{
 						"cpu":    resource.MustParse("2"),
@@ -264,7 +263,6 @@ var _ = Describe("QueueController", Ordered, func() {
 			Expect(k8sClient.Status().Update(ctx, createdPodGroup1)).Should(Succeed())
 
 			createdPodGroup2.Status = v2alpha2.PodGroupStatus{
-				Running: 1,
 				ResourcesStatus: v2alpha2.PodGroupResourcesStatus{
 					Allocated: v1.ResourceList{
 						"nvidia.com/gpu": resource.MustParse("2"),


### PR DESCRIPTION
## Description

The `PodGroup` (`scheduling.run.ai/v2alpha2`) status schema exposes `phase`, `running`, `succeeded`, `failed`, and `pending`, but no controller ever populates them — they are inert leftovers from the kube-batch/Volcano lineage. They appear authoritative in the served schema yet always read empty/zero, trapping consumers.

This PR removes those fields (and the `PodGroupPhase` type). Per the issue discussion, liveness should be determined via `status.resourcesStatus` and `status.schedulingConditions`, which remain. The `conditions` field is kept untouched.

- Removed `status.phase` / `running` / `succeeded` / `failed` / `pending` and the `PodGroupPhase` type from `pkg/apis/scheduling/v2alpha2/podgroup_types.go`
- Regenerated CRD manifest and deepcopy (`make generate manifests`)
- Updated two tests that used the removed fields as arbitrary filler to use the surviving `Conditions` field, preserving each test's original assertion

## Related Issues

Fixes #1650

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

These fields are removed from the served `v2alpha2` schema. Because `v2alpha2` is an **alpha** version (no compatibility guarantee under the Kubernetes API deprecation policy) and the fields belong to `status` (reconstructed by controllers, never written here), no new API version or conversion is required. On upgrade the CRD applies cleanly; existing PodGroups carry no data in these fields, so nothing is lost. Any consumer reading `status.phase`/counters (always empty today) must switch to `status.resourcesStatus` + `status.schedulingConditions`.

## Additional Notes

CHANGELOG updated under a new `Removed` section.