### PR TITLE
feat(admission): add opt-in deviceaccess plugin for NVIDIA_VISIBLE_DEVICES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Added an opt-in `deviceaccess` admission plugin (`--block-nvidia-visible-devices`, config field `admission.blockNvidiaVisibleDevices`, default disabled) that rejects pods overriding the `NVIDIA_VISIBLE_DEVICES` environment variable with values other than `void`/`none` (or via a `valueFrom` reference).
 - Added support for configuring admission Pod Disruption Budget via Helm values (`admission.podDisruptionBudget`) [#1490](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490) [dttung2905](https://github.com/dttung2905)
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.
 - Added `global.podSecurityContext`, `global.resourceReservation.namespaceLabels`, `nodescaleadjuster.labels`, `crdupgrader.resources`, `topologyMigration.resources`, and `postCleanup.resources` to the Helm. chart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Added an opt-in `deviceaccess` admission plugin (`--block-nvidia-visible-devices`, config field `admission.blockNvidiaVisibleDevices`, default disabled) that rejects pods overriding the `NVIDIA_VISIBLE_DEVICES` environment variable with values other than `void`/`none` (or via a `valueFrom` reference).
+- Added an opt-in `deviceaccess` admission plugin (`--block-nvidia-visible-devices`, config field `admission.blockNvidiaVisibleDevices`, default disabled) that (1) rejects pods overriding the `NVIDIA_VISIBLE_DEVICES` environment variable with values other than `void`/`none` (or via a `valueFrom` reference), and (2) injects `NVIDIA_VISIBLE_DEVICES=void` into containers that do not request a GPU, blocking their access to GPUs on the node.
 - Added support for configuring admission Pod Disruption Budget via Helm values (`admission.podDisruptionBudget`) [#1490](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490) [dttung2905](https://github.com/dttung2905)
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.
 - Added `global.podSecurityContext`, `global.resourceReservation.namespaceLabels`, `nodescaleadjuster.labels`, `crdupgrader.resources`, `topologyMigration.resources`, and `postCleanup.resources` to the Helm. chart.

--- a/cmd/admission/app/options.go
+++ b/cmd/admission/app/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	FakeGPUNodes                bool
 	GPUSharingEnabled           bool
 	HamiCoreEnabled             bool
+	BlockNvidiaVisibleDevices   bool
 	GPUPodRuntimeClassName      string
 	GPUFractionRuntimeClassName string
 }
@@ -84,6 +85,10 @@ func InitOptions() *Options {
 	fs.BoolVar(&options.HamiCoreEnabled,
 		"hami-core-enabled", false,
 		"Specifies if the HAMI-core GPU memory limit injection is enabled")
+	fs.BoolVar(&options.BlockNvidiaVisibleDevices,
+		"block-nvidia-visible-devices", false,
+		"Reject pods that set the NVIDIA_VISIBLE_DEVICES environment variable to values "+
+			"that conflict with NVIDIA's device plugin (only 'void'/'none' are allowed)")
 	fs.StringVar(&options.GPUPodRuntimeClassName,
 		"gpu-pod-runtime-class-name", constants.DefaultRuntimeClassName,
 		fmt.Sprintf("Deprecated: use --gpu-fraction-runtime-class-name. "+

--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/cmd/admission/app"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/admission/plugins"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/admission/webhook/v1alpha2/deviceaccess"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/admission/webhook/v1alpha2/gpusharing"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/admission/webhook/v1alpha2/hamicore"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/admission/webhook/v1alpha2/runtimeenforcement"
@@ -48,6 +49,10 @@ func registerPlugins(app *app.App) error {
 
 	if app.Options.HamiCoreEnabled {
 		admissionPlugins.RegisterPlugin(hamicore.New())
+	}
+
+	if app.Options.BlockNvidiaVisibleDevices {
+		admissionPlugins.RegisterPlugin(deviceaccess.New())
 	}
 
 	if rc := app.Options.ResolvedGPUFractionRuntimeClassName(); rc != "" {

--- a/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
@@ -50,9 +50,8 @@ spec:
                 properties:
                   blockNvidiaVisibleDevices:
                     description: |-
-                      BlockNvidiaVisibleDevices enables the device access plugin, which validates that
-                      pods do not override the NVIDIA_VISIBLE_DEVICES environment variable with
-                      values that conflict with NVIDIA's device plugin.
+                      BlockNvidiaVisibleDevices prevents pods from overriding the NVIDIA_VISIBLE_DEVICES
+                      environment variable, which would conflict with NVIDIA's device plugin.
                     type: boolean
                   gpuFractionRuntimeClassName:
                     description: |-

--- a/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
@@ -48,6 +48,12 @@ spec:
               admission:
                 description: Admission holds KAI admission webhooks
                 properties:
+                  blockNvidiaVisibleDevices:
+                    description: |-
+                      BlockNvidiaVisibleDevices enables the device access plugin, which validates that
+                      pods do not override the NVIDIA_VISIBLE_DEVICES environment variable with
+                      values that conflict with NVIDIA's device plugin.
+                    type: boolean
                   gpuFractionRuntimeClassName:
                     description: |-
                       GPUFractionRuntimeClassName specifies the runtime class to be set for

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -178,6 +178,7 @@ spec:
         maxUnavailable: {{ .Values.admission.podDisruptionBudget.maxUnavailable }}
         {{- end }}
     gpuSharing: {{ .Values.global.gpuSharing | default false }}
+    blockNvidiaVisibleDevices: {{ .Values.global.blockNvidiaVisibleDevices | default false }}
     queueLabelSelector: false
     webhook:
       port: 443

--- a/deployments/kai-scheduler/tests/device_access_test.yaml
+++ b/deployments/kai-scheduler/tests/device_access_test.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test block nvidia visible devices configuration
+
+set:
+  _test:
+    renderKaiConfig: true
+templates:
+  - kai-config.yaml
+tests:
+  - it: should render blockNvidiaVisibleDevices false by default
+    asserts:
+      - equal:
+          path: spec.admission.blockNvidiaVisibleDevices
+          value: false
+
+  - it: should render blockNvidiaVisibleDevices true when global.blockNvidiaVisibleDevices is set
+    set:
+      global.blockNvidiaVisibleDevices: true
+    asserts:
+      - equal:
+          path: spec.admission.blockNvidiaVisibleDevices
+          value: true

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -10,6 +10,7 @@ global:
   imagePullSecrets: [] # format: [{name: secret1}, {name: secret2}]
   leaderElection: false
   gpuSharing: false
+  blockNvidiaVisibleDevices: false
   clusterAutoscaling: false
   nodeSelector: {}
   affinity: {}

--- a/pkg/admission/webhook/v1alpha2/deviceaccess/device_access.go
+++ b/pkg/admission/webhook/v1alpha2/deviceaccess/device_access.go
@@ -1,0 +1,100 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package deviceaccess
+
+import (
+	"fmt"
+	"slices"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/binder/common"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/binder/common/gpusharingconfigmap"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/resources"
+)
+
+var visibleDevicesWhitelist = []string{"void", "none"}
+
+type DeviceAccess struct{}
+
+func New() *DeviceAccess {
+	return &DeviceAccess{}
+}
+
+func (da *DeviceAccess) Name() string {
+	return "deviceaccess"
+}
+
+func (da *DeviceAccess) Validate(pod *v1.Pod) error {
+	requestsFraction := resources.RequestsGPUFraction(pod)
+
+	var containerRef *gpusharingconfigmap.PodContainerRef
+	if requestsFraction {
+		var err error
+		containerRef, err = common.GetFractionContainerRef(pod)
+		if err != nil {
+			return fmt.Errorf("failed to get fraction container ref: %w", err)
+		}
+	}
+
+	for containerIndex := range pod.Spec.InitContainers {
+		if requestsFraction && containerRef.Type == gpusharingconfigmap.InitContainer && containerIndex == containerRef.Index {
+			continue
+		}
+
+		err := validateSingleContainer(&pod.Spec.InitContainers[containerIndex])
+		if err != nil {
+			return err
+		}
+	}
+
+	for containerIndex := range pod.Spec.Containers {
+		if requestsFraction && containerRef.Type == gpusharingconfigmap.RegularContainer && containerIndex == containerRef.Index {
+			continue
+		}
+
+		err := validateSingleContainer(&pod.Spec.Containers[containerIndex])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (da *DeviceAccess) Mutate(pod *v1.Pod) error {
+	return nil
+}
+
+func validateSingleContainer(container *v1.Container) error {
+	for _, envVar := range container.Env {
+		if envVar.Name == constants.NvidiaVisibleDevices {
+			if err := whitelistVisibleDevicesEnvVar(container, envVar); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func whitelistVisibleDevicesEnvVar(container *v1.Container, envVar v1.EnvVar) error {
+	if envVar.Value != "" {
+		if !slices.Contains(visibleDevicesWhitelist, envVar.Value) {
+			return fmt.Errorf(
+				"container %s has an environment variable NVIDIA_VISIBLE_DEVICES"+
+					" defined with a value of %s. This is forbidden due to conflicts with Nvidia's device plugin."+
+					" The only values that are allowed are 'void' or 'none'",
+				container.Name, envVar.Value)
+		}
+	} else if envVar.ValueFrom != nil {
+		return fmt.Errorf(
+			"container %s has an environment variable NVIDIA_VISIBLE_DEVICES defined "+
+				"with a valueFrom reference. "+
+				"This is forbidden due to possible conflicts with Nvidia's device plugin",
+			container.Name)
+	}
+
+	return nil
+}

--- a/pkg/admission/webhook/v1alpha2/deviceaccess/device_access.go
+++ b/pkg/admission/webhook/v1alpha2/deviceaccess/device_access.go
@@ -28,35 +28,25 @@ func (da *DeviceAccess) Name() string {
 }
 
 func (da *DeviceAccess) Validate(pod *v1.Pod) error {
-	requestsFraction := resources.RequestsGPUFraction(pod)
-
-	var containerRef *gpusharingconfigmap.PodContainerRef
-	if requestsFraction {
-		var err error
-		containerRef, err = common.GetFractionContainerRef(pod)
-		if err != nil {
-			return fmt.Errorf("failed to get fraction container ref: %w", err)
-		}
+	containerRef, err := fractionContainerRef(pod)
+	if err != nil {
+		return err
 	}
 
 	for containerIndex := range pod.Spec.InitContainers {
-		if requestsFraction && containerRef.Type == gpusharingconfigmap.InitContainer && containerIndex == containerRef.Index {
+		if isFractionContainer(containerRef, gpusharingconfigmap.InitContainer, containerIndex) {
 			continue
 		}
-
-		err := validateSingleContainer(&pod.Spec.InitContainers[containerIndex])
-		if err != nil {
+		if err := validateSingleContainer(&pod.Spec.InitContainers[containerIndex]); err != nil {
 			return err
 		}
 	}
 
 	for containerIndex := range pod.Spec.Containers {
-		if requestsFraction && containerRef.Type == gpusharingconfigmap.RegularContainer && containerIndex == containerRef.Index {
+		if isFractionContainer(containerRef, gpusharingconfigmap.RegularContainer, containerIndex) {
 			continue
 		}
-
-		err := validateSingleContainer(&pod.Spec.Containers[containerIndex])
-		if err != nil {
+		if err := validateSingleContainer(&pod.Spec.Containers[containerIndex]); err != nil {
 			return err
 		}
 	}
@@ -65,32 +55,47 @@ func (da *DeviceAccess) Validate(pod *v1.Pod) error {
 }
 
 func (da *DeviceAccess) Mutate(pod *v1.Pod) error {
-	requestsFraction := resources.RequestsGPUFraction(pod)
-
-	var containerRef *gpusharingconfigmap.PodContainerRef
-	if requestsFraction {
-		var err error
-		containerRef, err = common.GetFractionContainerRef(pod)
-		if err != nil {
-			return fmt.Errorf("failed to get fraction container ref: %w", err)
-		}
+	containerRef, err := fractionContainerRef(pod)
+	if err != nil {
+		return err
 	}
 
 	for containerIndex := range pod.Spec.InitContainers {
-		if requestsFraction && containerRef.Type == gpusharingconfigmap.InitContainer && containerIndex == containerRef.Index {
+		if isFractionContainer(containerRef, gpusharingconfigmap.InitContainer, containerIndex) {
 			continue
 		}
 		blockGPUAccessIfNotRequested(&pod.Spec.InitContainers[containerIndex])
 	}
 
 	for containerIndex := range pod.Spec.Containers {
-		if requestsFraction && containerRef.Type == gpusharingconfigmap.RegularContainer && containerIndex == containerRef.Index {
+		if isFractionContainer(containerRef, gpusharingconfigmap.RegularContainer, containerIndex) {
 			continue
 		}
 		blockGPUAccessIfNotRequested(&pod.Spec.Containers[containerIndex])
 	}
 
 	return nil
+}
+
+// fractionContainerRef returns the pod's GPU-fraction container reference, or nil when the pod
+// does not request a fraction. It returns nil (instead of calling GetFractionContainerRef, which
+// indexes pod.Spec.Containers[0]) when there are no regular containers, since the mutating
+// webhook can run before the API server enforces containers >= 1.
+func fractionContainerRef(pod *v1.Pod) (*gpusharingconfigmap.PodContainerRef, error) {
+	if !resources.RequestsGPUFraction(pod) || len(pod.Spec.Containers) == 0 {
+		return nil, nil
+	}
+	containerRef, err := common.GetFractionContainerRef(pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fraction container ref: %w", err)
+	}
+	return containerRef, nil
+}
+
+// isFractionContainer reports whether the container at the given type+index is the
+// GPU-fraction container that should be exempt from device-access handling.
+func isFractionContainer(ref *gpusharingconfigmap.PodContainerRef, containerType gpusharingconfigmap.ContainerType, index int) bool {
+	return ref != nil && ref.Type == containerType && index == ref.Index
 }
 
 // blockGPUAccessIfNotRequested sets NVIDIA_VISIBLE_DEVICES=void on containers that do not

--- a/pkg/admission/webhook/v1alpha2/deviceaccess/device_access.go
+++ b/pkg/admission/webhook/v1alpha2/deviceaccess/device_access.go
@@ -65,7 +65,63 @@ func (da *DeviceAccess) Validate(pod *v1.Pod) error {
 }
 
 func (da *DeviceAccess) Mutate(pod *v1.Pod) error {
+	requestsFraction := resources.RequestsGPUFraction(pod)
+
+	var containerRef *gpusharingconfigmap.PodContainerRef
+	if requestsFraction {
+		var err error
+		containerRef, err = common.GetFractionContainerRef(pod)
+		if err != nil {
+			return fmt.Errorf("failed to get fraction container ref: %w", err)
+		}
+	}
+
+	for containerIndex := range pod.Spec.InitContainers {
+		if requestsFraction && containerRef.Type == gpusharingconfigmap.InitContainer && containerIndex == containerRef.Index {
+			continue
+		}
+		blockGPUAccessIfNotRequested(&pod.Spec.InitContainers[containerIndex])
+	}
+
+	for containerIndex := range pod.Spec.Containers {
+		if requestsFraction && containerRef.Type == gpusharingconfigmap.RegularContainer && containerIndex == containerRef.Index {
+			continue
+		}
+		blockGPUAccessIfNotRequested(&pod.Spec.Containers[containerIndex])
+	}
+
 	return nil
+}
+
+// blockGPUAccessIfNotRequested sets NVIDIA_VISIBLE_DEVICES=void on containers that do not
+// request a GPU, preventing them from accessing GPUs on the node.
+func blockGPUAccessIfNotRequested(container *v1.Container) {
+	if containerRequestsGPU(container) {
+		return
+	}
+	setVisibleDevicesEnvVar(container, "void")
+}
+
+func containerRequestsGPU(container *v1.Container) bool {
+	if qty, found := container.Resources.Requests[v1.ResourceName(constants.NvidiaGpuResource)]; found && !qty.IsZero() {
+		return true
+	}
+	for name, qty := range container.Resources.Requests {
+		if resources.IsMigResource(name.String()) && !qty.IsZero() {
+			return true
+		}
+	}
+	return false
+}
+
+func setVisibleDevicesEnvVar(container *v1.Container, value string) {
+	for i, env := range container.Env {
+		if env.Name == constants.NvidiaVisibleDevices {
+			container.Env[i].Value = value
+			return
+		}
+	}
+	container.Env = append(container.Env, v1.EnvVar{Name: constants.NvidiaVisibleDevices, Value: value})
 }
 
 func validateSingleContainer(container *v1.Container) error {

--- a/pkg/admission/webhook/v1alpha2/deviceaccess/device_access_test.go
+++ b/pkg/admission/webhook/v1alpha2/deviceaccess/device_access_test.go
@@ -1,0 +1,168 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package deviceaccess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+)
+
+func cpuContainer(name string, env ...v1.EnvVar) v1.Container {
+	return v1.Container{
+		Name: name,
+		Resources: v1.ResourceRequirements{
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("100m"),
+			},
+		},
+		Env: env,
+	}
+}
+
+func visibleDevicesEnv(value string) v1.EnvVar {
+	return v1.EnvVar{Name: constants.NvidiaVisibleDevices, Value: value}
+}
+
+func visibleDevicesValueFromEnv() v1.EnvVar {
+	return v1.EnvVar{
+		Name: constants.NvidiaVisibleDevices,
+		ValueFrom: &v1.EnvVarSource{
+			ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{Name: "some-configmap"},
+			},
+		},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		expectedErr string
+	}{
+		{
+			name: "init container without NVIDIA_VISIBLE_DEVICES env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0")},
+			}},
+		},
+		{
+			name: "init container with NVIDIA_VISIBLE_DEVICES=void env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0", visibleDevicesEnv("void"))},
+			}},
+		},
+		{
+			name: "init container with NVIDIA_VISIBLE_DEVICES=none env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0", visibleDevicesEnv("none"))},
+			}},
+		},
+		{
+			name: "init container with NVIDIA_VISIBLE_DEVICES=all env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0", visibleDevicesEnv("all"))},
+			}},
+			expectedErr: "container init-container-0 has an environment variable NVIDIA_VISIBLE_DEVICES" +
+				" defined with a value of all. This is forbidden due to conflicts with Nvidia's device plugin." +
+				" The only values that are allowed are 'void' or 'none'",
+		},
+		{
+			name: "init container with invalid single index NVIDIA_VISIBLE_DEVICES env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0", visibleDevicesEnv("7"))},
+			}},
+			expectedErr: "container init-container-0 has an environment variable NVIDIA_VISIBLE_DEVICES" +
+				" defined with a value of 7. This is forbidden due to conflicts with Nvidia's device plugin." +
+				" The only values that are allowed are 'void' or 'none'",
+		},
+		{
+			name: "init container with invalid multi index NVIDIA_VISIBLE_DEVICES env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0", visibleDevicesEnv("3,6"))},
+			}},
+			expectedErr: "container init-container-0 has an environment variable NVIDIA_VISIBLE_DEVICES" +
+				" defined with a value of 3,6. This is forbidden due to conflicts with Nvidia's device plugin." +
+				" The only values that are allowed are 'void' or 'none'",
+		},
+		{
+			name: "init container with NVIDIA_VISIBLE_DEVICES env var mounted from config map",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0", visibleDevicesValueFromEnv())},
+			}},
+			expectedErr: "container init-container-0 has an environment variable NVIDIA_VISIBLE_DEVICES defined " +
+				"with a valueFrom reference. This is forbidden due to possible conflicts with Nvidia's device plugin",
+		},
+		{
+			name: "container without NVIDIA_VISIBLE_DEVICES env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0")},
+			}},
+		},
+		{
+			name: "container with NVIDIA_VISIBLE_DEVICES=void env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesEnv("void"))},
+			}},
+		},
+		{
+			name: "container with NVIDIA_VISIBLE_DEVICES=none env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesEnv("none"))},
+			}},
+		},
+		{
+			name: "container with NVIDIA_VISIBLE_DEVICES=all env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesEnv("all"))},
+			}},
+			expectedErr: "container container-0 has an environment variable NVIDIA_VISIBLE_DEVICES" +
+				" defined with a value of all. This is forbidden due to conflicts with Nvidia's device plugin." +
+				" The only values that are allowed are 'void' or 'none'",
+		},
+		{
+			name: "container with invalid single index NVIDIA_VISIBLE_DEVICES env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesEnv("7"))},
+			}},
+			expectedErr: "container container-0 has an environment variable NVIDIA_VISIBLE_DEVICES" +
+				" defined with a value of 7. This is forbidden due to conflicts with Nvidia's device plugin." +
+				" The only values that are allowed are 'void' or 'none'",
+		},
+		{
+			name: "container with invalid multi index NVIDIA_VISIBLE_DEVICES env var",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesEnv("3,6"))},
+			}},
+			expectedErr: "container container-0 has an environment variable NVIDIA_VISIBLE_DEVICES" +
+				" defined with a value of 3,6. This is forbidden due to conflicts with Nvidia's device plugin." +
+				" The only values that are allowed are 'void' or 'none'",
+		},
+		{
+			name: "container with NVIDIA_VISIBLE_DEVICES env var mounted from config map",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesValueFromEnv())},
+			}},
+			expectedErr: "container container-0 has an environment variable NVIDIA_VISIBLE_DEVICES defined " +
+				"with a valueFrom reference. This is forbidden due to possible conflicts with Nvidia's device plugin",
+		},
+	}
+
+	plugin := New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := plugin.Validate(tt.pod)
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/admission/webhook/v1alpha2/deviceaccess/device_access_test.go
+++ b/pkg/admission/webhook/v1alpha2/deviceaccess/device_access_test.go
@@ -297,3 +297,17 @@ func TestMutate(t *testing.T) {
 		})
 	}
 }
+
+// TestFractionPodWithoutRegularContainers guards against a panic: a pod with a GPU-fraction
+// annotation but no regular containers can reach the mutating webhook before the API server
+// enforces containers >= 1. GetFractionContainerRef indexes pod.Spec.Containers[0], so the
+// plugin must short-circuit instead of panicking.
+func TestFractionPodWithoutRegularContainers(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{constants.GpuFraction: "0.5"}},
+		Spec:       v1.PodSpec{InitContainers: []v1.Container{cpuContainer("init-container-0")}},
+	}
+	plugin := New()
+	assert.NoError(t, plugin.Validate(pod))
+	assert.NoError(t, plugin.Mutate(pod))
+}

--- a/pkg/admission/webhook/v1alpha2/deviceaccess/device_access_test.go
+++ b/pkg/admission/webhook/v1alpha2/deviceaccess/device_access_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 )
@@ -163,6 +164,136 @@ func TestValidate(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tt.expectedErr)
 			}
+		})
+	}
+}
+
+func gpuContainer(name string) v1.Container {
+	return v1.Container{
+		Name: name,
+		Resources: v1.ResourceRequirements{
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceName(constants.NvidiaGpuResource): resource.MustParse("1"),
+			},
+		},
+	}
+}
+
+func migContainer(name string) v1.Container {
+	return v1.Container{
+		Name: name,
+		Resources: v1.ResourceRequirements{
+			Requests: map[v1.ResourceName]resource.Quantity{
+				"nvidia.com/mig-3g.20gb": resource.MustParse("1"),
+			},
+		},
+	}
+}
+
+func fractionPod(initContainers, containers []v1.Container) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "n1",
+			Annotations: map[string]string{constants.GpuFraction: "0.5"},
+		},
+		Spec: v1.PodSpec{InitContainers: initContainers, Containers: containers},
+	}
+}
+
+// voidedContainerNames returns the names of containers that have
+// NVIDIA_VISIBLE_DEVICES set to "void" (i.e. were blocked from GPU access).
+func voidedContainerNames(pod *v1.Pod) []string {
+	var names []string
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		for _, env := range container.Env {
+			if env.Name == constants.NvidiaVisibleDevices && env.Value == "void" {
+				names = append(names, container.Name)
+				break
+			}
+		}
+	}
+	return names
+}
+
+func TestMutate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *v1.Pod
+		blocked []string // containers expected to get NVIDIA_VISIBLE_DEVICES=void
+	}{
+		{
+			name: "CPU pod - all containers blocked",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0")},
+				Containers:     []v1.Container{cpuContainer("container-0"), cpuContainer("container-1")},
+			}},
+			blocked: []string{"init-container-0", "container-0", "container-1"},
+		},
+		{
+			name: "CPU container with a pre-existing NVIDIA_VISIBLE_DEVICES is overridden to void",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{cpuContainer("container-0", visibleDevicesEnv("7"))},
+			}},
+			blocked: []string{"container-0"},
+		},
+		{
+			name: "whole GPU pod - single GPU container not blocked",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{gpuContainer("container-0")},
+			}},
+			blocked: nil,
+		},
+		{
+			name: "whole GPU pod - multiple GPU containers not blocked",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{gpuContainer("container-0"), gpuContainer("container-1")},
+			}},
+			blocked: nil,
+		},
+		{
+			name: "whole GPU pod - CPU sidecar blocked, GPU container not",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{gpuContainer("container-0"), cpuContainer("container-1")},
+			}},
+			blocked: []string{"container-1"},
+		},
+		{
+			name: "whole GPU pod - CPU init container blocked, GPU container not",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				InitContainers: []v1.Container{cpuContainer("init-container-0")},
+				Containers:     []v1.Container{gpuContainer("container-0")},
+			}},
+			blocked: []string{"init-container-0"},
+		},
+		{
+			name:    "fractional GPU pod - fraction container exempt",
+			pod:     fractionPod(nil, []v1.Container{cpuContainer("container-0")}),
+			blocked: nil,
+		},
+		{
+			name:    "fractional GPU pod - sidecar blocked, fraction container exempt",
+			pod:     fractionPod(nil, []v1.Container{cpuContainer("container-0"), cpuContainer("container-1")}),
+			blocked: []string{"container-1"},
+		},
+		{
+			name:    "fractional GPU pod - init container blocked, fraction container exempt",
+			pod:     fractionPod([]v1.Container{cpuContainer("init-container-0")}, []v1.Container{cpuContainer("container-0")}),
+			blocked: []string{"init-container-0"},
+		},
+		{
+			name: "pod requesting a MIG device not blocked",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{migContainer("container-0")},
+			}},
+			blocked: nil,
+		},
+	}
+
+	plugin := New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NoError(t, plugin.Mutate(tt.pod))
+			assert.ElementsMatch(t, tt.blocked, voidedContainerNames(tt.pod))
 		})
 	}
 }

--- a/pkg/apis/kai/v1/admission/admission.go
+++ b/pkg/apis/kai/v1/admission/admission.go
@@ -32,9 +32,8 @@ type Admission struct {
 	// +kubebuilder:validation:Optional
 	GPUSharing *bool `json:"gpuSharing,omitempty"`
 
-	// BlockNvidiaVisibleDevices enables the device access plugin, which validates that
-	// pods do not override the NVIDIA_VISIBLE_DEVICES environment variable with
-	// values that conflict with NVIDIA's device plugin.
+	// BlockNvidiaVisibleDevices prevents pods from overriding the NVIDIA_VISIBLE_DEVICES
+	// environment variable, which would conflict with NVIDIA's device plugin.
 	// +kubebuilder:validation:Optional
 	BlockNvidiaVisibleDevices *bool `json:"blockNvidiaVisibleDevices,omitempty"`
 

--- a/pkg/apis/kai/v1/admission/admission.go
+++ b/pkg/apis/kai/v1/admission/admission.go
@@ -32,6 +32,12 @@ type Admission struct {
 	// +kubebuilder:validation:Optional
 	GPUSharing *bool `json:"gpuSharing,omitempty"`
 
+	// BlockNvidiaVisibleDevices enables the device access plugin, which validates that
+	// pods do not override the NVIDIA_VISIBLE_DEVICES environment variable with
+	// values that conflict with NVIDIA's device plugin.
+	// +kubebuilder:validation:Optional
+	BlockNvidiaVisibleDevices *bool `json:"blockNvidiaVisibleDevices,omitempty"`
+
 	// QueueLabelSelector enables the queue label MatchExpression in webhooks
 	// +kubebuilder:validation:Optional
 	QueueLabelSelector *bool `json:"queueLabelSelector,omitempty"`
@@ -76,6 +82,7 @@ func (b *Admission) SetDefaultsWhereNeeded(replicaCount *int32, globalVPA *commo
 	b.Replicas = common.SetDefault(b.Replicas, ptr.To(ptr.Deref(replicaCount, 1)))
 	b.GPUSharing = common.SetDefault(b.GPUSharing, ptr.To(false))
 	b.QueueLabelSelector = common.SetDefault(b.QueueLabelSelector, ptr.To(false))
+	b.BlockNvidiaVisibleDevices = common.SetDefault(b.BlockNvidiaVisibleDevices, ptr.To(false))
 
 	b.ValidatingWebhookConfigurationName = common.SetDefault(b.ValidatingWebhookConfigurationName, ptr.To(defaultValidatingWebhookName))
 	b.MutatingWebhookConfigurationName = common.SetDefault(b.MutatingWebhookConfigurationName, ptr.To(defaultMutatingWebhookName))

--- a/pkg/apis/kai/v1/admission/zz_generated.deepcopy.go
+++ b/pkg/apis/kai/v1/admission/zz_generated.deepcopy.go
@@ -36,6 +36,11 @@ func (in *Admission) DeepCopyInto(out *Admission) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.BlockNvidiaVisibleDevices != nil {
+		in, out := &in.BlockNvidiaVisibleDevices, &out.BlockNvidiaVisibleDevices
+		*out = new(bool)
+		**out = **in
+	}
 	if in.QueueLabelSelector != nil {
 		in, out := &in.QueueLabelSelector, &out.QueueLabelSelector
 		*out = new(bool)

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -9,6 +9,7 @@ const (
 	AppLabelName              = "app"
 	NvidiaGpuResource         = "nvidia.com/gpu"
 	NvidiaGpuMemory           = "nvidia.com/gpu.memory"
+	NvidiaMigResourcePrefix   = "nvidia.com/mig-"
 	GpuResource               = "gpu"
 	UnlimitedResourceQuantity = float64(-1)
 

--- a/pkg/common/resources/mig.go
+++ b/pkg/common/resources/mig.go
@@ -1,0 +1,16 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"strings"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+)
+
+// IsMigResource reports whether the given resource name is an NVIDIA MIG device
+// resource (e.g. "nvidia.com/mig-3g.20gb").
+func IsMigResource(name string) bool {
+	return strings.HasPrefix(name, constants.NvidiaMigResourcePrefix)
+}

--- a/pkg/operator/operands/admission/resources.go
+++ b/pkg/operator/operands/admission/resources.go
@@ -382,6 +382,10 @@ func buildArgsList(kaiConfig *kaiv1.Config, config *kaiv1admission.Admission) []
 		args = append(args, "--hami-core-enabled=true")
 	}
 
+	if config.BlockNvidiaVisibleDevices != nil && *config.BlockNvidiaVisibleDevices {
+		args = append(args, "--block-nvidia-visible-devices=true")
+	}
+
 	if config.Replicas != nil && *config.Replicas > 1 {
 		args = append(args, "--leader-elect")
 	}

--- a/pkg/operator/operands/admission/resources_test.go
+++ b/pkg/operator/operands/admission/resources_test.go
@@ -287,6 +287,54 @@ func TestDeploymentForKAIConfig(t *testing.T) {
 			},
 			notExpectedArgs: []string{
 				"--hami-core-enabled=true",
+				"--block-nvidia-visible-devices=true",
+			},
+		},
+		{
+			name: "block-nvidia-visible-devices enabled",
+			config: &kaiv1.Config{
+				Spec: kaiv1.ConfigSpec{
+					Namespace: constants.DefaultKAINamespace,
+					Global: &kaiv1.GlobalConfig{
+						SchedulerName: ptr.To(constants.DefaultSchedulerName),
+					},
+					Admission: &admission.Admission{
+						Replicas:                  ptr.To(int32(1)),
+						GPUSharing:                ptr.To(true),
+						BlockNvidiaVisibleDevices: ptr.To(true),
+						Webhook: &admission.Webhook{
+							TargetPort:  ptr.To(9443),
+							ProbePort:   ptr.To(8081),
+							MetricsPort: ptr.To(8080),
+						},
+					},
+				},
+			},
+			expectedArgs: []string{
+				"--block-nvidia-visible-devices=true",
+			},
+		},
+		{
+			name: "block-nvidia-visible-devices disabled by default",
+			config: &kaiv1.Config{
+				Spec: kaiv1.ConfigSpec{
+					Namespace: constants.DefaultKAINamespace,
+					Global: &kaiv1.GlobalConfig{
+						SchedulerName: ptr.To(constants.DefaultSchedulerName),
+					},
+					Admission: &admission.Admission{
+						Replicas:   ptr.To(int32(1)),
+						GPUSharing: ptr.To(true),
+						Webhook: &admission.Webhook{
+							TargetPort:  ptr.To(9443),
+							ProbePort:   ptr.To(8081),
+							MetricsPort: ptr.To(8080),
+						},
+					},
+				},
+			},
+			notExpectedArgs: []string{
+				"--block-nvidia-visible-devices=true",
 			},
 		},
 	}

--- a/test/e2e/modules/configurations/feature_flags/device_access.go
+++ b/test/e2e/modules/configurations/feature_flags/device_access.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package feature_flags
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaiadmission "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/admission"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations"
+	testContext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/testconfig"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+)
+
+const blockNvidiaVisibleDevicesArg = "--block-nvidia-visible-devices=true"
+
+// SetBlockNvidiaVisibleDevices toggles the admission visible-devices validation plugin via the KAI Config CR
+// and blocks until the operator has reconciled the flag into the admission deployment args
+// and the rollout has completed, so callers can rely on the new behavior immediately.
+func SetBlockNvidiaVisibleDevices(ctx context.Context, testCtx *testContext.TestContext, value bool) error {
+	if err := configurations.PatchKAIConfig(ctx, testCtx, func(kaiConfig *kaiv1.Config) {
+		if kaiConfig.Spec.Admission == nil {
+			kaiConfig.Spec.Admission = &kaiadmission.Admission{}
+		}
+		kaiConfig.Spec.Admission.BlockNvidiaVisibleDevices = ptr.To(value)
+	}); err != nil {
+		return err
+	}
+
+	cfg := testconfig.GetConfig()
+	Eventually(func(g Gomega) {
+		deployment := &appsv1.Deployment{}
+		g.Expect(testCtx.ControllerClient.Get(ctx, client.ObjectKey{
+			Namespace: cfg.SystemPodsNamespace,
+			Name:      cfg.AdmissionDeploymentName,
+		}, deployment)).To(Succeed())
+
+		args := deployment.Spec.Template.Spec.Containers[0].Args
+		if value {
+			g.Expect(args).To(ContainElement(blockNvidiaVisibleDevicesArg))
+		} else {
+			g.Expect(args).NotTo(ContainElement(blockNvidiaVisibleDevicesArg))
+		}
+
+		// Ensure the rollout to the reconciled spec has fully completed (old pods gone,
+		// new pods available) so no stale admission pod serves the webhook.
+		desired := int32(1)
+		if deployment.Spec.Replicas != nil {
+			desired = *deployment.Spec.Replicas
+		}
+		g.Expect(deployment.Status.ObservedGeneration).To(Equal(deployment.Generation))
+		g.Expect(deployment.Status.UpdatedReplicas).To(Equal(desired))
+		g.Expect(deployment.Status.AvailableReplicas).To(Equal(desired))
+		g.Expect(deployment.Status.Replicas).To(Equal(desired))
+	}, 3*time.Minute, 2*time.Second).Should(Succeed())
+
+	return nil
+}

--- a/test/e2e/modules/constant/constant.go
+++ b/test/e2e/modules/constant/constant.go
@@ -16,6 +16,7 @@ const (
 
 	SchedulerDeploymentName = "kai-scheduler-default"
 	SchedulerContainerName  = "scheduler"
+	AdmissionDeploymentName = "admission"
 	AppLabelName            = "app"
 	KaiReservationNamespace = "kai-resource-reservation"
 

--- a/test/e2e/modules/testconfig/testconfig.go
+++ b/test/e2e/modules/testconfig/testconfig.go
@@ -15,6 +15,7 @@ type TestConfig struct {
 	SystemPodsNamespace     string
 	ReservationNamespace    string
 	SchedulerDeploymentName string
+	AdmissionDeploymentName string
 	QueueLabelKey           string
 	QueueNamespacePrefix    string
 	ContainerImage          string
@@ -27,6 +28,7 @@ var activeConfig = TestConfig{
 	SystemPodsNamespace:     "kai-scheduler",
 	ReservationNamespace:    "kai-resource-reservation",
 	SchedulerDeploymentName: "kai-scheduler-default",
+	AdmissionDeploymentName: "admission",
 	QueueLabelKey:           "kai.scheduler/queue",
 	QueueNamespacePrefix:    "kai-",
 	ContainerImage:          "ubuntu",

--- a/test/e2e/suites/admission/deviceaccess/device_access_specs.go
+++ b/test/e2e/suites/admission/deviceaccess/device_access_specs.go
@@ -131,10 +131,19 @@ func expectAdmitted(ctx context.Context, testCtx *testcontext.TestContext, value
 		Should(Succeed(), "expected pod with NVIDIA_VISIBLE_DEVICES=%s to be admitted", value)
 }
 
-// createPodWithVisibleDevices builds a kai-scheduler pod (fresh random name) that sets
-// NVIDIA_VISIBLE_DEVICES to the given value and submits it directly (single attempt).
+// createPodWithVisibleDevices builds a kai-scheduler pod (fresh random name) whose container
+// requests a GPU and sets NVIDIA_VISIBLE_DEVICES to the given value, then submits it directly.
+//
+// The container must request a GPU: the mutating webhook runs before the validating one and
+// injects NVIDIA_VISIBLE_DEVICES=void into non-GPU containers, which would neutralize a
+// forbidden value before validation ever sees it. GPU-requesting containers are exempt from
+// that mutation, so the validation path is actually exercised.
 func createPodWithVisibleDevices(ctx context.Context, testCtx *testcontext.TestContext, value string) (*v1.Pod, error) {
-	pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{})
+	pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceName(constants.NvidiaGpuResource): resource.MustParse("1"),
+		},
+	})
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{
 		Name:  constants.NvidiaVisibleDevices,
 		Value: value,

--- a/test/e2e/suites/admission/deviceaccess/device_access_specs.go
+++ b/test/e2e/suites/admission/deviceaccess/device_access_specs.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package deviceaccess
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+)
+
+func DescribeDeviceAccessSpecs() bool {
+	return Describe("Device access admission validation", Ordered, func() {
+		var testCtx *testcontext.TestContext
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+
+			parentQueue := queue.CreateQueueObject(utils.GenerateRandomK8sName(10), "")
+			childQueue := queue.CreateQueueObject(utils.GenerateRandomK8sName(10), parentQueue.Name)
+			testCtx.InitQueues([]*v2.Queue{childQueue, parentQueue})
+		})
+
+		AfterAll(func(ctx context.Context) {
+			// Restore the default (disabled) state regardless of which context ran last.
+			Expect(feature_flags.SetBlockNvidiaVisibleDevices(ctx, testCtx, false)).To(Succeed())
+			testCtx.ClusterCleanup(ctx)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			testCtx.TestContextCleanup(ctx)
+		})
+
+		Context("when device access validation is disabled (default)", Ordered, func() {
+			BeforeAll(func(ctx context.Context) {
+				Expect(feature_flags.SetBlockNvidiaVisibleDevices(ctx, testCtx, false)).To(Succeed())
+			})
+
+			It("admits a pod overriding NVIDIA_VISIBLE_DEVICES=all", func(ctx context.Context) {
+				_, err := createPodWithVisibleDevices(ctx, testCtx, "all")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when device access validation is enabled", Ordered, func() {
+			BeforeAll(func(ctx context.Context) {
+				Expect(feature_flags.SetBlockNvidiaVisibleDevices(ctx, testCtx, true)).To(Succeed())
+			})
+
+			AfterAll(func(ctx context.Context) {
+				Expect(feature_flags.SetBlockNvidiaVisibleDevices(ctx, testCtx, false)).To(Succeed())
+			})
+
+			DescribeTable("rejects forbidden NVIDIA_VISIBLE_DEVICES values",
+				func(ctx context.Context, value string) {
+					_, err := createPodWithVisibleDevices(ctx, testCtx, value)
+					Expect(err).To(HaveOccurred())
+				},
+				Entry("single index", "1"),
+				Entry("multiple indexes", "1,2"),
+				Entry("all", "all"),
+			)
+
+			DescribeTable("admits allowed NVIDIA_VISIBLE_DEVICES values",
+				func(ctx context.Context, value string) {
+					_, err := createPodWithVisibleDevices(ctx, testCtx, value)
+					Expect(err).ToNot(HaveOccurred())
+				},
+				Entry("void", "void"),
+				Entry("none", "none"),
+			)
+		})
+	})
+}
+
+// createPodWithVisibleDevices builds a kai-scheduler pod that sets NVIDIA_VISIBLE_DEVICES to
+// the given value and submits it directly (single attempt) so admission rejections surface
+// immediately instead of being retried.
+func createPodWithVisibleDevices(ctx context.Context, testCtx *testcontext.TestContext, value string) (*v1.Pod, error) {
+	pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{})
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{
+		Name:  constants.NvidiaVisibleDevices,
+		Value: value,
+	})
+	return testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+}

--- a/test/e2e/suites/admission/deviceaccess/device_access_specs.go
+++ b/test/e2e/suites/admission/deviceaccess/device_access_specs.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
@@ -81,8 +82,42 @@ func DescribeDeviceAccessSpecs() bool {
 				Entry("void", "void"),
 				Entry("none", "none"),
 			)
+
+			It("injects NVIDIA_VISIBLE_DEVICES=void into non-GPU containers, exempting the GPU container", func(ctx context.Context) {
+				pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceName(constants.NvidiaGpuResource): resource.MustParse("1"),
+					},
+				})
+				gpuContainerName := pod.Spec.Containers[0].Name
+				pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+					Name:  "cpu-sidecar",
+					Image: pod.Spec.Containers[0].Image,
+				})
+
+				created, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(visibleDevicesValue(created, gpuContainerName)).ToNot(Equal("void"))
+				Expect(visibleDevicesValue(created, "cpu-sidecar")).To(Equal("void"))
+			})
 		})
 	})
+}
+
+// visibleDevicesValue returns the NVIDIA_VISIBLE_DEVICES env value of the named container ("" if unset).
+func visibleDevicesValue(pod *v1.Pod, containerName string) string {
+	for _, container := range pod.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == constants.NvidiaVisibleDevices {
+				return env.Value
+			}
+		}
+	}
+	return ""
 }
 
 // createPodWithVisibleDevices builds a kai-scheduler pod that sets NVIDIA_VISIBLE_DEVICES to

--- a/test/e2e/suites/admission/deviceaccess/device_access_specs.go
+++ b/test/e2e/suites/admission/deviceaccess/device_access_specs.go
@@ -6,6 +6,7 @@ package deviceaccess
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,6 +22,12 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
 )
+
+// webhookPropagationTimeout bounds how long we retry pod submissions after toggling the
+// flag: SetBlockNvidiaVisibleDevices already waits for the admission Deployment rollout to
+// complete, but there is a brief window where the rolled-out webhook is not yet enforcing
+// the new config. Each retry uses a freshly-named pod, so admitted pods don't collide.
+const webhookPropagationTimeout = time.Minute
 
 func DescribeDeviceAccessSpecs() bool {
 	return Describe("Device access admission validation", Ordered, func() {
@@ -50,8 +57,7 @@ func DescribeDeviceAccessSpecs() bool {
 			})
 
 			It("admits a pod overriding NVIDIA_VISIBLE_DEVICES=all", func(ctx context.Context) {
-				_, err := createPodWithVisibleDevices(ctx, testCtx, "all")
-				Expect(err).ToNot(HaveOccurred())
+				expectAdmitted(ctx, testCtx, "all")
 			})
 		})
 
@@ -66,8 +72,7 @@ func DescribeDeviceAccessSpecs() bool {
 
 			DescribeTable("rejects forbidden NVIDIA_VISIBLE_DEVICES values",
 				func(ctx context.Context, value string) {
-					_, err := createPodWithVisibleDevices(ctx, testCtx, value)
-					Expect(err).To(HaveOccurred())
+					expectRejected(ctx, testCtx, value)
 				},
 				Entry("single index", "1"),
 				Entry("multiple indexes", "1,2"),
@@ -76,33 +81,65 @@ func DescribeDeviceAccessSpecs() bool {
 
 			DescribeTable("admits allowed NVIDIA_VISIBLE_DEVICES values",
 				func(ctx context.Context, value string) {
-					_, err := createPodWithVisibleDevices(ctx, testCtx, value)
-					Expect(err).ToNot(HaveOccurred())
+					expectAdmitted(ctx, testCtx, value)
 				},
 				Entry("void", "void"),
 				Entry("none", "none"),
 			)
 
 			It("injects NVIDIA_VISIBLE_DEVICES=void into non-GPU containers, exempting the GPU container", func(ctx context.Context) {
-				pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
-					Limits: v1.ResourceList{
-						v1.ResourceName(constants.NvidiaGpuResource): resource.MustParse("1"),
-					},
-				})
-				gpuContainerName := pod.Spec.Containers[0].Name
-				pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
-					Name:  "cpu-sidecar",
-					Image: pod.Spec.Containers[0].Image,
-				})
+				Eventually(func(g Gomega) {
+					pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceName(constants.NvidiaGpuResource): resource.MustParse("1"),
+						},
+					})
+					gpuContainerName := pod.Spec.Containers[0].Name
+					pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+						Name:  "cpu-sidecar",
+						Image: pod.Spec.Containers[0].Image,
+					})
 
-				created, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(visibleDevicesValue(created, gpuContainerName)).ToNot(Equal("void"))
-				Expect(visibleDevicesValue(created, "cpu-sidecar")).To(Equal("void"))
+					created, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(visibleDevicesValue(created, "cpu-sidecar")).To(Equal("void"))
+					g.Expect(visibleDevicesValue(created, gpuContainerName)).ToNot(Equal("void"))
+				}).WithContext(ctx).WithTimeout(webhookPropagationTimeout).WithPolling(2 * time.Second).Should(Succeed())
 			})
 		})
 	})
+}
+
+// expectRejected retries (with a fresh pod each time) until the admission webhook rejects a
+// pod setting NVIDIA_VISIBLE_DEVICES to the given value. It only passes on a real rejection,
+// so it tolerates webhook-propagation delay without masking a non-enforcing webhook.
+func expectRejected(ctx context.Context, testCtx *testcontext.TestContext, value string) {
+	Eventually(func() error {
+		_, err := createPodWithVisibleDevices(ctx, testCtx, value)
+		return err
+	}).WithContext(ctx).WithTimeout(webhookPropagationTimeout).WithPolling(2*time.Second).
+		Should(HaveOccurred(), "expected pod with NVIDIA_VISIBLE_DEVICES=%s to be rejected", value)
+}
+
+// expectAdmitted retries (with a fresh pod each time) until a pod setting NVIDIA_VISIBLE_DEVICES
+// to the given value is admitted.
+func expectAdmitted(ctx context.Context, testCtx *testcontext.TestContext, value string) {
+	Eventually(func() error {
+		_, err := createPodWithVisibleDevices(ctx, testCtx, value)
+		return err
+	}).WithContext(ctx).WithTimeout(webhookPropagationTimeout).WithPolling(2*time.Second).
+		Should(Succeed(), "expected pod with NVIDIA_VISIBLE_DEVICES=%s to be admitted", value)
+}
+
+// createPodWithVisibleDevices builds a kai-scheduler pod (fresh random name) that sets
+// NVIDIA_VISIBLE_DEVICES to the given value and submits it directly (single attempt).
+func createPodWithVisibleDevices(ctx context.Context, testCtx *testcontext.TestContext, value string) (*v1.Pod, error) {
+	pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{})
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{
+		Name:  constants.NvidiaVisibleDevices,
+		Value: value,
+	})
+	return testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 }
 
 // visibleDevicesValue returns the NVIDIA_VISIBLE_DEVICES env value of the named container ("" if unset).
@@ -118,16 +155,4 @@ func visibleDevicesValue(pod *v1.Pod, containerName string) string {
 		}
 	}
 	return ""
-}
-
-// createPodWithVisibleDevices builds a kai-scheduler pod that sets NVIDIA_VISIBLE_DEVICES to
-// the given value and submits it directly (single attempt) so admission rejections surface
-// immediately instead of being retried.
-func createPodWithVisibleDevices(ctx context.Context, testCtx *testcontext.TestContext, value string) (*v1.Pod, error) {
-	pod := rd.CreatePodObject(testCtx.Queues[0], v1.ResourceRequirements{})
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{
-		Name:  constants.NvidiaVisibleDevices,
-		Value: value,
-	})
-	return testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 }

--- a/test/e2e/suites/admission/deviceaccess/device_access_suite_test.go
+++ b/test/e2e/suites/admission/deviceaccess/device_access_suite_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+*/
+package deviceaccess
+
+import (
+	"testing"
+
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeDeviceAccessSpecs()
+
+func TestDeviceAccess(t *testing.T) {
+	utils.SetLogger()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Device Access Admission Suite")
+}


### PR DESCRIPTION
## Description

Adds an **opt-in** `deviceaccess` admission plugin that controls how pods may use the
`NVIDIA_VISIBLE_DEVICES` environment variable. When enabled it:

1. **Validates** — rejects pods that set `NVIDIA_VISIBLE_DEVICES` to a value other than
   `void`/`none` (or via a `valueFrom` reference) on any non-fraction container, since such
   values bypass/conflict with NVIDIA's device plugin.
2. **Mutates** — injects `NVIDIA_VISIBLE_DEVICES=void` into every container that does **not**
   request a GPU (whole-GPU or MIG), blocking those containers from accessing GPUs on the node.

The GPU-fraction container legitimately sets/uses this variable (via the GPU-sharing
ConfigMap) and is exempt in both paths, identified via `GetFractionContainerRef`.

Disabled by default; OSS clusters are unaffected unless explicitly enabled:
- CLI: `--block-nvidia-visible-devices`
- Config: `spec.admission.blockNvidiaVisibleDevices: true`
- Helm: `--set global.blockNvidiaVisibleDevices=true`

A single flag gates both behaviors. The admission operand emits the flag when the config
field is set, following the existing `hamicore`/`gpuSharing` pattern.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (plugin Validate + Mutate unit tests, `IsMigResource`, operand + helm unit tests, e2e suite)
- [x] Updated documentation (CHANGELOG)

## Breaking Changes

None — the feature is opt-in and disabled by default.

## Additional Notes

- New e2e suite `test/e2e/suites/admission/deviceaccess` toggles the flag at runtime and
  asserts: rejection of `all`/`1`/`1,2`, admission of `void`/`none`, a flag-off case, and that
  a non-GPU sidecar gets `NVIDIA_VISIBLE_DEVICES=void` while the GPU container does not.
- Adds `resources.IsMigResource` + `constants.NvidiaMigResourcePrefix` (needed by the mutation
  to recognise MIG device requests).
