### PR TITLE
feat(chart): add kaiConfigDeployer.enabled and scheduler.defaultShard.enabled toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.
 - Added `global.podSecurityContext`, `global.resourceReservation.namespaceLabels`, `nodescaleadjuster.labels`, `crdupgrader.resources`, `topologyMigration.resources`, and `postCleanup.resources` to the Helm. chart.
 - Added `kaiConfigDeployer.enabled` Helm value (default `true`) to allow disabling the post-install/post-upgrade hook that applies the kai-config CR, for managing the CR outside of the chart.
+- Added `scheduler.defaultShard.enabled` Helm value (default `true`) to allow installing KAI without deploying the chart-managed default `SchedulingShard` CR.
 
 ### Changed
 - Scoped admission `runtimeClassName` injection to GPU fraction pods only; whole-GPU pods are no longer mutated. `admission.gpuPodRuntimeClassName` is deprecated in favor of `admission.gpuFractionRuntimeClassName`. Reservation pod `runtimeClassName` now defaults to empty. [#1543](https://github.com/kai-scheduler/KAI-Scheduler/issues/1543) [davidLif](https://github.com/davidLif)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.
 - Added `global.podSecurityContext`, `global.resourceReservation.namespaceLabels`, `nodescaleadjuster.labels`, `crdupgrader.resources`, `topologyMigration.resources`, and `postCleanup.resources` to the Helm. chart.
 - Added `kaiConfigDeployer.enabled` Helm value (default `true`) to allow disabling the post-install/post-upgrade hook that applies the kai-config CR, for managing the CR outside of the chart.
-- Added `scheduler.defaultShard.enabled` Helm value (default `true`) to allow installing KAI without deploying the chart-managed default `SchedulingShard` CR.
+- Added `defaultShard.enabled` Helm value (default `true`) to allow installing KAI without deploying the chart-managed default `SchedulingShard` CR.
 
 ### Changed
 - Scoped admission `runtimeClassName` injection to GPU fraction pods only; whole-GPU pods are no longer mutated. `admission.gpuPodRuntimeClassName` is deprecated in favor of `admission.gpuFractionRuntimeClassName`. Reservation pod `runtimeClassName` now defaults to empty. [#1543](https://github.com/kai-scheduler/KAI-Scheduler/issues/1543) [davidLif](https://github.com/davidLif)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added support for configuring admission Pod Disruption Budget via Helm values (`admission.podDisruptionBudget`) [#1490](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490) [dttung2905](https://github.com/dttung2905)
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.
 - Added `global.podSecurityContext`, `global.resourceReservation.namespaceLabels`, `nodescaleadjuster.labels`, `crdupgrader.resources`, `topologyMigration.resources`, and `postCleanup.resources` to the Helm. chart.
+- Added `kaiConfigDeployer.enabled` Helm value (default `true`) to allow disabling the post-install/post-upgrade hook that applies the kai-config CR, for managing the CR outside of the chart.
 
 ### Changed
 - Scoped admission `runtimeClassName` injection to GPU fraction pods only; whole-GPU pods are no longer mutated. `admission.gpuPodRuntimeClassName` is deprecated in favor of `admission.gpuFractionRuntimeClassName`. Reservation pod `runtimeClassName` now defaults to empty. [#1543](https://github.com/kai-scheduler/KAI-Scheduler/issues/1543) [davidLif](https://github.com/davidLif)

--- a/deployments/kai-scheduler/templates/default-shard.yaml
+++ b/deployments/kai-scheduler/templates/default-shard.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.scheduler.defaultShard.enabled }}
+{{- if .Values.defaultShard.enabled }}
 apiVersion: kai.scheduler/v1
 kind: SchedulingShard
 metadata:

--- a/deployments/kai-scheduler/templates/default-shard.yaml
+++ b/deployments/kai-scheduler/templates/default-shard.yaml
@@ -1,6 +1,7 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.scheduler.defaultShard.enabled }}
 apiVersion: kai.scheduler/v1
 kind: SchedulingShard
 metadata:
@@ -26,3 +27,4 @@ spec:
   actions:
     {{- toYaml .Values.scheduler.actions | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/configmap.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/configmap.yaml
@@ -1,6 +1,7 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.kaiConfigDeployer.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,3 +14,4 @@ metadata:
 data:
   kai-config.yaml: |
     {{- include "kai-scheduler.kai-config" . | nindent 4 }}
+{{- end }}

--- a/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/job.yaml
@@ -1,6 +1,7 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.kaiConfigDeployer.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -87,3 +88,4 @@ spec:
       - name: manifest
         configMap:
           name: kai-config-manifest
+{{- end }}

--- a/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/rbac.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/rbac.yaml
@@ -1,6 +1,7 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.kaiConfigDeployer.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -40,3 +41,4 @@ subjects:
 - kind: ServiceAccount
   name: kai-config-deployer
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployments/kai-scheduler/tests/default_shard_test.yaml
+++ b/deployments/kai-scheduler/tests/default_shard_test.yaml
@@ -18,7 +18,7 @@ tests:
 
   - it: should render the default SchedulingShard when explicitly enabled
     set:
-      scheduler.defaultShard.enabled: true
+      defaultShard.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -27,7 +27,7 @@ tests:
 
   - it: should not render the default SchedulingShard when disabled
     set:
-      scheduler.defaultShard.enabled: false
+      defaultShard.enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/deployments/kai-scheduler/tests/default_shard_test.yaml
+++ b/deployments/kai-scheduler/tests/default_shard_test.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test default SchedulingShard configuration
+
+templates:
+  - default-shard.yaml
+tests:
+  - it: should render the default SchedulingShard by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: SchedulingShard
+      - equal:
+          path: metadata.name
+          value: default
+
+  - it: should render the default SchedulingShard when explicitly enabled
+    set:
+      scheduler.defaultShard.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: SchedulingShard
+
+  - it: should not render the default SchedulingShard when disabled
+    set:
+      scheduler.defaultShard.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deployments/kai-scheduler/tests/kai_config_deployer_test.yaml
+++ b/deployments/kai-scheduler/tests/kai_config_deployer_test.yaml
@@ -1,0 +1,49 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test kaiConfigDeployer enabled configuration
+
+templates:
+  - hooks/post/kai-config-deployer/job.yaml
+  - hooks/post/kai-config-deployer/configmap.yaml
+  - hooks/post/kai-config-deployer/rbac.yaml
+tests:
+  - it: should render the deployer hook resources by default
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: hooks/post/kai-config-deployer/job.yaml
+      - hasDocuments:
+          count: 1
+        template: hooks/post/kai-config-deployer/configmap.yaml
+      - hasDocuments:
+          count: 3
+        template: hooks/post/kai-config-deployer/rbac.yaml
+
+  - it: should render the deployer hook resources when explicitly enabled
+    set:
+      kaiConfigDeployer.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: hooks/post/kai-config-deployer/job.yaml
+      - hasDocuments:
+          count: 1
+        template: hooks/post/kai-config-deployer/configmap.yaml
+      - hasDocuments:
+          count: 3
+        template: hooks/post/kai-config-deployer/rbac.yaml
+
+  - it: should not render the deployer hook resources when disabled
+    set:
+      kaiConfigDeployer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hooks/post/kai-config-deployer/job.yaml
+      - hasDocuments:
+          count: 0
+        template: hooks/post/kai-config-deployer/configmap.yaml
+      - hasDocuments:
+          count: 0
+        template: hooks/post/kai-config-deployer/rbac.yaml

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -111,11 +111,6 @@ scheduler:
     name: scheduler
     pullPolicy: IfNotPresent
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
-  # defaultShard controls the chart-managed "default" SchedulingShard CR.
-  # Disable to install KAI without deploying the default SchedulingShard
-  # (e.g. to manage shards out-of-band).
-  defaultShard:
-    enabled: true
   placementStrategy: binpack
   ports:
     metricsPort: 8080
@@ -154,6 +149,13 @@ scheduler:
   #   mycustomaction:
   #     priority: 150
   actions: {}
+
+# defaultShard controls the chart-managed "default" SchedulingShard CR,
+# whose spec is populated from the scheduler.* values above.
+# Disable to install KAI without deploying the default SchedulingShard
+# (e.g. to manage shards out-of-band).
+defaultShard:
+  enabled: true
 
 queuecontroller:
   enabled: true

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -111,6 +111,11 @@ scheduler:
     name: scheduler
     pullPolicy: IfNotPresent
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
+  # defaultShard controls the chart-managed "default" SchedulingShard CR.
+  # Disable to install KAI without deploying the default SchedulingShard
+  # (e.g. to manage shards out-of-band).
+  defaultShard:
+    enabled: true
   placementStrategy: binpack
   ports:
     metricsPort: 8080

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -201,6 +201,8 @@ crdupgrader:
 
 kaiConfigDeployer:
   # Post-install/post-upgrade hook that applies the kai-config CR out-of-release (#1536).
+  # Disable to manage the kai-config CR outside of this chart.
+  enabled: true
   image:
     name: crd-upgrader
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

Adds two Helm value toggles to make chart-managed bootstrap resources optional:

1. **`kaiConfigDeployer.enabled`** (default `true`) — controls the post-install/post-upgrade hook that applies the `kai-config` CR. When `false`, the deployer Job, the `kai-config-manifest` ConfigMap, and the deployer RBAC (ServiceAccount, ClusterRole, ClusterRoleBinding) are no longer rendered, letting the CR be managed outside the chart.
2. **`defaultShard.enabled`** (default `true`) — controls the chart-managed default `SchedulingShard` CR. When `false`, KAI installs without deploying the default shard, allowing shards to be managed out-of-band.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None — both fields default to `true`, preserving existing behavior.

## Additional Notes

Added helm unittest coverage:
- `tests/kai_config_deployer_test.yaml`
- `tests/default_shard_test.yaml`

Full helm unittest suite passes (103 tests).