### PR TITLE
fix(operator): align node-scale-adjuster default image name with GHCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Grove grouper now sets `minSubGroup` (equal to the number of child SubGroups) instead of `minMember=0` on parent SubGroups generated from `topologyConstraintGroupConfigs` [#1639](https://github.com/kai-scheduler/KAI-Scheduler/issues/1639) [davidLif](https://github.com/davidLif)
 - Fixed Helm chart not wiring `podgrouper.queueLabelKey` into `spec.global.queueLabelKey` on the Config CR, so custom queue label keys were ignored at install time [#1655](https://github.com/kai-scheduler/KAI-Scheduler/pull/1655) [dttung2905](https://github.com/dttung2905)
 - Fixed scheduler nil-pointer panic in the preempt scenario builder when a (partial) job has no tasks to allocate (`NewIdleGpusFilter` dereferenced a nil scenario); added the missing nil-guard matching the sibling filters [#1664](https://github.com/kai-scheduler/KAI-Scheduler/issues/1664) [sam-huang1223](https://github.com/sam-huang1223)
+- Fixed default node-scale-adjuster image name (`node-scale-adjuster` → `nodescaleadjuster`) so it matches the image published to GHCR
 
 ## [v0.15.0] - 2026-05-20
 

--- a/pkg/apis/kai/v1/node_scale_adjuster/node_scale_adjuster.go
+++ b/pkg/apis/kai/v1/node_scale_adjuster/node_scale_adjuster.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	imageName           = "node-scale-adjuster"
+	imageName           = "nodescaleadjuster"
 	scalingPodImageName = "scalingpod"
 )
 


### PR DESCRIPTION
## Description

The operator's default image name for the node-scale-adjuster did not match the image published to GHCR.

GHCR image names are derived deterministically from the Makefile `SERVICE_NAMES` (`${DOCKER_REPO_BASE}/${SERVICE_NAME}`), so the published name is `nodescaleadjuster`. The operator Go default (`pkg/apis/kai/v1/node_scale_adjuster`) was `node-scale-adjuster` instead.

The Helm chart already sets this name correctly in the KAIConfig CR, so the default only takes effect when a KAIConfig is applied without an explicit image name — in which case the operator previously rendered a non-existent image, leading to `ImagePullBackOff`.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed) — no new tests; existing unit tests reference the constant, not the literal, and pass
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

A closely related mismatch exists but is out of scope here: `pkg/apis/kai/v1/binder/binder.go` defaults the resource-reservation image to `resource-reservation`, while GHCR publishes `resourcereservation`. Helm sets it correctly, so it only affects direct-KAIConfig users.
