### PR TITLE
docs: add v0.15 to support matrix

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,6 +20,7 @@ The following versions are currently supported.
 
 | Version | Type | Release Date | End of Support | Status |
 | :--- | :--- | :--- | :--- | :--- |
+| **v0.15** | Standard | Jun 2026 | *Until v0.16* | **Active** |
 | **v0.14** | **LTS** | Mar 2026 | Mar 2027 | **Maintenance** |
 | **v0.13** | Standard | Mar 2026 | *Until v0.14* | **End of Life** |
 | **v0.12** | **LTS** | Dec 2025 | Dec 2026 | **Maintenance** |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,6 +30,8 @@ The following versions are currently supported.
 | **v0.4** | **LTS** | Apr 2025 | **Apr 2026** | **End of Life** |
 | **< v0.4** | Legacy | - | - | **End of Life** |
 
+> **Note:** With the release of `v0.15`, the Standard release `v0.13` has reached End of Life and is no longer supported.
+
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
 ## Reporting Bugs

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,8 +30,6 @@ The following versions are currently supported.
 | **v0.4** | **LTS** | Apr 2025 | **Apr 2026** | **End of Life** |
 | **< v0.4** | Legacy | - | - | **End of Life** |
 
-> **Note:** With the release of `v0.15`, the Standard release `v0.13` has reached End of Life and is no longer supported.
-
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
 ## Reporting Bugs


### PR DESCRIPTION
## Description

Adds **v0.15** to the support matrix in `SUPPORT.md` as the active Standard release (supported until v0.16). v0.13 remains End of Life per the "Standard versions supported only until the next version" policy.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)