### PR TITLE
ci: expand k8s support testing to 1.28+ (v0.14 backport)

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -86,7 +86,7 @@ jobs:
           # Update with each release to match the current k8s support window.
           # Verify patch versions at https://github.com/kubernetes-sigs/kind/releases
           # DRA feature config is only relevant for v1.32 (v1beta1) and v1.33 (v1beta2).
-          # v1.34+ has DRA GA; v1.31 predates the DRA beta.
+          # v1.34+ has DRA GA; v1.31 and earlier predate the DRA beta.
           - k8s_version: v1.35.0
             feature_config: default
           - k8s_version: v1.34.0
@@ -100,6 +100,12 @@ jobs:
           - k8s_version: v1.32.3
             feature_config: dra-enabled
           - k8s_version: v1.31.6
+            feature_config: default
+          - k8s_version: v1.30.4
+            feature_config: default
+          - k8s_version: v1.29.8
+            feature_config: default
+          - k8s_version: v1.28.13
             feature_config: default
     steps:
       - name: Checkout code

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -31,7 +31,7 @@ The following versions are currently supported.
 
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
-## Kubernetes Support Matrix
+## Kubernetes Compatibility Matrix
 
 The `v0.14` release line is validated against the following Kubernetes versions.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -31,6 +31,14 @@ The following versions are currently supported.
 
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
+## Kubernetes Support Matrix
+
+The `v0.14` release line is validated against the following Kubernetes versions.
+
+| KAI Release Line | Kubernetes Versions Validated | Notes |
+| :--- | :--- | :--- |
+| `v0.14.x` tags | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | Release workflow validation for the `v0.14` line. |
+
 ## Reporting Bugs
 
 If you encounter a bug, please [open an issue](https://github.com/kai-scheduler/KAI-scheduler/issues) on GitHub.


### PR DESCRIPTION
## Description

Backport of [PR #1687](https://github.com/kai-scheduler/KAI-scheduler/pull/1687).

This adds v1.28.13, v1.29.8, and v1.30.4 to the release workflow e2e matrix and updates SUPPORT.md for the v0.14 release line.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Backport branch: backport/v0.14-k8s-1.28.