### PR TITLE
ci: expand k8s support testing to 1.28+ (v0.15 backport)

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -86,7 +86,7 @@ jobs:
           # Update with each release to match the current k8s support window.
           # Verify patch versions at https://github.com/kubernetes-sigs/kind/releases
           # DRA feature config is only relevant for v1.32 (v1beta1) and v1.33 (v1beta2).
-          # v1.34+ has DRA GA; v1.31 predates the DRA beta.
+          # v1.34+ has DRA GA; v1.31 and earlier predate the DRA beta.
           - k8s_version: v1.35.0
             feature_config: default
           - k8s_version: v1.34.0
@@ -100,6 +100,12 @@ jobs:
           - k8s_version: v1.32.3
             feature_config: dra-enabled
           - k8s_version: v1.31.6
+            feature_config: default
+          - k8s_version: v1.30.4
+            feature_config: default
+          - k8s_version: v1.29.8
+            feature_config: default
+          - k8s_version: v1.28.13
             feature_config: default
     steps:
       - name: Checkout code

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,6 +20,7 @@ The following versions are currently supported.
 
 | Version | Type | Release Date | End of Support | Status |
 | :--- | :--- | :--- | :--- | :--- |
+| **v0.15** | Standard | Jun 2026 | *Until v0.16* | **Active** |
 | **v0.14** | **LTS** | Mar 2026 | Mar 2027 | **Maintenance** |
 | **v0.13** | Standard | Mar 2026 | *Until v0.14* | **End of Life** |
 | **v0.12** | **LTS** | Dec 2025 | Dec 2026 | **Maintenance** |
@@ -30,6 +31,14 @@ The following versions are currently supported.
 | **< v0.4** | Legacy | - | - | **End of Life** |
 
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
+
+## Kubernetes Support Matrix
+
+The `v0.15` release line is validated against the following Kubernetes versions.
+
+| KAI Release Line | Kubernetes Versions Validated | Notes |
+| :--- | :--- | :--- |
+| `v0.15.x` tags | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | Release workflow validation for the `v0.15` line. |
 
 ## Reporting Bugs
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -32,7 +32,7 @@ The following versions are currently supported.
 
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
-## Kubernetes Support Matrix
+## Kubernetes Compatibility Matrix
 
 The `v0.15` release line is validated against the following Kubernetes versions.
 


### PR DESCRIPTION
## Description

Backport of [PR #1687](https://github.com/kai-scheduler/KAI-scheduler/pull/1687).

This adds v1.28.13, v1.29.8, and v1.30.4 to the release workflow e2e matrix and updates SUPPORT.md for the v0.15 release line.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Backport branch: backport/v0.15-k8s-1.28.