### PR TITLE
ci: expand k8s support testing to 1.28+

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -54,10 +54,10 @@ runs:
           --output /tmp/kind-config.yaml
 
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.13.0
+      uses: helm/kind-action@v1.14.0
       with:
         cluster_name: kind
-        version: v0.31.0
+        version: v0.32.0
         config: /tmp/kind-config.yaml
         node_image: kindest/node:${{ inputs.k8s_version }}
 

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -87,6 +87,8 @@ jobs:
           # Verify patch versions at https://github.com/kubernetes-sigs/kind/releases
           # DRA feature config is only relevant for v1.32 (v1beta1) and v1.33 (v1beta2).
           # v1.34+ has DRA GA; v1.31 predates the DRA beta.
+          - k8s_version: v1.36.0
+            feature_config: default
           - k8s_version: v1.35.0
             feature_config: default
           - k8s_version: v1.34.0

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -87,7 +87,7 @@ jobs:
           # Verify patch versions at https://github.com/kubernetes-sigs/kind/releases
           # DRA feature config is only relevant for v1.32 (v1beta1) and v1.33 (v1beta2).
           # v1.34+ has DRA GA; v1.31 and earlier predate the DRA beta.
-          - k8s_version: v1.36.0
+          - k8s_version: v1.36.1
             feature_config: default
           - k8s_version: v1.35.0
             feature_config: default

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -86,7 +86,7 @@ jobs:
           # Update with each release to match the current k8s support window.
           # Verify patch versions at https://github.com/kubernetes-sigs/kind/releases
           # DRA feature config is only relevant for v1.32 (v1beta1) and v1.33 (v1beta2).
-          # v1.34+ has DRA GA; v1.31 predates the DRA beta.
+          # v1.34+ has DRA GA; v1.31 and earlier predate the DRA beta.
           - k8s_version: v1.36.0
             feature_config: default
           - k8s_version: v1.35.0
@@ -102,6 +102,12 @@ jobs:
           - k8s_version: v1.32.3
             feature_config: dra-enabled
           - k8s_version: v1.31.6
+            feature_config: default
+          - k8s_version: v1.30.4
+            feature_config: default
+          - k8s_version: v1.29.8
+            feature_config: default
+          - k8s_version: v1.28.13
             feature_config: default
     steps:
       - name: Checkout code

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -40,7 +40,7 @@ Historical support additions are listed after the table.
 | KAI Release Line | Kubernetes Versions Validated | Notes |
 | :--- | :--- | :--- |
 | `v0.14.x` and `v0.15.x` tags | `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | This matrix landed in `5f09d6dc` and is present through tag `v0.15.2`. |
-| `main` / next unreleased line | Same as above plus `v1.36.0` | `5743bccc` added `v1.36.0` to the release workflow. |
+| `main` / next unreleased line | Same as above plus `v1.36.1` | `5743bccc` added `v1.36.0`; the workflow now pins `v1.36.1` so kind can pull the matching prebuilt node image. |
 
 ### Historical Support Notes
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -40,7 +40,7 @@ Historical support additions are listed after the table.
 | KAI Release Line | Kubernetes Versions Validated | Notes |
 | :--- | :--- | :--- |
 | `v0.14.x` and `v0.15.x` tags | `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | This matrix landed in `5f09d6dc` and is present through tag `v0.15.2`. |
-| `main` / next unreleased line | Same as above plus `v1.36.1` | `5743bccc` added `v1.36.0`; the workflow now pins `v1.36.1` so kind can pull the matching prebuilt node image. |
+| `main` / next unreleased line | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0`, `v1.36.1` | We support Kubernetes `v1.28` onwards in the release workflow matrix. |
 
 ### Historical Support Notes
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -32,7 +32,7 @@ The following versions are currently supported.
 
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
-## Kubernetes Support Matrix
+## Kubernetes Compatibility Matrix
 
 The release workflow matrix below is the current KAI-to-Kubernetes support window.
 Historical support additions are listed after the table.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -40,7 +40,7 @@ Historical support additions are listed after the table.
 | KAI Release Line | Kubernetes Versions Validated | Notes |
 | :--- | :--- | :--- |
 | `v0.14.x` and `v0.15.x` tags | `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | This matrix landed in `5f09d6dc` and is present through tag `v0.15.2`. |
-| `main` / next unreleased line | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0`, `v1.36.1` | We support Kubernetes `v1.28` onwards in the release workflow matrix. |
+| `main` / next unreleased line | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0`, `v1.36.1` | Release workflow validation for the main line. |
 
 ### Historical Support Notes
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -32,6 +32,21 @@ The following versions are currently supported.
 
 > **Note on Versioning:** The strict "Even numbers are LTS" policy begins with `v0.12`. The versions listed above (`v0.9`, `v0.6`, `v0.4`) are supported as transitional LTS releases.
 
+## Kubernetes Support Matrix
+
+The release workflow matrix below is the current KAI-to-Kubernetes support window.
+Historical support additions are listed after the table.
+
+| KAI Release Line | Kubernetes Versions Validated | Notes |
+| :--- | :--- | :--- |
+| `v0.14.x` and `v0.15.x` tags | `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | This matrix landed in `5f09d6dc` and is present through tag `v0.15.2`. |
+| `main` / next unreleased line | Same as above plus `v1.36.0` | `5743bccc` added `v1.36.0` to the release workflow. |
+
+### Historical Support Notes
+
+* `v0.13.x` added version-aware DRA handling, including the `1.32`/`1.33` runtime-config split and DRA tracker gating (`62391cc4`, `032d7641`, `2f429935`).
+* `v0.9.x`, `v0.6.x`, and `v0.4.x` explicitly added `v1.34` DRA support (`281f4269`, `2279b43d`, `95c963e2`).
+
 ## Reporting Bugs
 
 If you encounter a bug, please [open an issue](https://github.com/kai-scheduler/KAI-scheduler/issues) on GitHub.


### PR DESCRIPTION
## Description

Updates the mainline Kubernetes support matrix in SUPPORT.md.

The doc now states that the release workflow validates Kubernetes v1.28 and newer, with the current matrix running through v1.36.1.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Mainline branch: erez/test-1.36-support.