### PR TITLE
docs: add DCO sign-off guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,26 @@ Need support or have a question? We're here to help:
 - Report issues or ask questions by [opening an issue on GitHub](https://github.com/kai-scheduler/KAI-scheduler/issues).
 - Join the conversation in the [#batch-wg](https://cloud-native.slack.com/archives/C02Q5DFF3MM) Slack channel to connect with the community and contributors.
 
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify you authored the change and agree to the [DCO](https://developercertificate.org/). Add `-s` to your commit command:
+
+```bash
+git commit -s -m "feat: my change"
+```
+
+This appends a `Signed-off-by: Your Name <your@email.com>` line to the commit message.
+
+**Fixing unsigned commits:**
+
+```bash
+# Amend the last commit
+git commit --amend -s
+
+# Sign all commits on your branch at once
+git rebase --signoff origin/main
+```
+
 ## License
 By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,19 +129,6 @@ git commit --amend -s
 git rebase --signoff origin/main
 ```
 
-**Auto sign-off every commit in this repo:**
-
-Configure a local `prepare-commit-msg` hook to append the sign-off automatically:
-
-```bash
-cat > .git/hooks/prepare-commit-msg <<'EOF'
-#!/bin/sh
-SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
-grep -qs "^${SOB}" "$1" || printf "\n%s\n" "${SOB}" >> "$1"
-EOF
-chmod +x .git/hooks/prepare-commit-msg
-```
-
 ## License
 By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,19 @@ git commit --amend -s
 git rebase --signoff origin/main
 ```
 
+**Auto sign-off every commit in this repo:**
+
+Configure a local `prepare-commit-msg` hook to append the sign-off automatically:
+
+```bash
+cat > .git/hooks/prepare-commit-msg <<'EOF'
+#!/bin/sh
+SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+grep -qs "^${SOB}" "$1" || printf "\n%s\n" "${SOB}" >> "$1"
+EOF
+chmod +x .git/hooks/prepare-commit-msg
+```
+
 ## License
 By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
 


### PR DESCRIPTION
## Description

Adds a DCO section to `CONTRIBUTING.md` covering:
- How to sign commits with `-s`
- How to fix unsigned commits (amend / rebase --signoff)
- 
## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Docs-only change — no build/test impact.