### PR TITLE
fix(binder): prevent duplicate reservation pods for a single gpu-group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed Helm chart not wiring `podgrouper.queueLabelKey` into `spec.global.queueLabelKey` on the Config CR, so custom queue label keys were ignored at install time [#1655](https://github.com/kai-scheduler/KAI-Scheduler/pull/1655) [dttung2905](https://github.com/dttung2905)
 - Fixed scheduler nil-pointer panic in the preempt scenario builder when a (partial) job has no tasks to allocate (`NewIdleGpusFilter` dereferenced a nil scenario); added the missing nil-guard matching the sibling filters [#1664](https://github.com/kai-scheduler/KAI-Scheduler/issues/1664) [sam-huang1223](https://github.com/sam-huang1223)
 - Fixed default node-scale-adjuster image name (`node-scale-adjuster` → `nodescaleadjuster`) so it matches the image published to GHCR
+- Fixed duplicate GPU reservation pods being created for a single `gpu-group` on a node (each reserving a different physical GPU), which corrupted the scheduler's fractional-GPU accounting and left devices unschedulable. Reservation pods are now named deterministically per (node, gpu-group) and treat AlreadyExists as success, so concurrent or retried binds collide on one object instead of duplicating [#1673](https://github.com/kai-scheduler/KAI-Scheduler/issues/1673)
 
 ## [v0.15.0] - 2026-05-20
 

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -5,6 +5,8 @@ package resourcereservation
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -17,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,12 +39,11 @@ type Interface interface {
 }
 
 const (
-	resourceReservation            = "resource-reservation"
-	gpuReservationPodPrefix        = "gpu-reservation"
-	gpuIndexAnnotationName         = "run.ai/reserve_for_gpu_index"
-	numberOfGPUsToReserve          = 1
-	reservationPodRandomCharacters = 5
-	unknownGpuIndicator            = "-1"
+	resourceReservation     = "resource-reservation"
+	gpuReservationPodPrefix = "gpu-reservation"
+	gpuIndexAnnotationName  = "run.ai/reserve_for_gpu_index"
+	numberOfGPUsToReserve   = 1
+	unknownGpuIndicator     = "-1"
 )
 
 type service struct {
@@ -427,7 +427,7 @@ func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGr
 		return nil, fmt.Errorf("cluster is scaling up, could not create reservation pod")
 	}
 
-	podName := fmt.Sprintf("%s-%s-%s", gpuReservationPodPrefix, nodeName, rand.String(reservationPodRandomCharacters))
+	podName := reservationPodName(nodeName, gpuGroup)
 
 	// Build resource requirements starting with GPU resources
 	resources := v1.ResourceRequirements{
@@ -452,6 +452,15 @@ func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGr
 
 	pod, err := rsc.createResourceReservationPod(nodeName, gpuGroup, podName, resources)
 	if err != nil {
+		// The reservation pod name is deterministic per (node, gpu-group). AlreadyExists
+		// means another actor (a concurrent bind, a retry, or another binder replica)
+		// already created the reservation pod for this gpu-group, so reuse it rather than
+		// creating a duplicate on a different physical GPU.
+		if apierrors.IsAlreadyExists(err) {
+			logger.Info("GPU reservation pod already exists for gpu group, reusing",
+				"nodeName", nodeName, "namespace", rsc.namespace, "name", podName, "gpuGroup", gpuGroup)
+			return pod, nil
+		}
 		logger.Error(err, "Failed to create GPU reservation pod on node",
 			"nodeName", nodeName, "namespace", rsc.namespace, "name", podName)
 		return nil, err
@@ -612,4 +621,13 @@ func (rsc *service) isScalingUp(ctx context.Context) bool {
 
 func IsGPUReservationPod(pod *v1.Pod) bool {
 	return strings.HasPrefix(pod.Name, gpuReservationPodPrefix)
+}
+
+// reservationPodName derives a deterministic reservation pod name from the node and
+// gpu-group, so concurrent or retried creates for the same gpu-group collide on a
+// single API-server object (AlreadyExists) instead of producing duplicate reservation
+// pods on different physical GPUs.
+func reservationPodName(nodeName, gpuGroup string) string {
+	hash := sha256.Sum256([]byte(nodeName + "/" + gpuGroup))
+	return fmt.Sprintf("%s-%s", gpuReservationPodPrefix, hex.EncodeToString(hash[:8]))
 }

--- a/pkg/binder/binding/resourcereservation/resource_reservation_test.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation_test.go
@@ -6,6 +6,8 @@ package resourcereservation
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1533,6 +1535,76 @@ var _ = Describe("Race condition: reservation pod deleted during concurrent bind
 			Expect(pod.Spec.SecurityContext).To(BeNil())
 			Expect(pod.Spec.Containers[0].SecurityContext).To(BeNil())
 		})
+	})
+})
+
+var _ = Describe("Reservation pod duplicate gpu-group race", func() {
+	const (
+		raceNodeName = "race-node"
+		raceGroup    = "race-gpu-group"
+	)
+
+	// This test covers issue #1673: two reservation pods getting assigned the same
+	// gpu-group while reserving different physical GPUs.
+	//
+	// In production the reservation service reads through an informer cache that lags
+	// behind writes, while it creates/watches against the API server directly. So a
+	// find-or-create of the reservation pod can miss a pod a previous ReserveGpuDevice
+	// call just created, and a second call for the same gpu-group would create a
+	// duplicate reservation pod on a different physical GPU.
+	//
+	// The interceptor models that cache lag deterministically: List in the reservation
+	// namespace always appears empty, and each created reservation pod is allocated a
+	// distinct physical GPU index. Deterministic per-(node, gpu-group) naming plus
+	// AlreadyExists handling must collapse the second create onto the first pod.
+	It("creates a single reservation pod for a gpu-group despite cache lag", func() {
+		base := fake.NewClientBuilder().WithScheme(testScheme).
+			WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+
+		var gpuIndexCounter int32
+		laggingClient := interceptor.NewClient(base, interceptor.Funcs{
+			List: func(ctx context.Context, c runtimeClient.WithWatch, list runtimeClient.ObjectList, opts ...runtimeClient.ListOption) error {
+				listOpts := runtimeClient.ListOptions{}
+				listOpts.ApplyOptions(opts)
+				if _, ok := list.(*v1.PodList); ok && listOpts.Namespace == resourceReservationNameSpace {
+					return nil // cache lag: reservation namespace appears empty
+				}
+				return c.List(ctx, list, opts...)
+			},
+			Create: func(ctx context.Context, c runtimeClient.WithWatch, obj runtimeClient.Object, opts ...runtimeClient.CreateOption) error {
+				// Simulate the GPU device plugin allocating a distinct physical GPU index
+				// to each reservation pod it admits.
+				if pod, ok := obj.(*v1.Pod); ok && pod.Namespace == resourceReservationNameSpace {
+					if pod.Annotations == nil {
+						pod.Annotations = map[string]string{}
+					}
+					pod.Annotations[gpuIndexAnnotationName] = strconv.Itoa(int(atomic.AddInt32(&gpuIndexCounter, 1) - 1))
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+			Watch: func(ctx context.Context, c runtimeClient.WithWatch, obj runtimeClient.ObjectList, opts ...runtimeClient.ListOption) (watch.Interface, error) {
+				return exampleMockWatchPod("0", 0), nil
+			},
+		})
+
+		rsc := initializeTestService(laggingClient)
+
+		fractionPodA := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "frac-a"}}
+		fractionPodB := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "frac-b"}}
+		Expect(base.Create(context.Background(), fractionPodA)).To(Succeed())
+		Expect(base.Create(context.Background(), fractionPodB)).To(Succeed())
+
+		_, err := rsc.ReserveGpuDevice(context.Background(), fractionPodA, raceNodeName, raceGroup)
+		Expect(err).To(Succeed())
+		_, err = rsc.ReserveGpuDevice(context.Background(), fractionPodB, raceNodeName, raceGroup)
+		Expect(err).To(Succeed())
+
+		reservationPods := &v1.PodList{}
+		Expect(base.List(context.Background(), reservationPods,
+			runtimeClient.InNamespace(resourceReservationNameSpace),
+			runtimeClient.MatchingLabels{constants.GPUGroup: raceGroup})).To(Succeed())
+		Expect(reservationPods.Items).To(HaveLen(1),
+			"a single gpu-group must map to exactly one reservation pod / physical GPU")
 	})
 })
 


### PR DESCRIPTION
## Description

At scale with fractional GPU workloads, multiple GPU **reservation pods** could be created for a single `runai-gpu-group` on a node, each reserving a **different physical GPU**. Since the scheduler tracks fractional-GPU capacity by gpu-group, a group spanning two devices corrupts accounting — affected GPUs appear full, fractional pods stay pending, and the state does not self-correct (the manual workaround was deleting the duplicate reservation pods).

**Root cause:** the binder's find-or-create of reservation pods reads through the informer cache (which lags writes) while it creates against the API server directly. So a second bind for the same gpu-group does not observe the reservation pod a previous bind just created, and creates a duplicate on another physical GPU. The per-group mutex doesn't help because it is released before the cache catches up (and is in-process only).

### Change
- **Deterministic naming + idempotent create:** reservation pods are named deterministically per `(node, gpu-group)` (hashed) and `AlreadyExists` on create is treated as success (reuse the existing pod). This makes concurrent, retried, and multi-replica creates collide on a single API-server object instead of duplicating — a guarantee no client-side read can provide. The node is included in the hash because gpu-group values are not universally globally-unique UUIDs (the scheduler also uses numeric per-node group identifiers, so hashing the group alone could collide across nodes).

## Related Issues

Fixes #1673

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

- Added a deterministic unit test (fake client + interceptor) that reproduces the duplicate under simulated cache lag and verifies the deterministic name collapses the second create onto the first reservation pod.
- Verified: `resourcereservation` unit tests, binder `controllers` + `integration_tests`, and the full `pkg/env-tests` suite pass (envtest); `go build ./...`, `go vet`, and `gofmt` clean.
- Existing reservation pods (old random-suffix names) are unaffected: they are still resolved by gpu-group label, so no migration is needed; only newly created reservation pods use the deterministic name.