### PR TITLE
test: adding more unschedulable reclaim benchmarks

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
@@ -9,9 +9,13 @@ import (
 
 	. "go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kaiv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/topology_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
@@ -26,7 +30,21 @@ type unschedulableDistributedReclaimBenchmarkParams struct {
 	RunningJobsPerNode    int
 	Queue0DeservedGPUs    int
 	Queue1DeservedGPUs    int
+	FailureMode           unschedulableDistributedReclaimFailureMode
 }
+
+type unschedulableDistributedReclaimFailureMode int
+
+const (
+	unschedulableDistributedReclaimProportion unschedulableDistributedReclaimFailureMode = iota
+	unschedulableDistributedReclaimAntiAffinity
+	unschedulableDistributedReclaimTopology
+)
+
+const (
+	unschedulableDistributedJobName = "unschedulable-distributed-job"
+	unschedulableDistributedRackKey = "benchmark.kai.scheduler/rack"
+)
 
 func BenchmarkReclaimUnschedulableDistributedJob_10Node(b *testing.B) {
 	benchmarkReclaimUnschedulableDistributedJob(b, 10)
@@ -38,6 +56,22 @@ func BenchmarkReclaimUnschedulableDistributedJob_50Node(b *testing.B) {
 
 func BenchmarkReclaimUnschedulableDistributedJob_100Node(b *testing.B) {
 	benchmarkReclaimUnschedulableDistributedJob(b, 100)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_AntiAffinity100Node(b *testing.B) {
+	params := defaultUnschedulableDistributedReclaimBenchmarkParams(100)
+	params.Queue0DeservedGPUs = (params.NumNodes * params.GPUsPerNode) -
+		(params.PodsPerDistributedJob * params.GPUsPerNode)
+	params.FailureMode = unschedulableDistributedReclaimAntiAffinity
+	benchmarkReclaimUnschedulableDistributedJobWithParams(b, params)
+}
+
+func BenchmarkReclaimUnschedulableDistributedJob_Topology100Node(b *testing.B) {
+	params := defaultUnschedulableDistributedReclaimBenchmarkParams(100)
+	params.Queue0DeservedGPUs = (params.NumNodes * params.GPUsPerNode) -
+		(params.PodsPerDistributedJob * params.GPUsPerNode)
+	params.FailureMode = unschedulableDistributedReclaimTopology
+	benchmarkReclaimUnschedulableDistributedJobWithParams(b, params)
 }
 
 func BenchmarkReclaimUnschedulableDistributedJob_200Node(b *testing.B) {
@@ -53,12 +87,18 @@ func BenchmarkReclaimUnschedulableDistributedJob_1000Node(b *testing.B) {
 }
 
 func benchmarkReclaimUnschedulableDistributedJob(b *testing.B, numNodes int) {
+	benchmarkReclaimUnschedulableDistributedJobWithParams(
+		b, defaultUnschedulableDistributedReclaimBenchmarkParams(numNodes),
+	)
+}
+
+func benchmarkReclaimUnschedulableDistributedJobWithParams(
+	b *testing.B, params unschedulableDistributedReclaimBenchmarkParams,
+) {
 	defer gock.Off()
 
 	test_utils.InitTestingInfrastructure()
-	topology := buildUnschedulableDistributedReclaimBenchmarkTopology(
-		defaultUnschedulableDistributedReclaimBenchmarkParams(numNodes),
-	)
+	topology := buildUnschedulableDistributedReclaimBenchmarkTopology(params)
 	action := reclaim.New()
 
 	for b.Loop() {
@@ -85,9 +125,16 @@ func buildUnschedulableDistributedReclaimBenchmarkTopology(
 ) test_utils.TestTopologyBasic {
 	nodes := make(map[string]nodes_fake.TestNodeBasic, params.NumNodes)
 	for i := 0; i < params.NumNodes; i++ {
-		nodes[fmt.Sprintf("node%d", i)] = nodes_fake.TestNodeBasic{
+		node := nodes_fake.TestNodeBasic{
 			GPUs: params.GPUsPerNode,
 		}
+		if params.FailureMode == unschedulableDistributedReclaimAntiAffinity ||
+			params.FailureMode == unschedulableDistributedReclaimTopology {
+			node.Labels = map[string]string{
+				unschedulableDistributedRackKey: fmt.Sprintf("rack-%d", i%unschedulableDistributedRackCount(params)),
+			}
+		}
+		nodes[fmt.Sprintf("node%d", i)] = node
 	}
 
 	totalRunningJobs := params.NumNodes * params.RunningJobsPerNode
@@ -107,23 +154,40 @@ func buildUnschedulableDistributedReclaimBenchmarkTopology(
 		})
 	}
 
-	distributedTasks := make([]*tasks_fake.TestTaskBasic, params.PodsPerDistributedJob)
-	for i := 0; i < params.PodsPerDistributedJob; i++ {
-		distributedTasks[i] = &tasks_fake.TestTaskBasic{State: pod_status.Pending}
-	}
-
-	jobs = append(jobs, &jobs_fake.TestJobBasic{
-		Name:                "unschedulable-distributed-job",
+	distributedJob := &jobs_fake.TestJobBasic{
+		Name:                unschedulableDistributedJobName,
 		RequiredGPUsPerTask: 8,
 		Priority:            constants.PriorityTrainNumber,
 		QueueName:           "queue-1",
-		Tasks:               distributedTasks,
-	})
+		Tasks:               make([]*tasks_fake.TestTaskBasic, params.PodsPerDistributedJob),
+	}
+	if params.FailureMode == unschedulableDistributedReclaimTopology {
+		distributedJob.RootSubGroupSet = subgroup_info.NewSubGroupSet(
+			subgroup_info.RootSubGroupSetName,
+			&topology_info.TopologyConstraintInfo{
+				Topology:      "benchmark-topology",
+				RequiredLevel: unschedulableDistributedRackKey,
+			},
+		)
+	}
+	for i := 0; i < params.PodsPerDistributedJob; i++ {
+		task := &tasks_fake.TestTaskBasic{State: pod_status.Pending}
+		if params.FailureMode == unschedulableDistributedReclaimAntiAffinity {
+			task.PodAffinityLabels = map[string]string{
+				"benchmark.kai.scheduler/job": "distributed-reclaimer",
+			}
+			task.PodAntiAffinityTopologyKey = unschedulableDistributedRackKey
+		}
+		distributedJob.Tasks[i] = task
+	}
+
+	jobs = append(jobs, distributedJob)
 
 	return test_utils.TestTopologyBasic{
-		Name:  "unschedulable distributed reclaim benchmark",
-		Jobs:  jobs,
-		Nodes: nodes,
+		Name:       "unschedulable distributed reclaim benchmark",
+		Jobs:       jobs,
+		Nodes:      nodes,
+		Topologies: buildUnschedulableDistributedReclaimTopologies(params),
 		Queues: []test_utils.TestQueueBasic{
 			{
 				Name:               "queue-0",
@@ -138,6 +202,35 @@ func buildUnschedulableDistributedReclaimBenchmarkTopology(
 		},
 		Mocks: &test_utils.TestMock{
 			CacheRequirements: &test_utils.CacheMocking{},
+		},
+	}
+}
+
+func unschedulableDistributedRackCount(params unschedulableDistributedReclaimBenchmarkParams) int {
+	switch params.FailureMode {
+	case unschedulableDistributedReclaimAntiAffinity:
+		return params.PodsPerDistributedJob - 1
+	case unschedulableDistributedReclaimTopology:
+		return params.PodsPerDistributedJob + 2
+	default:
+		return 0
+	}
+}
+
+func buildUnschedulableDistributedReclaimTopologies(
+	params unschedulableDistributedReclaimBenchmarkParams,
+) []*kaiv1alpha1.Topology {
+	if params.FailureMode != unschedulableDistributedReclaimTopology {
+		return nil
+	}
+	return []*kaiv1alpha1.Topology{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "benchmark-topology"},
+			Spec: kaiv1alpha1.TopologySpec{
+				Levels: []kaiv1alpha1.TopologyLevel{
+					{NodeLabel: unschedulableDistributedRackKey},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Description

Adding more unschedulable reclaim benchmarks to test other reasons for the job to be unschedulable.

## Related Issues

Refers #1660 