### PR TITLE
docs(scheduler): update semi-preemptible HLD with minSubGroups and multi-level tree semantics

### DIFF
--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -4,34 +4,70 @@
 
 In v0.10 we separated Priority and Preemption to allow users to control the two parameters independently, where Preemption has 2 modes (values) - **preemptible** and **non-preemptible**.
 
-We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup will be non-preemptible up to the `min-members`, and any extra pods are "elastic" pods and preemptible.
+We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup will be non-preemptible up to the `minMember` count of each leaf PodSet, and any extra pods are "elastic" pods and preemptible.
 
 ## Use Cases
 
-This value means a workload with `minReplicas` such as Inference and Elastic Distributed Training can request to be non-preemptible up to its `minReplicas` and then other pods above `min-replicas` are preemptible. This allows to run critical workload with some assured resources and some on-demand and availability based.
+A workload with `minReplicas` such as Inference and Elastic Distributed Training can request to be non-preemptible up to its `minReplicas`, with any pods above that count being preemptible. This allows running a critical workload with some assured resources and some on-demand, availability-based resources.
 
 ## Quota Requirements
 
-The `min-replicas` must be in-quota when allocated. Any "extra" pods can be allocated over-quota. All the pods must respect the Limit setting for the job's queue.
-With this requirements, we can see that: 
-- A semi-preemptible podgroup where the amount of pods equal to minMember == non-preemptible podgroup
-- A semi-preemptible podgroup where minMember is set to 0 == preemptible podgroup
+The "core" pods (up to `minMember` per leaf PodSet) must be in-quota when allocated. Any "extra" pods can be allocated over-quota. All pods must respect the Limit setting for the job's queue.
 
-## Subgroups
+From this:
+- A semi-preemptible podgroup where the total pod count equals `minMember` == non-preemptible podgroup
+- A semi-preemptible podgroup where `minMember` is 0 == preemptible podgroup
 
-Subgroups inherit the preemption mode from the podGroup - For example, if the podgroup is **semi-preemptible**, then all the subgroups are **semi-preemptible**.
+## Subgroups and Multi-Level Trees
 
-Under the current implementation, the `minMember` behavior is relevant only for the leaf subgroups and the top podgroup (calculated based on the pod sum). If the top `minMember` equals to the sum of the leaf `minMembers`, all the requirements will remain satisfied under a **semi-preemptible** mode.
+### Scope: semi-elasticity is a pod-level concept
 
-For podgroups without any subgroups, we are still dependant on the pod ordering plugin in the scheduler, just like before.
+Semi-elasticity (the core/elastic split) applies **exclusively to pods**. Subgroups and groups are atomic scheduling units — they are either fully scheduled or not. There is no "semi-elastic subgroup" concept. A user who defines fine-grained subgroups intends them to be scheduled as a whole.
+
+### Inheritance
+
+Subgroups inherit the preemption mode from the root PodGroup. If the PodGroup is **semi-preemptible**, all subgroups are **semi-preemptible**.
+
+### `minMember` vs. `minSubGroups`
+
+The core/elastic split is determined **only at nodes that have `minMember` set** (leaf PodSets). Intermediate nodes that use `minSubGroups` define a scheduling gate (how many child subgroups must be satisfied) but do not themselves define a non-preemptible pod threshold.
+
+Since pods are always attached to leaf PodSets and never to intermediate SubGroupSets, this is a natural boundary: `minMember` is always a leaf-level concept.
+
+**Non-preemptible resource count** = sum of (`minMember × pod resource request`) across all scheduled leaf PodSets.
+
+### Behavior when `minSubGroups < scheduled children`
+
+When a parent node requires fewer children than are actually scheduled (i.e., some children are "extra" from the scheduling perspective), each child's core/elastic split is still determined independently by that child's own `minMember`. The "extra-ness" is a scheduling-gate concept handled by the existing elastic subgroup scheduling; it does not override the per-subgroup semi-preemptible semantics.
+
+## Immutability Constraint
+
+A validation webhook must **prevent increases** to `minMember` and `minSubGroups` on a semi-preemptible PodGroup after creation. This applies to the root PodGroup spec and to all SubGroup entries within it.
+
+**Rationale:** once a semi-preemptible job is running, some pods may be over-quota (the elastic ones). Increasing `minMember` or `minSubGroups` would silently reclassify those over-quota pods as "core" non-preemptible pods, violating quota invariants without a rescheduling cycle.
+
+Decreasing these fields is allowed — it can only widen the elastic tier.
 
 ## Simulation Considerations
 
-In simulations, I would consider "possible victims" only the last `n-m` ("the extra") pods. This approach might miss some solutions, but I don't think that checking all $\binom{n}{m}$ options is important enough to make the code less readable and more complicated.
+In simulations, only the "extra" (`n - minMember`) pods per leaf PodSet are considered as possible victims. This is applied independently per PodSet; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all $\binom{n}{m}$ orderings, but the added complexity is not justified for the MVP.
 
 ## Implementation Notes
 
-- **Over-quota checks are different**: base in quota, extra can be over-quota
-- **For podgroup and queue statuses**: consider only the `min-member` resources for the non-preemptible counting. Like the scheduler, they should know the pod order to know which pods are considered "core", and which pods are "extra".
-- "Fully preemptible" representative job for solver simulations containing the "extra" pods of a semi-preemptible job.
+- **Over-quota checks**: core pods (up to `minMember` per leaf) must be in-quota; extra pods may be over-quota
+- **Podgroup and queue status**: count only `minMember` resources per leaf PodSet toward the non-preemptible totals. The pod ordering plugin determines which specific pods are "core" vs. "extra"
+- **Solver simulation**: represent the "extra" pods of a semi-preemptible job as a fully-preemptible representative job
 
+## Future Work: `minNonPreemptible` field
+
+This design uses `minMember` as the non-preemptible threshold. A future `minNonPreemptible` field (pod-level only, no subgroup analog) would decouple the scheduling minimum from the non-preemptible threshold — allowing e.g. `minMember=4, minNonPreemptible=2` (needs 4 pods to start, but only 2 are non-preemptible).
+
+**Work required:**
+1. New API field: `minNonPreemptible *int32` on PodGroupSpec and SubGroup
+2. Validation: `minNonPreemptible ≤ minMember`
+3. Quota accounting decoupled from `minMember`
+4. Webhook: `minNonPreemptible` is also immutable post-creation on semi-preemptible PodGroups
+5. Solver/simulation: "core" count = `minNonPreemptible`, not `minMember`
+6. Status/queue reporting updated
+
+**Key complexity introduced:** a new middle pod tier — "required for scheduling but elastic for preemption" — between core and extra-elastic. Today pod ordering has two tiers; this adds a third. Explicit ordering or labeling is needed to identify which specific pods fall into each tier.

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -6,15 +6,25 @@ In `v0.10` we separated Priority and Preemption to allow users to control the tw
 
 We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup is non-preemptible up to its **minimum required shape** — `minMember` pods at each leaf PodSet and `minSubGroup` child subgroups at each intermediate node — and anything beyond that minimum is "elastic" and preemptible. Elasticity therefore applies at **every level of the subgroup tree**, not just to pods.
 
+## Goals / Non-Goals
+
+**Goals**
+- Add a third preemptibility mode, `semi-preemptible`, on top of the **existing APIs** (the `preemptibility` field/label, `minMember`, `minSubGroup`) — no new API fields.
+- Keep a job's **minimum required shape** non-preemptible and in-quota; allow anything beyond it to run elastically (over-quota, reclaimed first).
+- Apply the core/elastic split at **every level** of the subgroup tree, and compose cleanly with [segmented subgroups](../segmented-subgroups/README.md).
+- Change nothing for existing workloads — the mode is strictly opt-in.
+
+**Non-Goals**
+- Solving queue **quota scale-down** in general for KAI Scheduler. If a queue's deserved quota drops below a running job's core allocation, the queue stays over-quota until the job releases resources on its own — exactly as a `non-preemptible` job behaves today. No new mitigation is introduced (see [Quota Scale-Down](#quota-scale-down)).
+- The `minNonPreemptible` field that would decouple the scheduling minimum from the non-preemptible threshold (see [Future Work](#future-work-minnonpreemptible-field)).
+
 ## Use Cases
 
 A workload with `minReplicas` such as Inference and Elastic Distributed Training can request to be non-preemptible up to its `minReplicas`, with any pods above that count being preemptible. This allows running a critical workload with some assured resources and some on-demand, availability-based resources.
 
 ## Usage
 
-Semi-preemptible reuses the **existing preemptibility API** introduced in [priority/preemptibility separation](../priority-preemptibility-separation/README.md)
-
-This is an **opt-in** feature.
+Semi-preemptible reuses the **existing preemptibility API** introduced in [priority/preemptibility separation](../priority-preemptibility-separation/README.md). It is an **opt-in** feature — when `preemptibility` is omitted, behavior is unchanged.
 
 **On the PodGroup spec** — a single elastic group (3 core pods, bursts beyond):
 ```yaml
@@ -40,31 +50,9 @@ spec:
     metadata:
       labels:
         kai.scheduler/preemptibility: "semi-preemptible"
-    spec:
-      # ... pod spec
 ```
 
-**Subgroup-level (multi-level tree)** — `minSubGroup` makes whole subgroups core vs. elastic:
-```yaml
-apiVersion: scheduling.kai.nvidia.com/v2alpha2
-kind: PodGroup
-metadata:
-  name: segmented-training
-spec:
-  preemptibility: "semi-preemptible"
-  minSubGroup: 2          # 2 core subgroups; additional subgroups are elastic
-  subGroups:
-    - name: segment-0
-      minMember: 4
-    - name: segment-1
-      minMember: 4
-    - name: segment-2     # elastic — reclaimed as a whole before any core subgroup
-      minMember: 4
-  priorityClassName: "train"
-  # ... rest of podgroup spec
-```
-
-When `preemptibility` is omitted, behavior is unchanged (priority-based default). Semi-preemptible is never applied implicitly — it is always opt-in.
+For multi-level trees, `minSubGroup` makes whole subgroups core vs. elastic — see [Interaction with Segmented Subgroups](#interaction-with-segmented-subgroups).
 
 ## Quota Requirements
 
@@ -76,122 +64,56 @@ From this:
 
 ### Quota Scale-Down
 
-If a queue's deserved quota is reduced below the running **core** (non-preemptible) allocation of a semi-preemptible job, the queue becomes persistently over-quota with no automatic mitigation. Reclaim evicts the job's elastic pods first; the core pods remain (protected by the existing `minAvailable` / `GetNumActiveAllocatedTasks()` eviction guard) and the queue stays over-quota until the job completes or scales down on its own.
-
-This is **accepted behavior** — it is identical to how a fully `non-preemptible` job already behaves when its queue is scaled down today. No special mitigation is introduced for semi-preemptible jobs.
-
-Future options considered and deferred:
-- **Conditional non-preemptibility:** make core pods reclaimable once `Deserved < AllocatedNotPreemptible`. Requires a new reclaim path and breaks the "core pods are always safe" guarantee.
-- **Queue quota-floor webhook:** extend the existing Queue validating webhook (`pkg/admission/webhook/queuehooks/queue_validator.go`) to reject lowering quota below `Status.AllocatedNonPreemptible`. A guardrail only — eventually-consistent (validates the queue-controller status projection, not the scheduler's live accounting) and introduces GitOps friction.
+If a queue's deserved quota drops below a semi-preemptible job's running **core** allocation, the queue becomes persistently over-quota: reclaim evicts the job's elastic pods/subgroups first, but the core remains (protected by the existing `minAvailable` / `GetNumActiveAllocatedTasks()` eviction guard) until the job ends or scales down on its own. This is **accepted behavior** — identical to how a fully `non-preemptible` job already behaves when its queue is scaled down — and is an explicit [non-goal](#goals--non-goals): no special mitigation is introduced for semi-preemptible jobs.
 
 ## Subgroups and Multi-Level Trees
 
-### Scope: semi-elasticity applies at every level of the tree
+The core/elastic split is defined by the **minimum of each node** in the subgroup tree, not by pods alone:
 
-The core/elastic split is **not** limited to pods. It is defined by the minimum requirement of each node in the subgroup tree:
+- a **leaf PodSet** with `minMember = m` keeps `m` pods core; pods beyond `m` are elastic;
+- an **intermediate SubGroupSet** with `minSubGroup = k` keeps its `k` highest-priority child subgroups core; additional scheduled subgroups are elastic and reclaimed **as a whole** (subgroups stay atomic — never split).
 
-- A **leaf PodSet** with `minMember = m` keeps `m` pods core (non-preemptible); any pods beyond `m` are elastic.
-- An **intermediate SubGroupSet** with `minSubGroup = k` keeps its `k` most-prioritized child subgroups core; any additional scheduled child subgroups are elastic and reclaimed as a whole.
+Subgroups inherit the mode from the root: a `semi-preemptible` PodGroup makes the whole tree semi-preemptible, and each node's minimum sets its own core/elastic boundary.
 
-Subgroups remain **atomic** as a scheduling unit: an elastic subgroup is evicted in its entirety (gang), never partially. "Semi-elasticity at the subgroup level" means *which* subgroups are protected, not that a subgroup is itself split.
+**Non-preemptible (core) resources = the tree's minimal satisfying set**, computed recursively: at each SubGroupSet descend into the `minSubGroup` highest-priority children (all of them if `minSubGroup` is unset); at each leaf take `minMember` pods × the per-pod request. This is the same set the allocator builds in its gang phase, so quota and scheduling agree on what "core" means. Where scheduled count equals the minimum, that node is fully non-preemptible; `minMember == 0` / no minimum ⇒ fully preemptible at that node.
 
-This matches what the scheduler already does. The allocator's gang phase (`collectTasksFromSubGroupSet` in `allocation_info.go`) schedules the `minSubGroup` highest-priority children first and then bursts extra children opportunistically; eviction (`eviction_info.go`) protects exactly the `minSubGroup` core children (`GetMinMembersToSatisfy()`) and reclaims surplus subgroups whole. As today, an elastic (extra) subgroup is only deployed if its pods can be gang-scheduled — otherwise it simply stays unsatisfied.
-
-### Inheritance
-
-Subgroups inherit the preemption mode from the root PodGroup. If the PodGroup is **semi-preemptible**, the whole tree is **semi-preemptible**, and each node's minimum (`minMember` or `minSubGroup`) defines its own core/elastic boundary.
-
-### Non-preemptible resource count = the minimal satisfying set
-
-The non-preemptible (core) resources of a semi-preemptible job are the resources of the tree's **minimal satisfying set**, computed recursively from the root:
-
-- at each SubGroupSet, descend into the `minSubGroup` most-prioritized children (all of them if `minSubGroup` is unset);
-- at each leaf PodSet, take `minMember` pods × the per-pod request.
-
-This is **the same set the allocator computes in its gang phase**, so quota and scheduling agree on what "core" means. It replaces the earlier leaf-only definition (`Σ minMember × request` over all leaf PodSets), which over-counted core resources whenever an intermediate `minSubGroup` made some leaf subgroups elastic.
-
-Degenerate cases follow naturally:
-- a leaf where total pods `== minMember`, or a node where scheduled children `== minSubGroup`, is fully non-preemptible at that level;
-- the lower a node's `minSubGroup` (or a leaf's `minMember`) relative to what is scheduled, the wider its elastic tier;
-- `minMember == 0` / no minimum ⇒ fully preemptible at that node.
+The scheduler already gates this way: allocation (`collectTasksFromSubGroupSet`) schedules the `minSubGroup` core children then bursts extras opportunistically, and eviction (`eviction_info.go`) protects exactly the core children (`GetMinMembersToSatisfy()`) and reclaims surplus whole. An elastic subgroup is deployed only if its pods can be gang-scheduled — otherwise it stays unsatisfied.
 
 ## Immutability Constraint
 
-A validation webhook must **prevent increases** to `minMember` and `minSubGroups` on a semi-preemptible PodGroup after creation. This applies to the root PodGroup spec and to all SubGroup entries within it.
-
-**Rationale:** once a semi-preemptible job is running, some of its shape may be over-quota (the elastic pods *and* the elastic subgroups). Increasing `minMember` would reclassify over-quota elastic pods as core; increasing `minSubGroup` would reclassify whole over-quota elastic subgroups as core. Either silently grows the minimal satisfying set and violates quota invariants without a rescheduling cycle — which is why both fields are immutable upward.
-
-Decreasing these fields is allowed — it can only widen the elastic tier (at the pod or subgroup level, respectively).
+A validation webhook must **reject increases** to `minMember` or `minSubGroup` on a running semi-preemptible PodGroup (the root spec and every SubGroup entry). Raising either would reclassify already-running over-quota elastic pods/subgroups as core, silently growing the minimal satisfying set and breaking quota invariants without a rescheduling cycle. Decreasing is allowed — it can only widen the elastic tier.
 
 ## Interaction with Segmented Subgroups
 
-The [segmented subgroups](../segmented-subgroups/README.md) feature auto-builds a specific tree shape: a workload's replicas are split into `N` fixed-size **segments**, each emitted as a leaf PodSet with `minAvailable = segmentSize`, nested under a parent SubGroupSet that may carry a `minSubGroup`. Segmentation forces this shape so each segment lands in its own topology domain (e.g. a rack).
+[Segmented subgroups](../segmented-subgroups/README.md) auto-builds a fixed shape: a workload's replicas are split into `N` fixed-size **segments**, each emitted as a leaf PodSet with `minAvailable = segmentSize`, under a parent SubGroupSet that may carry a `minSubGroup`. Segmentation forces this shape so each segment lands in its own topology domain (e.g. a rack).
 
-Subgroup-level semi-elasticity is **what makes semi-preemptible meaningful for segmented workloads**:
+Subgroup-level elasticity is what makes semi-preemptible **meaningful** here. Each segment is fully gang (`minAvailable == segmentSize`), so it has no pod-level surplus — under a pod-only model every segment would be core and the job would collapse to plain non-preemptible. With the tree-level model the parent's `minSubGroup` decides how many **segments** are core; the rest are elastic and reclaimed a **whole segment at a time**, so the forced topology shape is never torn apart.
 
-- Each segment is fully gang (`minAvailable == segmentSize`), so there is **no pod-level elastic tier inside a segment**. Under a pod-only model every pod of every segment would be core, and a segmented semi-preemptible job would collapse to plain non-preemptible.
-- With the tree-level model, the parent's `minSubGroup` defines how many **segments** are core; extra segments are elastic. A job with `minSubGroup: 2` over 4 segments keeps 2 segments core (in-quota, non-preemptible) and lets the other 2 burst as elastic, over-quota, reclaimed-first.
+The elastic tier exists only when `minSubGroup < #segments`. Example — `minSubGroup: 2` over 4 segments: 2 segments core (in-quota), 2 elastic (over-quota, reclaimed first):
 
-Because elastic eviction at the subgroup level drops a **whole** segment (a segment is a gang PodSet with no internal surplus), reclaim never tears apart a segment — the forced topology shape is preserved. Segmentation and semi-preemptible therefore compose cleanly: segmentation decides the shape, semi-preemptible decides which parts of that shape are guaranteed.
-
-### Examples
-
-For a segmented job, the elastic tier exists **only at the parent `minSubGroup` node, and only when `minSubGroup < #segments`**. The leaf segments are always fully core (each is fully gang, so it has no pod-level surplus). The unit of preemption is therefore an entire segment, never pods within one.
-
-**Elastic tier present** — `minSubGroup: 2` over 4 segments → 2 core segments, 2 elastic:
-```yaml
-apiVersion: scheduling.kai.nvidia.com/v2alpha2
-kind: PodGroup
-metadata:
-  name: segmented-elastic
-spec:
-  preemptibility: "semi-preemptible"
-  minSubGroup: 2            # 2 segments are core (in-quota, non-preemptible)
-  subGroups:
-    - name: segment-0       # core
-      minMember: 8          # fully gang: no pod-level elasticity inside the segment
-    - name: segment-1       # core
-      minMember: 8
-    - name: segment-2       # elastic — evicted as a whole segment, reclaimed first
-      minMember: 8
-    - name: segment-3       # elastic — evicted as a whole segment
-      minMember: 8
-```
-Core (minimal satisfying set) = 2 segments × 8 pods = 16 pods, which must be in-quota. The other 16 pods (segments 2 and 3) may run over-quota and are reclaimed a whole segment at a time, topology intact.
-
-**No elastic tier (degenerate)** — `minSubGroup` equals the segment count, so every segment is core:
 ```yaml
 spec:
   preemptibility: "semi-preemptible"
-  minSubGroup: 4            # == #segments ⇒ no surplus at the subgroup level
+  minSubGroup: 2          # 2 of 4 segments are core; the rest are elastic
   subGroups:
-    - name: segment-0
+    - name: segment-0     # core
+      minMember: 8        # fully gang: no pod-level elasticity inside a segment
+    - name: segment-1     # core
       minMember: 8
-    - name: segment-1
+    - name: segment-2     # elastic — evicted as a whole segment
       minMember: 8
-    - name: segment-2
-      minMember: 8
-    - name: segment-3
+    - name: segment-3     # elastic — evicted as a whole segment
       minMember: 8
 ```
-There is no node where `count > minimum`, so the job has no elastic shape and behaves as **fully non-preemptible** despite the `semi-preemptible` setting. Marking such a job `semi-preemptible` is a no-op — lower `minSubGroup` (here, below 4) to create an elastic segment tier.
+
+If `minSubGroup` equals the segment count, no node has surplus and the job is effectively non-preemptible despite the setting — lower `minSubGroup` to create an elastic segment tier.
 
 ## Simulation Considerations
 
 Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.
 
-This implies that pods will be treated equally within the same subgroups in consideration of eviction, prompting the user to use subgroup API to specify any ordering or hierarchy for pod eviction. 
+This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction.
 
 ## Future Work: `minNonPreemptible` field
 
-This design uses `minMember` as the non-preemptible threshold. A future `minNonPreemptible` field (pod-level only, no subgroup analog) would decouple the scheduling minimum from the non-preemptible threshold — allowing e.g. `minMember=4, minNonPreemptible=2` (needs 4 pods to start, but only 2 are non-preemptible).
-
-**Work required:**
-1. New API field: `minNonPreemptible *int32` on PodGroupSpec and SubGroup
-2. Validation: `minNonPreemptible ≤ minMember`
-3. Quota accounting decoupled from `minMember`
-4. Webhook: `minNonPreemptible` is also immutable post-creation on semi-preemptible PodGroups
-5. Solver/simulation: "core" count = `minNonPreemptible`, not `minMember`
-6. Status/queue reporting updated
-
-**Key complexity introduced:** a new middle pod tier — "required for scheduling but elastic for preemption" — between core and extra-elastic. Today pod ordering has two tiers; this adds a third. Explicit ordering or labeling is needed to identify which specific pods fall into each tier.
+This design uses `minMember` as the non-preemptible threshold. A future `minNonPreemptible` field (pod-level only, no subgroup analog) would decouple the scheduling minimum from the non-preemptible threshold — e.g. `minMember=4, minNonPreemptible=2` (needs 4 pods to start, but only 2 are non-preemptible). It introduces a third pod tier — "required for scheduling but elastic for preemption" — between core and extra-elastic, requiring explicit ordering or labeling to identify which pods fall into each tier, plus a new API field, validation (`minNonPreemptible ≤ minMember`), quota accounting decoupled from `minMember`, and matching webhook/solver/status updates.

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -11,10 +11,11 @@ We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup is
 **Goals**
 - Add a third preemptibility mode, `semi-preemptible`, on top of the **existing APIs** (the `preemptibility` field/label, `minMember`, `minSubGroup`) — no new API fields.
 - Keep a job's **minimum required shape** non-preemptible and in-quota; allow anything beyond it to run elastically (over-quota, reclaimed first).
-- Apply the core/elastic split at **every level** of the subgroup tree, and compose cleanly with [segmented subgroups](../segmented-subgroups/README.md).
+- Apply the core/elastic split at **every level** of the subgroup tree, so whole child subgroups burst elastically in the same manner as surplus pods do at a leaf — driven by `minSubGroup` on **hand-authored** subgroup trees.
 - Change nothing for existing workloads — the mode is strictly opt-in.
 
 **Non-Goals**
+- **Automated segmented subgroups** (the `kai.scheduler/segment-size` annotation path). Automated segmentation is **out of scope** and mutually exclusive with semi-preemptible; the combination is soft-enforced (see [Automated Segmentation](#automated-segmentation-out-of-scope)). Subgroup-level elasticity is supported only for **hand-authored** subgroup trees.
 - Solving queue **quota scale-down** in general for KAI Scheduler. If a queue's deserved quota drops below a running job's core allocation, the queue stays over-quota until the job releases resources on its own — exactly as a `non-preemptible` job behaves today. No new mitigation is introduced (see [Quota Scale-Down](#quota-scale-down)).
 - The `minNonPreemptible` field that would decouple the scheduling minimum from the non-preemptible threshold (see [Future Work](#future-work-minnonpreemptible-field)).
 
@@ -52,7 +53,7 @@ spec:
         kai.scheduler/preemptibility: "semi-preemptible"
 ```
 
-For multi-level trees, `minSubGroup` makes whole subgroups core vs. elastic — see [Interaction with Segmented Subgroups](#interaction-with-segmented-subgroups).
+For multi-level trees, `minSubGroup` makes whole subgroups core vs. elastic — see [Subgroups and Multi-Level Trees](#subgroups-and-multi-level-trees).
 
 ## Quota Requirements
 
@@ -79,34 +80,38 @@ Subgroups inherit the mode from the root: a `semi-preemptible` PodGroup makes th
 
 The scheduler already gates this way: allocation (`collectTasksFromSubGroupSet`) schedules the `minSubGroup` core children then bursts extras opportunistically, and eviction (`eviction_info.go`) protects exactly the core children (`GetMinMembersToSatisfy()`) and reclaims surplus whole. An elastic subgroup is deployed only if its pods can be gang-scheduled — otherwise it stays unsatisfied.
 
-## Immutability Constraint
-
-A validation webhook must **reject increases** to `minMember` or `minSubGroup` on a running semi-preemptible PodGroup (the root spec and every SubGroup entry). Raising either would reclassify already-running over-quota elastic pods/subgroups as core, silently growing the minimal satisfying set and breaking quota invariants without a rescheduling cycle. Decreasing is allowed — it can only widen the elastic tier.
-
-## Interaction with Segmented Subgroups
-
-[Segmented subgroups](../segmented-subgroups/README.md) auto-builds a fixed shape: a workload's replicas are split into `N` fixed-size **segments**, each emitted as a leaf PodSet with `minAvailable = segmentSize`, under a parent SubGroupSet that may carry a `minSubGroup`. Segmentation forces this shape so each segment lands in its own topology domain (e.g. a rack).
-
-Subgroup-level elasticity is what makes semi-preemptible **meaningful** here. Each segment is fully gang (`minAvailable == segmentSize`), so it has no pod-level surplus — under a pod-only model every segment would be core and the job would collapse to plain non-preemptible. With the tree-level model the parent's `minSubGroup` decides how many **segments** are core; the rest are elastic and reclaimed a **whole segment at a time**, so the forced topology shape is never torn apart.
-
-The elastic tier exists only when `minSubGroup < #segments`. Example — `minSubGroup: 2` over 4 segments: 2 segments core (in-quota), 2 elastic (over-quota, reclaimed first):
+**Example** — a hand-authored PodGroup of 4 fully-gang replica subgroups with `minSubGroup: 2`: 2 replicas are core (in-quota), the other 2 burst elastically (over-quota, reclaimed a whole replica at a time):
 
 ```yaml
 spec:
   preemptibility: "semi-preemptible"
-  minSubGroup: 2          # 2 of 4 segments are core; the rest are elastic
+  minSubGroup: 2          # 2 of 4 replica subgroups are core; the rest are elastic
   subGroups:
-    - name: segment-0     # core
-      minMember: 8        # fully gang: no pod-level elasticity inside a segment
-    - name: segment-1     # core
+    - name: replica-0     # core
+      minMember: 8        # fully gang: no pod-level elasticity inside the subgroup
+    - name: replica-1     # core
       minMember: 8
-    - name: segment-2     # elastic — evicted as a whole segment
+    - name: replica-2     # elastic — evicted as a whole subgroup
       minMember: 8
-    - name: segment-3     # elastic — evicted as a whole segment
+    - name: replica-3     # elastic — evicted as a whole subgroup
       minMember: 8
 ```
 
-If `minSubGroup` equals the segment count, no node has surplus and the job is effectively non-preemptible despite the setting — lower `minSubGroup` to create an elastic segment tier.
+Because each subgroup here is fully gang (`minMember == size`), there is no pod-level surplus inside a subgroup; `minSubGroup` is what creates the elastic tier. If `minSubGroup` equalled the subgroup count, no node would have surplus and the job would be effectively non-preemptible despite the setting.
+
+## Immutability Constraint
+
+A validation webhook must **reject increases** to `minMember` or `minSubGroup` on a running semi-preemptible PodGroup (the root spec and every SubGroup entry). Raising either would reclassify already-running over-quota elastic pods/subgroups as core, silently growing the minimal satisfying set and breaking quota invariants without a rescheduling cycle. Decreasing is allowed — it can only widen the elastic tier.
+
+## Automated Segmentation (Out of Scope)
+
+[Automated segmented subgroups](../segmented-subgroups/README.md) (the `kai.scheduler/segment-size` annotation, wired for PyTorchJob Worker replicas and LeaderWorkerSet) are **out of scope** for semi-preemptible and are **mutually exclusive** with it.
+
+Automated segmentation emits a **fully-gang** tree: every segment leaf gets `minAvailable = segmentSize`, with no `minSubGroup` and no `minMember = 0`. A fully-gang tree has no surplus at any level, so semi-preemptible has nothing to make elastic and silently collapses to plain non-preemptible. Rather than ship a combination that looks meaningful but is inert, the two are kept apart.
+
+This does **not** remove subgroup-level elasticity — it remains fully supported for **hand-authored** subgroup trees (see [Subgroups and Multi-Level Trees](#subgroups-and-multi-level-trees)), where the user sets `minSubGroup` below the number of child subgroups to create an elastic tier. The exclusion applies only to the automated, annotation-driven path.
+
+**Enforcement (soft).** When a workload requests both automated segmentation and `semi-preemptible`, the PodGrouper still creates the PodGroup but emits a `PodGrouperWarning` event on the pod, noting that the two are mutually exclusive and the workload will behave as non-preemptible. Enforcement lives in the PodGrouper rather than an admission webhook because only the grouper sees both the resolved preemptibility and the segmentation decision, and for auto-segmented workloads the user submits the source workload (PyTorchJob/LWS) — never the PodGroup — so a Warning event on the pod is more visible than a PodGroup-webhook rejection. Being non-blocking, it never breaks an existing workload that happens to set both.
 
 ## Simulation Considerations
 

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -134,6 +134,48 @@ Subgroup-level semi-elasticity is **what makes semi-preemptible meaningful for s
 
 Because elastic eviction at the subgroup level drops a **whole** segment (a segment is a gang PodSet with no internal surplus), reclaim never tears apart a segment — the forced topology shape is preserved. Segmentation and semi-preemptible therefore compose cleanly: segmentation decides the shape, semi-preemptible decides which parts of that shape are guaranteed.
 
+### Examples
+
+For a segmented job, the elastic tier exists **only at the parent `minSubGroup` node, and only when `minSubGroup < #segments`**. The leaf segments are always fully core (each is fully gang, so it has no pod-level surplus). The unit of preemption is therefore an entire segment, never pods within one.
+
+**Elastic tier present** — `minSubGroup: 2` over 4 segments → 2 core segments, 2 elastic:
+```yaml
+apiVersion: scheduling.kai.nvidia.com/v2alpha2
+kind: PodGroup
+metadata:
+  name: segmented-elastic
+spec:
+  preemptibility: "semi-preemptible"
+  minSubGroup: 2            # 2 segments are core (in-quota, non-preemptible)
+  subGroups:
+    - name: segment-0       # core
+      minMember: 8          # fully gang: no pod-level elasticity inside the segment
+    - name: segment-1       # core
+      minMember: 8
+    - name: segment-2       # elastic — evicted as a whole segment, reclaimed first
+      minMember: 8
+    - name: segment-3       # elastic — evicted as a whole segment
+      minMember: 8
+```
+Core (minimal satisfying set) = 2 segments × 8 pods = 16 pods, which must be in-quota. The other 16 pods (segments 2 and 3) may run over-quota and are reclaimed a whole segment at a time, topology intact.
+
+**No elastic tier (degenerate)** — `minSubGroup` equals the segment count, so every segment is core:
+```yaml
+spec:
+  preemptibility: "semi-preemptible"
+  minSubGroup: 4            # == #segments ⇒ no surplus at the subgroup level
+  subGroups:
+    - name: segment-0
+      minMember: 8
+    - name: segment-1
+      minMember: 8
+    - name: segment-2
+      minMember: 8
+    - name: segment-3
+      minMember: 8
+```
+There is no node where `count > minimum`, so the job has no elastic shape and behaves as **fully non-preemptible** despite the `semi-preemptible` setting. Marking such a job `semi-preemptible` is a no-op — lower `minSubGroup` (here, below 4) to create an elastic segment tier.
+
 ## Simulation Considerations
 
 Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In v0.10 we separated Priority and Preemption to allow users to control the two parameters independently, where Preemption has 2 modes (values) - **preemptible** and **non-preemptible**.
+In `v0.10` we separated Priority and Preemption to allow users to control the two parameters independently, where Preemption has 2 modes (values) - **preemptible** and **non-preemptible**.
 
 We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup is non-preemptible up to its **minimum required shape** — `minMember` pods at each leaf PodSet and `minSubGroup` child subgroups at each intermediate node — and anything beyond that minimum is "elastic" and preemptible. Elasticity therefore applies at **every level of the subgroup tree**, not just to pods.
 
@@ -12,9 +12,9 @@ A workload with `minReplicas` such as Inference and Elastic Distributed Training
 
 ## Usage
 
-Semi-preemptible reuses the **existing preemptibility API** introduced in [priority/preemptibility separation](../priority-preemptibility-separation/README.md) — it is simply a third value, `semi-preemptible`, alongside `preemptible` and `non-preemptible`. There is no new field or label. The minimum that stays non-preemptible is the PodGroup's existing minimum shape (`minMember` at leaf PodSets, `minSubGroup` at intermediate nodes); nothing extra needs to be declared.
+Semi-preemptible reuses the **existing preemptibility API** introduced in [priority/preemptibility separation](../priority-preemptibility-separation/README.md)
 
-It can be set either directly on the PodGroup spec, or via the `kai.scheduler/preemptibility` label on a workload (the PodGrouper passes it through to the generated PodGroup).
+This is an **opt-in** feature.
 
 **On the PodGroup spec** — a single elastic group (3 core pods, bursts beyond):
 ```yaml
@@ -180,13 +180,7 @@ There is no node where `count > minimum`, so the job has no elastic shape and be
 
 Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.
 
-## Implementation Notes
-
-- **Allocation & eviction — already tree-aware.** `allocation_info.go` (`collectTasksFromSubGroupSet`) and `eviction_info.go` (`hasElasticSurplusInSubGroupSet`, `GetMinMembersToSatisfy()`) already gate core vs. elastic at every level of the tree. Admitting semi-preemptible jobs into the victim pools is enough for reclaim/preempt to evict only the surplus (elastic pods and surplus subgroups); no change to allocation or eviction logic is needed.
-- **Over-quota checks**: the minimal satisfying set (see above) must be in-quota; anything beyond it may be over-quota.
-- **Quota accounting — follow-up gap (impl branch, PR #1713).** The current quota accounting is **leaf-only**: `pkg/scheduler/plugins/proportion/proportion.go` (`isCoreTaskForSemiPreemptible`, `updateQueuesCurrentResourceUsage`) and `pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy.go` (`filterCoreTasksToAllocate`, `isTaskCoreForSemiPreemptibleJob`) classify a pod as core purely by `count ≤ minMember` within its PodSet and ignore `minSubGroup`. This over-counts `AllocatedNotPreemptible` whenever an intermediate `minSubGroup` makes some leaf subgroups elastic (e.g. a `minSubGroup: 2` job over 4 segments counts all 4 segments as core while eviction protects only 2). These must be reworked to use the tree's minimal satisfying set, so quota matches the allocation/eviction semantics.
-- **Correctness item to verify during impl**: ensure preempt/reclaim only ever take the elastic-phase victims for semi-preemptible jobs and never fall back to the phase-3 full eviction in `collectTasksToEvictFromSubGroupSet`, so core subgroups/pods are never offered as victims.
-- **Solver simulation**: represent the elastic surplus of a semi-preemptible job (extra pods and extra subgroups) as a fully-preemptible representative job.
+This implies that pods will be treated equally within the same subgroups in consideration of eviction, prompting the user to use subgroup API to specify any ordering or hierarchy for pod eviction. 
 
 ## Future Work: `minNonPreemptible` field
 

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -18,6 +18,16 @@ From this:
 - A semi-preemptible podgroup where the total pod count equals `minMember` == non-preemptible podgroup
 - A semi-preemptible podgroup where `minMember` is 0 == preemptible podgroup
 
+### Quota Scale-Down
+
+If a queue's deserved quota is reduced below the running **core** (non-preemptible) allocation of a semi-preemptible job, the queue becomes persistently over-quota with no automatic mitigation. Reclaim evicts the job's elastic pods first; the core pods remain (protected by the existing `minAvailable` / `GetNumActiveAllocatedTasks()` eviction guard) and the queue stays over-quota until the job completes or scales down on its own.
+
+This is **accepted behavior** — it is identical to how a fully `non-preemptible` job already behaves when its queue is scaled down today. No special mitigation is introduced for semi-preemptible jobs.
+
+Future options considered and deferred:
+- **Conditional non-preemptibility:** make core pods reclaimable once `Deserved < AllocatedNotPreemptible`. Requires a new reclaim path and breaks the "core pods are always safe" guarantee.
+- **Queue quota-floor webhook:** extend the existing Queue validating webhook (`pkg/admission/webhook/queuehooks/queue_validator.go`) to reject lowering quota below `Status.AllocatedNonPreemptible`. A guardrail only — eventually-consistent (validates the queue-controller status projection, not the scheduler's live accounting) and introduces GitOps friction.
+
 ## Subgroups and Multi-Level Trees
 
 ### Scope: semi-elasticity is a pod-level concept

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -117,16 +117,16 @@ This does **not** remove subgroup-level elasticity — it remains fully supporte
 
 Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.
 
-This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction (see [Footnote: Eviction Randomness](#footnote-eviction-randomness)).
+This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction (see [Footnote: Eviction Ordering](#footnote-eviction-ordering)).
 
 
-## Footnote: Eviction Randomness
+## Footnote: Eviction Ordering
 
-In a `Semi-Preemptible` PodGroup / SubGroup, Pods are NOT "colored out" as preemptible — there is no election of individual pods. All pods within a subgroup are treated equally, and when surplus must be reclaimed the victims are chosen arbitrarily.
+In a `Semi-Preemptible` PodGroup / SubGroup, pods are NOT "colored out" as preemptible — there is no election of individual pods. All pods within a subgroup are treated equally: victims are drawn from the surplus using the **existing pod eviction ordering** (the same ordering used elsewhere in preemption), which is role-agnostic. It does not know that one pod is a master and another is a worker.
 
-A non-homogeneous subgroup / podgroup with the semi-preemptible attribute might therefore experience reduced service because the "wrong" pods are evicted. This is amended by correctly configuring subgroups and grouping similar pods into logical structures.
+A non-homogeneous subgroup / podgroup with the semi-preemptible attribute might therefore experience reduced service because the "wrong" pods are evicted — the ordering has no notion of the user's intended hierarchy. This is amended by correctly configuring subgroups and grouping similar pods into logical structures.
 
-**Unadvised**— one master pod and three workers mixed in a single leaf PodSet with `minMember: 2`. Any 2 of the 4 pods are kept as core; because pods are indistinguishable to eviction, the master is not guaranteed to survive, and the job can be left with 2 workers and no master:
+**Unadvised** — one master pod and three workers mixed in a single leaf PodSet with `minMember: 2`. Any 2 of the 4 pods are kept as core; because eviction ordering does not distinguish roles, the master is not guaranteed to survive, and the job can be left with 2 workers and no master:
 
 ```yaml
 spec:

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -10,6 +10,62 @@ We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup is
 
 A workload with `minReplicas` such as Inference and Elastic Distributed Training can request to be non-preemptible up to its `minReplicas`, with any pods above that count being preemptible. This allows running a critical workload with some assured resources and some on-demand, availability-based resources.
 
+## Usage
+
+Semi-preemptible reuses the **existing preemptibility API** introduced in [priority/preemptibility separation](../priority-preemptibility-separation/README.md) — it is simply a third value, `semi-preemptible`, alongside `preemptible` and `non-preemptible`. There is no new field or label. The minimum that stays non-preemptible is the PodGroup's existing minimum shape (`minMember` at leaf PodSets, `minSubGroup` at intermediate nodes); nothing extra needs to be declared.
+
+It can be set either directly on the PodGroup spec, or via the `kai.scheduler/preemptibility` label on a workload (the PodGrouper passes it through to the generated PodGroup).
+
+**On the PodGroup spec** — a single elastic group (3 core pods, bursts beyond):
+```yaml
+apiVersion: scheduling.kai.nvidia.com/v2alpha2
+kind: PodGroup
+metadata:
+  name: elastic-inference
+spec:
+  preemptibility: "semi-preemptible"
+  minMember: 3            # 3 core (non-preemptible) pods; pods above 3 are elastic
+  priorityClassName: "inference"
+  # ... rest of podgroup spec
+```
+
+**On a workload (label)** — the PodGrouper propagates it to the PodGroup:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elastic-inference
+spec:
+  template:
+    metadata:
+      labels:
+        kai.scheduler/preemptibility: "semi-preemptible"
+    spec:
+      # ... pod spec
+```
+
+**Subgroup-level (multi-level tree)** — `minSubGroup` makes whole subgroups core vs. elastic:
+```yaml
+apiVersion: scheduling.kai.nvidia.com/v2alpha2
+kind: PodGroup
+metadata:
+  name: segmented-training
+spec:
+  preemptibility: "semi-preemptible"
+  minSubGroup: 2          # 2 core subgroups; additional subgroups are elastic
+  subGroups:
+    - name: segment-0
+      minMember: 4
+    - name: segment-1
+      minMember: 4
+    - name: segment-2     # elastic — reclaimed as a whole before any core subgroup
+      minMember: 4
+  priorityClassName: "train"
+  # ... rest of podgroup spec
+```
+
+When `preemptibility` is omitted, behavior is unchanged (priority-based default). Semi-preemptible is never applied implicitly — it is always opt-in.
+
 ## Quota Requirements
 
 The "core" pods (up to `minMember` per leaf PodSet) must be in-quota when allocated. Any "extra" pods can be allocated over-quota. All pods must respect the Limit setting for the job's queue.

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -117,7 +117,35 @@ This does **not** remove subgroup-level elasticity — it remains fully supporte
 
 Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.
 
-This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction.
+This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction (see [Footnote: Eviction Randomness](#footnote-eviction-randomness)).
+
+
+## Footnote: Eviction Randomness
+
+In a `Semi-Preemptible` PodGroup / SubGroup, Pods are NOT "colored out" as preemptible — there is no election of individual pods. All pods within a subgroup are treated equally, and when surplus must be reclaimed the victims are chosen arbitrarily.
+
+A non-homogeneous subgroup / podgroup with the semi-preemptible attribute might therefore experience reduced service because the "wrong" pods are evicted. This is amended by correctly configuring subgroups and grouping similar pods into logical structures.
+
+**Unadvised**— one master pod and three workers mixed in a single leaf PodSet with `minMember: 2`. Any 2 of the 4 pods are kept as core; because pods are indistinguishable to eviction, the master is not guaranteed to survive, and the job can be left with 2 workers and no master:
+
+```yaml
+spec:
+  preemptibility: "semi-preemptible"
+  minMember: 2            # keeps ANY 2 of {master, worker, worker, worker} — master may be evicted
+```
+
+**Aligned with API** — separate master and workers into their own subgroups so eviction can only target the surplus workers, never the master:
+
+```yaml
+spec:
+  preemptibility: "semi-preemptible"
+  minSubGroup: 2          # both subgroups below are core
+  subGroups:
+    - name: master        # core — never evicted
+      minMember: 1
+    - name: workers       # 2 workers core; extra workers are elastic
+      minMember: 2
+```
 
 ## Future Work: `minNonPreemptible` field
 

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -4,7 +4,7 @@
 
 In v0.10 we separated Priority and Preemption to allow users to control the two parameters independently, where Preemption has 2 modes (values) - **preemptible** and **non-preemptible**.
 
-We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup will be non-preemptible up to the `minMember` count of each leaf PodSet, and any extra pods are "elastic" pods and preemptible.
+We want to add a new 3rd mode, named **semi-preemptible**, where the podgroup is non-preemptible up to its **minimum required shape** — `minMember` pods at each leaf PodSet and `minSubGroup` child subgroups at each intermediate node — and anything beyond that minimum is "elastic" and preemptible. Elasticity therefore applies at **every level of the subgroup tree**, not just to pods.
 
 ## Use Cases
 
@@ -30,43 +30,65 @@ Future options considered and deferred:
 
 ## Subgroups and Multi-Level Trees
 
-### Scope: semi-elasticity is a pod-level concept
+### Scope: semi-elasticity applies at every level of the tree
 
-Semi-elasticity (the core/elastic split) applies **exclusively to pods**. Subgroups and groups are atomic scheduling units — they are either fully scheduled or not. There is no "semi-elastic subgroup" concept. A user who defines fine-grained subgroups intends them to be scheduled as a whole.
+The core/elastic split is **not** limited to pods. It is defined by the minimum requirement of each node in the subgroup tree:
+
+- A **leaf PodSet** with `minMember = m` keeps `m` pods core (non-preemptible); any pods beyond `m` are elastic.
+- An **intermediate SubGroupSet** with `minSubGroup = k` keeps its `k` most-prioritized child subgroups core; any additional scheduled child subgroups are elastic and reclaimed as a whole.
+
+Subgroups remain **atomic** as a scheduling unit: an elastic subgroup is evicted in its entirety (gang), never partially. "Semi-elasticity at the subgroup level" means *which* subgroups are protected, not that a subgroup is itself split.
+
+This matches what the scheduler already does. The allocator's gang phase (`collectTasksFromSubGroupSet` in `allocation_info.go`) schedules the `minSubGroup` highest-priority children first and then bursts extra children opportunistically; eviction (`eviction_info.go`) protects exactly the `minSubGroup` core children (`GetMinMembersToSatisfy()`) and reclaims surplus subgroups whole. As today, an elastic (extra) subgroup is only deployed if its pods can be gang-scheduled — otherwise it simply stays unsatisfied.
 
 ### Inheritance
 
-Subgroups inherit the preemption mode from the root PodGroup. If the PodGroup is **semi-preemptible**, all subgroups are **semi-preemptible**.
+Subgroups inherit the preemption mode from the root PodGroup. If the PodGroup is **semi-preemptible**, the whole tree is **semi-preemptible**, and each node's minimum (`minMember` or `minSubGroup`) defines its own core/elastic boundary.
 
-### `minMember` vs. `minSubGroups`
+### Non-preemptible resource count = the minimal satisfying set
 
-The core/elastic split is determined **only at nodes that have `minMember` set** (leaf PodSets). Intermediate nodes that use `minSubGroups` define a scheduling gate (how many child subgroups must be satisfied) but do not themselves define a non-preemptible pod threshold.
+The non-preemptible (core) resources of a semi-preemptible job are the resources of the tree's **minimal satisfying set**, computed recursively from the root:
 
-Since pods are always attached to leaf PodSets and never to intermediate SubGroupSets, this is a natural boundary: `minMember` is always a leaf-level concept.
+- at each SubGroupSet, descend into the `minSubGroup` most-prioritized children (all of them if `minSubGroup` is unset);
+- at each leaf PodSet, take `minMember` pods × the per-pod request.
 
-**Non-preemptible resource count** = sum of (`minMember × pod resource request`) across all scheduled leaf PodSets.
+This is **the same set the allocator computes in its gang phase**, so quota and scheduling agree on what "core" means. It replaces the earlier leaf-only definition (`Σ minMember × request` over all leaf PodSets), which over-counted core resources whenever an intermediate `minSubGroup` made some leaf subgroups elastic.
 
-### Behavior when `minSubGroups < scheduled children`
-
-When a parent node requires fewer children than are actually scheduled (i.e., some children are "extra" from the scheduling perspective), each child's core/elastic split is still determined independently by that child's own `minMember`. The "extra-ness" is a scheduling-gate concept handled by the existing elastic subgroup scheduling; it does not override the per-subgroup semi-preemptible semantics.
+Degenerate cases follow naturally:
+- a leaf where total pods `== minMember`, or a node where scheduled children `== minSubGroup`, is fully non-preemptible at that level;
+- the lower a node's `minSubGroup` (or a leaf's `minMember`) relative to what is scheduled, the wider its elastic tier;
+- `minMember == 0` / no minimum ⇒ fully preemptible at that node.
 
 ## Immutability Constraint
 
 A validation webhook must **prevent increases** to `minMember` and `minSubGroups` on a semi-preemptible PodGroup after creation. This applies to the root PodGroup spec and to all SubGroup entries within it.
 
-**Rationale:** once a semi-preemptible job is running, some pods may be over-quota (the elastic ones). Increasing `minMember` or `minSubGroups` would silently reclassify those over-quota pods as "core" non-preemptible pods, violating quota invariants without a rescheduling cycle.
+**Rationale:** once a semi-preemptible job is running, some of its shape may be over-quota (the elastic pods *and* the elastic subgroups). Increasing `minMember` would reclassify over-quota elastic pods as core; increasing `minSubGroup` would reclassify whole over-quota elastic subgroups as core. Either silently grows the minimal satisfying set and violates quota invariants without a rescheduling cycle — which is why both fields are immutable upward.
 
-Decreasing these fields is allowed — it can only widen the elastic tier.
+Decreasing these fields is allowed — it can only widen the elastic tier (at the pod or subgroup level, respectively).
+
+## Interaction with Segmented Subgroups
+
+The [segmented subgroups](../segmented-subgroups/README.md) feature auto-builds a specific tree shape: a workload's replicas are split into `N` fixed-size **segments**, each emitted as a leaf PodSet with `minAvailable = segmentSize`, nested under a parent SubGroupSet that may carry a `minSubGroup`. Segmentation forces this shape so each segment lands in its own topology domain (e.g. a rack).
+
+Subgroup-level semi-elasticity is **what makes semi-preemptible meaningful for segmented workloads**:
+
+- Each segment is fully gang (`minAvailable == segmentSize`), so there is **no pod-level elastic tier inside a segment**. Under a pod-only model every pod of every segment would be core, and a segmented semi-preemptible job would collapse to plain non-preemptible.
+- With the tree-level model, the parent's `minSubGroup` defines how many **segments** are core; extra segments are elastic. A job with `minSubGroup: 2` over 4 segments keeps 2 segments core (in-quota, non-preemptible) and lets the other 2 burst as elastic, over-quota, reclaimed-first.
+
+Because elastic eviction at the subgroup level drops a **whole** segment (a segment is a gang PodSet with no internal surplus), reclaim never tears apart a segment — the forced topology shape is preserved. Segmentation and semi-preemptible therefore compose cleanly: segmentation decides the shape, semi-preemptible decides which parts of that shape are guaranteed.
 
 ## Simulation Considerations
 
-In simulations, only the "extra" (`n - minMember`) pods per leaf PodSet are considered as possible victims. This is applied independently per PodSet; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all $\binom{n}{m}$ orderings, but the added complexity is not justified for the MVP.
+Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.
 
 ## Implementation Notes
 
-- **Over-quota checks**: core pods (up to `minMember` per leaf) must be in-quota; extra pods may be over-quota
-- **Podgroup and queue status**: count only `minMember` resources per leaf PodSet toward the non-preemptible totals. The pod ordering plugin determines which specific pods are "core" vs. "extra"
-- **Solver simulation**: represent the "extra" pods of a semi-preemptible job as a fully-preemptible representative job
+- **Allocation & eviction — already tree-aware.** `allocation_info.go` (`collectTasksFromSubGroupSet`) and `eviction_info.go` (`hasElasticSurplusInSubGroupSet`, `GetMinMembersToSatisfy()`) already gate core vs. elastic at every level of the tree. Admitting semi-preemptible jobs into the victim pools is enough for reclaim/preempt to evict only the surplus (elastic pods and surplus subgroups); no change to allocation or eviction logic is needed.
+- **Over-quota checks**: the minimal satisfying set (see above) must be in-quota; anything beyond it may be over-quota.
+- **Quota accounting — follow-up gap (impl branch, PR #1713).** The current quota accounting is **leaf-only**: `pkg/scheduler/plugins/proportion/proportion.go` (`isCoreTaskForSemiPreemptible`, `updateQueuesCurrentResourceUsage`) and `pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy.go` (`filterCoreTasksToAllocate`, `isTaskCoreForSemiPreemptibleJob`) classify a pod as core purely by `count ≤ minMember` within its PodSet and ignore `minSubGroup`. This over-counts `AllocatedNotPreemptible` whenever an intermediate `minSubGroup` makes some leaf subgroups elastic (e.g. a `minSubGroup: 2` job over 4 segments counts all 4 segments as core while eviction protects only 2). These must be reworked to use the tree's minimal satisfying set, so quota matches the allocation/eviction semantics.
+- **Correctness item to verify during impl**: ensure preempt/reclaim only ever take the elastic-phase victims for semi-preemptible jobs and never fall back to the phase-3 full eviction in `collectTasksToEvictFromSubGroupSet`, so core subgroups/pods are never offered as victims.
+- **Solver simulation**: represent the elastic surplus of a semi-preemptible job (extra pods and extra subgroups) as a fully-preemptible representative job.
 
 ## Future Work: `minNonPreemptible` field
 

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -120,6 +120,131 @@ Victim selection considers only the **surplus** of each node: the "extra" (`n - 
 This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction (see [Footnote: Eviction Ordering](#footnote-eviction-ordering)).
 
 
+## Non-Preemptible Accounting API (Option A)
+
+### Problem
+
+Two components compute "non-preemptible allocated" resources independently, and for
+semi-preemptible jobs they diverge:
+
+- The **scheduler** (proportion plugin) counts the **core only** — the minimal-satisfying set,
+  via `GetCoreTasks` (`pkg/scheduler/api/podgroup_info/core_info.go`). This is the number that
+  drives real quota and reclaim decisions.
+- The **podgroupcontroller** counts **all allocated pods** (a flat sum) in `getStatusWithMetadata`
+  (`pkg/podgroupcontroller/controllers/patcher/pod_group.go`) and publishes it to
+  `PodGroup.Status.ResourcesStatus.AllocatedNonPreemptible`, which the queuecontroller rolls up into
+  `Queue.Status.AllocatedNonPreemptible`.
+
+For a semi-preemptible job the controller therefore reports **core + elastic burst** as
+non-preemptible. Example: `minSubGroup: 2` over 4 fully-gang subgroups (`minMember: 8`) → the
+scheduler counts **16** core pods while the controller publishes **32** — a 2× overstatement. The
+value is *observational only* (the scheduler re-seeds core from live job state every session and
+never reads the published status back), so scheduling stays correct; but the queue's reported
+protected usage is wrong for users, dashboards, and external consumers, and can "flip" between
+reconciles because core membership was ranked by live allocation ratio.
+
+### Chosen approach
+
+The **scheduler is the single source of truth** for the core amount. It already computes the core
+resource vector per job (`coreResourceQuantities` in the proportion plugin). It publishes that
+amount at the **PodGroup level**, and the podgroupcontroller **consumes** it instead of re-deriving
+which pods are "core". This removes the divergence and the flip by construction, and stays fully
+**Pod-agnostic** — no pod-level labels or markers (an anti-pattern for this feature).
+
+### API shape
+
+A new **scheduler-owned** status block on the PodGroup (in
+`pkg/apis/scheduling/v2alpha2/podgroup_types.go`). It is a separate block — not a new field on the
+controller-owned `ResourcesStatus` — so each struct keeps a single writer:
+
+```go
+// PodGroupSchedulingState carries the scheduler's authoritative accounting for this pod group.
+// It is populated exclusively by the scheduler; all other controllers MUST treat it as read-only.
+// This is the single source of truth for resource classifications that depend on scheduling order
+// (e.g. which portion of a semi-preemptible job's allocation is "core").
+type PodGroupSchedulingState struct {
+	// NonPreemptibleAllocated is the portion of this pod group's current allocation that the
+	// scheduler protects from preemption/reclaim (the "core", i.e. the minimal-satisfying set).
+	//   - preemptible      pod group -> empty
+	//   - non-preemptible  pod group -> equals total allocation
+	//   - semi-preemptible pod group -> the core only (excludes elastic burst)
+	// Expressed in the same units as ResourcesStatus (GPU fractions, CPU millicpus, Memory MB).
+	// +optional
+	NonPreemptibleAllocated v1.ResourceList `json:"nonPreemptibleAllocated,omitempty"`
+}
+
+type PodGroupStatus struct {
+	// ... existing: Conditions, SchedulingConditions, ResourcesStatus ...
+
+	// SchedulingState is the scheduler's authoritative view of this pod group. Read-only for
+	// non-scheduler components.
+	// +optional
+	SchedulingState *PodGroupSchedulingState `json:"schedulingState,omitempty"`
+}
+```
+
+`ResourcesStatus` (`Allocated`, `AllocatedNonPreemptible`, `Requested`) is unchanged in shape. The
+field is `+optional`/`omitempty` and PodGroup is a single-version alpha type (`v2alpha2`, storage
+version), so the change is additive and needs no conversion webhook.
+
+### Data flow
+
+```
+scheduler (proportion.coreResourceQuantities)
+    → convert rs.ResourceQuantities → v1.ResourceList
+    → publish PodGroup.Status.SchedulingState.NonPreemptibleAllocated   [scheduler-owned]
+                                   │
+                                   ▼
+podgroupcontroller.getStatusWithMetadata
+    → PodGroup.Status.ResourcesStatus.AllocatedNonPreemptible           [controller-owned]
+                                   │
+                                   ▼
+queuecontroller.sumPodGroupsResources
+    → Queue.Status.AllocatedNonPreemptible                              [unchanged rollup]
+```
+
+Controller consumption changes its *source*, not its output field:
+
+```go
+if state := originalStatus.SchedulingState; state != nil && state.NonPreemptibleAllocated != nil {
+	updatedStatus.ResourcesStatus.AllocatedNonPreemptible = state.NonPreemptibleAllocated
+} else if !metaData.Preemptible {
+	updatedStatus.ResourcesStatus.AllocatedNonPreemptible = metaData.Allocated // legacy fallback
+}
+```
+
+### Why a nested block (designed for expansion)
+
+`schedulingState` is a namespace for scheduler-authoritative accounting so future needs land without
+further top-level status churn. Illustrative future fields (not built now):
+
+```go
+// ElasticAllocated        v1.ResourceList // surplus beyond core (reclaimed first)
+// MinRequirementSatisfied *bool           // job has reached its minimal shape
+// CoreSubGroups           []string        // which subgroups the scheduler counts as core (debug/observability)
+// LastEvaluatedSession    string          // scheduler session id/generation for staleness detection
+```
+
+Intended invariant once `ElasticAllocated` exists:
+`NonPreemptibleAllocated + ElasticAllocated == ResourcesStatus.Allocated`.
+
+### Notes / trade-offs
+
+- **Fidelity**: the scheduler's quota vector tracks CPU/Memory/GPU only, whereas the controller's
+  `Allocated` is a full `v1.ResourceList` (may include extended resources). `NonPreemptibleAllocated`
+  reflects the scheduler's quota dimensions — acceptable, since non-preemptible quota is
+  CPU/Mem/GPU-based. For this reason the field is set for semi-preemptible jobs first; for other
+  modes the controller keeps its existing fallback until the producer is broadened.
+- **Ownership**: the scheduler and controller already patch `PodGroup.Status` on disjoint paths
+  (`schedulingConditions` / annotations vs `resourcesStatus`); adding scheduler-written
+  `schedulingState` introduces no new write-conflict class.
+- **Staleness**: the value refreshes each scheduler session and only changes when allocation changes
+  (which is scheduler-driven). `LastEvaluatedSession` is the future hook if staleness detection is
+  ever needed.
+- **Defense-in-depth**: Option A removes the need for both sides to recompute core independently. If
+  they ever must, core ordering should be deterministic *and reproducible* — rank by static priority
+  then name rather than by live allocation ratio (the root cause of the flip).
+
 ## Footnote: Eviction Ordering
 
 In a `Semi-Preemptible` PodGroup / SubGroup, pods are NOT "colored out" as preemptible — there is no election of individual pods. All pods within a subgroup are treated equally: victims are drawn from the surplus using the **existing pod eviction ordering** (the same ordering used elsewhere in preemption), which is role-agnostic. It does not know that one pod is a master and another is a worker.

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -120,7 +120,7 @@ Victim selection considers only the **surplus** of each node: the "extra" (`n - 
 This implies that pods are treated equally within the same subgroup for eviction, prompting the user to use the subgroup API to specify any ordering or hierarchy for pod eviction (see [Footnote: Eviction Ordering](#footnote-eviction-ordering)).
 
 
-## Non-Preemptible Accounting API (Option A)
+## Non-Preemptible Accounting API
 
 ### Problem
 

--- a/docs/developer/designs/semi-preemptible/README.md
+++ b/docs/developer/designs/semi-preemptible/README.md
@@ -103,16 +103,6 @@ Because each subgroup here is fully gang (`minMember == size`), there is no pod-
 
 A validation webhook must **reject increases** to `minMember` or `minSubGroup` on a running semi-preemptible PodGroup (the root spec and every SubGroup entry). Raising either would reclassify already-running over-quota elastic pods/subgroups as core, silently growing the minimal satisfying set and breaking quota invariants without a rescheduling cycle. Decreasing is allowed — it can only widen the elastic tier.
 
-## Automated Segmentation (Out of Scope)
-
-[Automated segmented subgroups](../segmented-subgroups/README.md) (the `kai.scheduler/segment-size` annotation, wired for PyTorchJob Worker replicas and LeaderWorkerSet) are **out of scope** for semi-preemptible and are **mutually exclusive** with it.
-
-Automated segmentation emits a **fully-gang** tree: every segment leaf gets `minAvailable = segmentSize`, with no `minSubGroup` and no `minMember = 0`. A fully-gang tree has no surplus at any level, so semi-preemptible has nothing to make elastic and silently collapses to plain non-preemptible. Rather than ship a combination that looks meaningful but is inert, the two are kept apart.
-
-This does **not** remove subgroup-level elasticity — it remains fully supported for **hand-authored** subgroup trees (see [Subgroups and Multi-Level Trees](#subgroups-and-multi-level-trees)), where the user sets `minSubGroup` below the number of child subgroups to create an elastic tier. The exclusion applies only to the automated, annotation-driven path.
-
-**Enforcement (soft).** When a workload requests both automated segmentation and `semi-preemptible`, the PodGrouper still creates the PodGroup but emits a `PodGrouperWarning` event on the pod, noting that the two are mutually exclusive and the workload will behave as non-preemptible. Enforcement lives in the PodGrouper rather than an admission webhook because only the grouper sees both the resolved preemptibility and the segmentation decision, and for auto-segmented workloads the user submits the source workload (PyTorchJob/LWS) — never the PodGroup — so a Warning event on the pod is more visible than a PodGroup-webhook rejection. Being non-blocking, it never breaks an existing workload that happens to set both.
-
 ## Simulation Considerations
 
 Victim selection considers only the **surplus** of each node: the "extra" (`n - minMember`) pods at a leaf PodSet, and the extra (`scheduled - minSubGroup`) child subgroups at an intermediate node (evicted whole). This is applied independently per node; no cross-subgroup victim selection is needed. This approach may miss some solutions when checking all orderings, but the added complexity is not justified for the MVP.


### PR DESCRIPTION
## Description

Updates the semi-preemptible design document to reflect the current API (which now includes `minSubGroups`) and resolves open questions from issues #1585 and #1596.

Key changes:
- Clarifies that the core/elastic pod split applies exclusively at `minMember` leaf PodSets — `minSubGroups` intermediate nodes define scheduling gates only, not preemption thresholds
- Defines multi-level tree behavior: semi-elasticity is a pod-level concept; subgroups are atomic scheduling units (not semi-elastic)
- Adds immutability constraint: `minMember` and `minSubGroups` must not increase on semi-preemptible PodGroups post-creation (validation webhook requirement)
- Documents future `minNonPreemptible` field: scope, work required, and the three-tier pod ordering complexity it introduces

## Related Issues

Fixes #1585
Fixes #1596

## Checklist

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None — documentation only.

## Additional Notes

This is an HLD update only. Technical design and implementation are tracked separately.