### PR TITLE
fix(binder): prevent duplicate reservation pods for a single gpu-group (#1693) [v0.14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fixed default node-scale-adjuster image name (`node-scale-adjuster` → `nodescaleadjuster`) so it matches the image published to GHCR
 - Account for native sidecar containers (initContainers with `restartPolicy: Always`, KEP-753) in pod resource accounting, matching kubelet's `AggregateContainerRequests`. Previously, native sidecar requests were max'd against regular containers instead of summed with them, causing the scheduler to bind pods that kubelet then rejected at admission with `OutOfCpu`/`OutOfGpu`. [#1556](https://github.com/kai-scheduler/KAI-Scheduler/pull/1556)
+- Fixed duplicate GPU reservation pods being created for a single `gpu-group` on a node (each reserving a different physical GPU), which corrupted the scheduler's fractional-GPU accounting and left devices unschedulable. Reservation pods are now named deterministically per (node, gpu-group) and treat AlreadyExists as success, so concurrent or retried binds collide on one object instead of duplicating [#1673](https://github.com/kai-scheduler/KAI-Scheduler/issues/1673)
 
 ## [v0.14.5] - 2026-06-02
 

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -5,6 +5,8 @@ package resourcereservation
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -17,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,12 +39,11 @@ type Interface interface {
 }
 
 const (
-	resourceReservation            = "resource-reservation"
-	gpuReservationPodPrefix        = "gpu-reservation"
-	gpuIndexAnnotationName         = "run.ai/reserve_for_gpu_index"
-	numberOfGPUsToReserve          = 1
-	reservationPodRandomCharacters = 5
-	unknownGpuIndicator            = "-1"
+	resourceReservation     = "resource-reservation"
+	gpuReservationPodPrefix = "gpu-reservation"
+	gpuIndexAnnotationName  = "run.ai/reserve_for_gpu_index"
+	numberOfGPUsToReserve   = 1
+	unknownGpuIndicator     = "-1"
 )
 
 type service struct {
@@ -421,7 +421,7 @@ func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGr
 		return nil, fmt.Errorf("cluster is scaling up, could not create reservation pod")
 	}
 
-	podName := fmt.Sprintf("%s-%s-%s", gpuReservationPodPrefix, nodeName, rand.String(reservationPodRandomCharacters))
+	podName := reservationPodName(nodeName, gpuGroup)
 
 	// Build resource requirements starting with GPU resources
 	resources := v1.ResourceRequirements{
@@ -446,6 +446,15 @@ func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGr
 
 	pod, err := rsc.createResourceReservationPod(nodeName, gpuGroup, podName, resources)
 	if err != nil {
+		// The reservation pod name is deterministic per (node, gpu-group). AlreadyExists
+		// means another actor (a concurrent bind, a retry, or another binder replica)
+		// already created the reservation pod for this gpu-group, so reuse it rather than
+		// creating a duplicate on a different physical GPU.
+		if apierrors.IsAlreadyExists(err) {
+			logger.Info("GPU reservation pod already exists for gpu group, reusing",
+				"nodeName", nodeName, "namespace", rsc.namespace, "name", podName, "gpuGroup", gpuGroup)
+			return pod, nil
+		}
 		logger.Error(err, "Failed to create GPU reservation pod on node",
 			"nodeName", nodeName, "namespace", rsc.namespace, "name", podName)
 		return nil, err
@@ -604,4 +613,13 @@ func (rsc *service) isScalingUp(ctx context.Context) bool {
 
 func IsGPUReservationPod(pod *v1.Pod) bool {
 	return strings.HasPrefix(pod.Name, gpuReservationPodPrefix)
+}
+
+// reservationPodName derives a deterministic reservation pod name from the node and
+// gpu-group, so concurrent or retried creates for the same gpu-group collide on a
+// single API-server object (AlreadyExists) instead of producing duplicate reservation
+// pods on different physical GPUs.
+func reservationPodName(nodeName, gpuGroup string) string {
+	hash := sha256.Sum256([]byte(nodeName + "/" + gpuGroup))
+	return fmt.Sprintf("%s-%s", gpuReservationPodPrefix, hex.EncodeToString(hash[:8]))
 }

--- a/pkg/binder/binding/resourcereservation/resource_reservation_test.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation_test.go
@@ -6,6 +6,8 @@ package resourcereservation
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1490,5 +1492,75 @@ var _ = Describe("Race condition: reservation pod deleted during concurrent bind
 			Expect(len(pods.Items)).To(Equal(1),
 				"Reservation pod should be preserved when an active BindRequest exists")
 		})
+	})
+})
+
+var _ = Describe("Reservation pod duplicate gpu-group race", func() {
+	const (
+		raceNodeName = "race-node"
+		raceGroup    = "race-gpu-group"
+	)
+
+	// This test covers issue #1673: two reservation pods getting assigned the same
+	// gpu-group while reserving different physical GPUs.
+	//
+	// In production the reservation service reads through an informer cache that lags
+	// behind writes, while it creates/watches against the API server directly. So a
+	// find-or-create of the reservation pod can miss a pod a previous ReserveGpuDevice
+	// call just created, and a second call for the same gpu-group would create a
+	// duplicate reservation pod on a different physical GPU.
+	//
+	// The interceptor models that cache lag deterministically: List in the reservation
+	// namespace always appears empty, and each created reservation pod is allocated a
+	// distinct physical GPU index. Deterministic per-(node, gpu-group) naming plus
+	// AlreadyExists handling must collapse the second create onto the first pod.
+	It("creates a single reservation pod for a gpu-group despite cache lag", func() {
+		base := fake.NewClientBuilder().WithScheme(testScheme).
+			WithIndex(&v1.Pod{}, "spec.nodeName", nodeNameIndexer).Build()
+
+		var gpuIndexCounter int32
+		laggingClient := interceptor.NewClient(base, interceptor.Funcs{
+			List: func(ctx context.Context, c runtimeClient.WithWatch, list runtimeClient.ObjectList, opts ...runtimeClient.ListOption) error {
+				listOpts := runtimeClient.ListOptions{}
+				listOpts.ApplyOptions(opts)
+				if _, ok := list.(*v1.PodList); ok && listOpts.Namespace == resourceReservationNameSpace {
+					return nil // cache lag: reservation namespace appears empty
+				}
+				return c.List(ctx, list, opts...)
+			},
+			Create: func(ctx context.Context, c runtimeClient.WithWatch, obj runtimeClient.Object, opts ...runtimeClient.CreateOption) error {
+				// Simulate the GPU device plugin allocating a distinct physical GPU index
+				// to each reservation pod it admits.
+				if pod, ok := obj.(*v1.Pod); ok && pod.Namespace == resourceReservationNameSpace {
+					if pod.Annotations == nil {
+						pod.Annotations = map[string]string{}
+					}
+					pod.Annotations[gpuIndexAnnotationName] = strconv.Itoa(int(atomic.AddInt32(&gpuIndexCounter, 1) - 1))
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+			Watch: func(ctx context.Context, c runtimeClient.WithWatch, obj runtimeClient.ObjectList, opts ...runtimeClient.ListOption) (watch.Interface, error) {
+				return exampleMockWatchPod("0", 0), nil
+			},
+		})
+
+		rsc := initializeTestService(laggingClient)
+
+		fractionPodA := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "frac-a"}}
+		fractionPodB := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "frac-b"}}
+		Expect(base.Create(context.Background(), fractionPodA)).To(Succeed())
+		Expect(base.Create(context.Background(), fractionPodB)).To(Succeed())
+
+		_, err := rsc.ReserveGpuDevice(context.Background(), fractionPodA, raceNodeName, raceGroup)
+		Expect(err).To(Succeed())
+		_, err = rsc.ReserveGpuDevice(context.Background(), fractionPodB, raceNodeName, raceGroup)
+		Expect(err).To(Succeed())
+
+		reservationPods := &v1.PodList{}
+		Expect(base.List(context.Background(), reservationPods,
+			runtimeClient.InNamespace(resourceReservationNameSpace),
+			runtimeClient.MatchingLabels{constants.GPUGroup: raceGroup})).To(Succeed())
+		Expect(reservationPods.Items).To(HaveLen(1),
+			"a single gpu-group must map to exactly one reservation pod / physical GPU")
 	})
 })


### PR DESCRIPTION
## Description

Backport of #1693 to the `v0.14` release branch.

At scale with fractional GPU workloads, multiple GPU reservation pods could be created for a single `runai-gpu-group` on a node, each reserving a different physical GPU. Since the scheduler tracks fractional-GPU capacity by gpu-group, a group spanning two devices corrupts accounting — affected GPUs appear full, fractional pods stay pending, and the state does not self-correct.

**Fix:** reservation pods are named deterministically per `(node, gpu-group)` (hashed) and `AlreadyExists` on create is treated as success (reuse the existing pod), so concurrent, retried, and multi-replica creates collide on a single API-server object instead of duplicating. Existing reservation pods (old random-suffix names) are unaffected — they are still resolved by gpu-group label, so no migration is needed.

## Related Issues

Fixes #1673

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Cherry-pick of `73298061` from #1693 onto `v0.14` (manual adjustments limited to conflict resolution: dropping the unused `rand` import and placing the new test / changelog entry into this branch's layout). Verified locally on `v0.14`: `go build`, `go vet`, `gofmt`, and the `resourcereservation` package tests (including the new duplicate-gpu-group race test) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
