### PR TITLE
feat: Persist predicted NUMA placements

### DIFF
--- a/deployments/kai-scheduler/crds/scheduling.run.ai_bindrequests.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_bindrequests.yaml
@@ -413,6 +413,34 @@ spec:
                 items:
                   type: string
                 type: array
+              selectedNUMAZones:
+                description: |-
+                  SelectedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
+                  selected node, set only on nodes whose kubelet Topology Manager policy rejects on topology
+                  grounds (single-numa-node / restricted). The binder records it as a pod annotation; the
+                  scheduler reads it back to keep per-zone accounting stable across cycles. Empty when the pod
+                  is not NUMA-constrained.
+                items:
+                  description: |-
+                    NUMAZonePlacement is the predicted placement of a pod's resources on one NUMA zone: the durable
+                    NUMA-node zone id and the amount of each resource placed there.
+                  properties:
+                    amount:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Amount is the per-resource quantity placed on this
+                        zone.
+                      type: object
+                    zone:
+                      description: Zone is the NUMA-node zone id (the NodeResourceTopology
+                        Zone.Name).
+                      type: string
+                  type: object
+                type: array
               selectedNode:
                 description: SelectedNode is the name of the selected node the pod
                   should be bound to

--- a/deployments/kai-scheduler/crds/scheduling.run.ai_bindrequests.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_bindrequests.yaml
@@ -52,6 +52,33 @@ spec:
               podName:
                 description: PodName is the name of the pod to bind
                 type: string
+              predictedNUMAZones:
+                description: |-
+                  PredictedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
+                  selected node.
+                items:
+                  description: |-
+                    NUMAZonePlacement is a pod's durable per-zone placement record: the NRT zone id and the
+                    per-resource amounts placed there. Serialized to kai.scheduler/numa-placement-observed and
+                    kai.scheduler/numa-placement-predicted.
+                  properties:
+                    amount:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: ResourceList is a set of (resource name, quantity)
+                        pairs.
+                      type: object
+                    zone:
+                      type: string
+                  required:
+                  - amount
+                  - zone
+                  type: object
+                type: array
               receivedGPU:
                 description: ReceivedGPU is the amount of GPUs that were received
                 properties:
@@ -412,33 +439,6 @@ spec:
                   Only if the RecievedResourceType is "Fraction"
                 items:
                   type: string
-                type: array
-              selectedNUMAZones:
-                description: |-
-                  SelectedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
-                  selected node.
-                items:
-                  description: |-
-                    NUMAZonePlacement is a pod's durable per-zone placement record: the NRT zone id and the
-                    per-resource amounts placed there. Serialized to kai.scheduler/numa-placement-observed and
-                    kai.scheduler/numa-placement-predicted.
-                  properties:
-                    amount:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: ResourceList is a set of (resource name, quantity)
-                        pairs.
-                      type: object
-                    zone:
-                      type: string
-                  required:
-                  - amount
-                  - zone
-                  type: object
                 type: array
               selectedNode:
                 description: SelectedNode is the name of the selected node the pod

--- a/deployments/kai-scheduler/crds/scheduling.run.ai_bindrequests.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_bindrequests.yaml
@@ -416,14 +416,12 @@ spec:
               selectedNUMAZones:
                 description: |-
                   SelectedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
-                  selected node, set only on nodes whose kubelet Topology Manager policy rejects on topology
-                  grounds (single-numa-node / restricted). The binder records it as a pod annotation; the
-                  scheduler reads it back to keep per-zone accounting stable across cycles. Empty when the pod
-                  is not NUMA-constrained.
+                  selected node.
                 items:
                   description: |-
-                    NUMAZonePlacement is the predicted placement of a pod's resources on one NUMA zone: the durable
-                    NUMA-node zone id and the amount of each resource placed there.
+                    NUMAZonePlacement is a pod's durable per-zone placement record: the NRT zone id and the
+                    per-resource amounts placed there. Serialized to kai.scheduler/numa-placement-observed and
+                    kai.scheduler/numa-placement-predicted.
                   properties:
                     amount:
                       additionalProperties:
@@ -432,13 +430,14 @@ spec:
                         - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: Amount is the per-resource quantity placed on this
-                        zone.
+                      description: ResourceList is a set of (resource name, quantity)
+                        pairs.
                       type: object
                     zone:
-                      description: Zone is the NUMA-node zone id (the NodeResourceTopology
-                        Zone.Name).
                       type: string
+                  required:
+                  - amount
+                  - zone
                   type: object
                 type: array
               selectedNode:

--- a/pkg/apis/scheduling/v1alpha2/bindrequest_types.go
+++ b/pkg/apis/scheduling/v1alpha2/bindrequest_types.go
@@ -29,9 +29,9 @@ type BindRequestSpec struct {
 	// ResourceClaims is the list of resource claims that need to be bound for this pod
 	ResourceClaimAllocations []ResourceClaimAllocation `json:"resourceClaimAllocations,omitempty"`
 
-	// SelectedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
+	// PredictedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
 	// selected node.
-	SelectedNUMAZones []NUMAZonePlacement `json:"selectedNUMAZones,omitempty"`
+	PredictedNUMAZones []NUMAZonePlacement `json:"predictedNUMAZones,omitempty"`
 
 	// BackoffLimit is the number of retries before giving up
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`

--- a/pkg/apis/scheduling/v1alpha2/bindrequest_types.go
+++ b/pkg/apis/scheduling/v1alpha2/bindrequest_types.go
@@ -29,6 +29,10 @@ type BindRequestSpec struct {
 	// ResourceClaims is the list of resource claims that need to be bound for this pod
 	ResourceClaimAllocations []ResourceClaimAllocation `json:"resourceClaimAllocations,omitempty"`
 
+	// SelectedNUMAZones is the scheduler's predicted NUMA placement of the pod's resources on the
+	// selected node.
+	SelectedNUMAZones []NUMAZonePlacement `json:"selectedNUMAZones,omitempty"`
+
 	// BackoffLimit is the number of retries before giving up
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 }

--- a/pkg/apis/scheduling/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.deepcopy.go
@@ -94,8 +94,8 @@ func (in *BindRequestSpec) DeepCopyInto(out *BindRequestSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.SelectedNUMAZones != nil {
-		in, out := &in.SelectedNUMAZones, &out.SelectedNUMAZones
+	if in.PredictedNUMAZones != nil {
+		in, out := &in.PredictedNUMAZones, &out.PredictedNUMAZones
 		*out = make([]NUMAZonePlacement, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/pkg/apis/scheduling/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.deepcopy.go
@@ -94,6 +94,13 @@ func (in *BindRequestSpec) DeepCopyInto(out *BindRequestSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SelectedNUMAZones != nil {
+		in, out := &in.SelectedNUMAZones, &out.SelectedNUMAZones
+		*out = make([]NUMAZonePlacement, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
 		*out = new(int32)

--- a/pkg/binder/binding/binder.go
+++ b/pkg/binder/binding/binder.go
@@ -62,9 +62,9 @@ func (b *Binder) Bind(ctx context.Context, pod *v1.Pod, node *v1.Node, bindReque
 		return err
 	}
 
-	err = b.patchResourceReceivedTypeAnnotation(ctx, pod, bindRequest)
+	err = b.patchBindAnnotations(ctx, pod, bindRequest)
 	if err != nil {
-		return fmt.Errorf("failed to patch pod <%s/%s> with resource receive type annotation: %w", pod.Namespace, pod.Name, err)
+		return fmt.Errorf("failed to patch pod <%s/%s> with bind annotations: %w", pod.Namespace, pod.Name, err)
 	}
 
 	logger.Info("Binding pod", "namespace", pod.Namespace, "name", pod.Name, "hostname", node.Name)
@@ -127,18 +127,27 @@ func (b *Binder) reserveGPUs(ctx context.Context, pod *v1.Pod, bindRequest *v1al
 	return gpuIndexes, nil
 }
 
-func (b *Binder) patchResourceReceivedTypeAnnotation(ctx context.Context, pod *v1.Pod, bindRequest *v1alpha2.BindRequest) error {
+func (b *Binder) patchBindAnnotations(ctx context.Context, pod *v1.Pod, bindRequest *v1alpha2.BindRequest) error {
+	annotations := map[string]string{
+		constants.ReceivedResourceType: bindRequest.Spec.ReceivedResourceType,
+	}
+
+	if len(bindRequest.Spec.SelectedNUMAZones) > 0 {
+		placement, err := json.Marshal(bindRequest.Spec.SelectedNUMAZones)
+		if err != nil {
+			return err
+		}
+		annotations[constants.NumaPlacementPredicted] = string(placement)
+	}
+
 	patchBytes, err := json.Marshal(map[string]interface{}{
 		"metadata": map[string]interface{}{
-			"annotations": map[string]string{
-				constants.ReceivedResourceType: bindRequest.Spec.ReceivedResourceType,
-			},
+			"annotations": annotations,
 		},
 	})
 	if err != nil {
 		return err
 	}
 
-	err = b.kubeClient.Patch(ctx, pod, client.RawPatch(types.MergePatchType, patchBytes))
-	return err
+	return b.kubeClient.Patch(ctx, pod, client.RawPatch(types.MergePatchType, patchBytes))
 }

--- a/pkg/binder/binding/binder.go
+++ b/pkg/binder/binding/binder.go
@@ -132,8 +132,8 @@ func (b *Binder) patchBindAnnotations(ctx context.Context, pod *v1.Pod, bindRequ
 		constants.ReceivedResourceType: bindRequest.Spec.ReceivedResourceType,
 	}
 
-	if len(bindRequest.Spec.SelectedNUMAZones) > 0 {
-		placement, err := json.Marshal(bindRequest.Spec.SelectedNUMAZones)
+	if len(bindRequest.Spec.PredictedNUMAZones) > 0 {
+		placement, err := json.Marshal(bindRequest.Spec.PredictedNUMAZones)
 		if err != nil {
 			return err
 		}

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -63,6 +63,7 @@ const (
 	LastStartTimeStamp            = "kai.scheduler/last-start-timestamp"
 	GpuSharingConfigMapAnnotation = "runai/shared-gpu-configmap"
 	NvidiaVisibleDevices          = "NVIDIA_VISIBLE_DEVICES"
+	NumaPlacementPredicted        = "kai.scheduler/numa-placement-predicted"
 	NumaPlacementObserved         = "kai.scheduler/numa-placement-observed"
 
 	// UsageDB Prometheus Selector

--- a/pkg/scheduler/actions/allocate/allocate_numa_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_numa_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package allocate_test
+
+import (
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+// TestHandleAllocationNuma drives the real allocate action against single-numa-node and restricted
+// nodes, asserting both the scheduling verdict (which node, or stays pending) and the resulting
+// per-zone NUMA placement. The numa plugin is enabled automatically because nodes carry a topology.
+func TestHandleAllocationNuma(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+
+	for testNumber, testMetadata := range getNumaAllocationTestsMetadata() {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.Name)
+
+		ssn := test_utils.BuildSession(testMetadata, controller)
+		allocate.New().Execute(ssn)
+
+		test_utils.MatchExpectedAndRealTasks(t, testNumber, testMetadata, ssn)
+	}
+}
+
+func cpu(amount string) map[v1.ResourceName]string {
+	return map[v1.ResourceName]string{v1.ResourceCPU: amount}
+}
+
+func getNumaAllocationTestsMetadata() []test_utils.TestTopologyBasic {
+	return []test_utils.TestTopologyBasic{
+		{
+			Name: "Guaranteed pod fits a single NUMA zone - placed on the lowest fitting zone",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "pending_job0", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("4")), nodes_fake.NewNumaZone("zone-1", cpu("4")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"pending_job0": {NodeName: "node0", Status: pod_status.Binding, NUMAZones: []int{0}},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("4")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{NumberOfCacheBinds: 5}},
+		},
+		{
+			Name: "Guaranteed pod too large for any single zone - stays pending (NUMA, not capacity)",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "pending_job0", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 6, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("4")), nodes_fake.NewNumaZone("zone-1", cpu("4")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"pending_job0": {Status: pod_status.Pending},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("4"), 1: cpu("4")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{NumberOfCacheBinds: 0}},
+		},
+		{
+			Name: "Node selection - lands on the node that can NUMA-align, skips the one whose zones are too small",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "pending_job0", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"small-node": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("2")), nodes_fake.NewNumaZone("zone-1", cpu("2")),
+				)},
+				"good-node": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("4")), nodes_fake.NewNumaZone("zone-1", cpu("4")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"pending_job0": {NodeName: "good-node", Status: pod_status.Binding, NUMAZones: []int{0}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{NumberOfCacheBinds: 5}},
+		},
+		{
+			Name: "In-cycle per-zone accounting - two pods fill both zones, third has no zone left",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "high", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+				{
+					Name: "mid", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+				{
+					Name: "low", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("4")), nodes_fake.NewNumaZone("zone-1", cpu("4")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"high": {NodeName: "node0", Status: pod_status.Binding, NUMAZones: []int{0}},
+				"mid":  {NodeName: "node0", Status: pod_status.Binding, NUMAZones: []int{1}},
+				"low":  {Status: pod_status.Pending},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("1")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{NumberOfCacheBinds: 5}},
+		},
+		{
+			Name: "Restricted policy - request spanning two zones is admitted and split across the mask",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "pending_job0", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 6, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicyRestricted, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("4")), nodes_fake.NewNumaZone("zone-1", cpu("4")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"pending_job0": {NodeName: "node0", Status: pod_status.Binding, NUMAZones: []int{0, 1}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{NumberOfCacheBinds: 5}},
+		},
+		{
+			Name: "Pass-through - a Burstable pod is not NUMA-constrained even when it fits no single zone",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "pending_job0", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 6, QOSClass: v1.PodQOSBurstable,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZone("zone-0", cpu("4")), nodes_fake.NewNumaZone("zone-1", cpu("4")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"pending_job0": {NodeName: "node0", Status: pod_status.Binding, NUMAZones: []int{}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{NumberOfCacheBinds: 5}},
+		},
+	}
+}

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "go.uber.org/mock/gomock"
 
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/integration_tests/integration_tests_utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
@@ -1811,6 +1812,6 @@ type failingBindCache struct {
 	cache.Cache
 }
 
-func (f *failingBindCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string) error {
+func (f *failingBindCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
 	return fmt.Errorf("create pod error")
 }

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -1812,6 +1812,6 @@ type failingBindCache struct {
 	cache.Cache
 }
 
-func (f *failingBindCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
+func (f *failingBindCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, predictedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
 	return fmt.Errorf("create pod error")
 }

--- a/pkg/scheduler/actions/integration_tests/numa/numa_test.go
+++ b/pkg/scheduler/actions/integration_tests/numa/numa_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa_test
+
+import (
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/consolidation"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/preempt"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+// TestNumaBookkeepingThroughFullPipeline runs the whole action pipeline
+// (allocate -> consolidation -> reclaim -> preempt) on a single session and asserts the per-NUMA-zone
+// ledger ends exact and non-negative.
+func TestNumaBookkeepingThroughFullPipeline(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+
+	for testNumber, testMetadata := range getNumaBookkeepingTestsMetadata() {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.Name)
+
+		ssn := test_utils.BuildSession(testMetadata, controller)
+		for _, action := range []framework.Action{
+			allocate.New(), consolidation.New(), reclaim.New(), preempt.New(),
+		} {
+			action.Execute(ssn)
+		}
+
+		test_utils.MatchExpectedAndRealTasks(t, testNumber, testMetadata, ssn)
+	}
+}
+
+func cpu(amount string) map[v1.ResourceName]string {
+	return map[v1.ResourceName]string{v1.ResourceCPU: amount}
+}
+
+func twoFullZonesNode() map[string]nodes_fake.TestNodeBasic {
+	return map[string]nodes_fake.TestNodeBasic{
+		"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+			node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+			nodes_fake.NewNumaZoneWithAllocatable("zone-0", cpu("4"), cpu("1")),
+			nodes_fake.NewNumaZoneWithAllocatable("zone-1", cpu("4"), cpu("1")),
+		)},
+	}
+}
+
+func runningVictim(name, queue string, priority int32, zoneID string) *jobs_fake.TestJobBasic {
+	return &jobs_fake.TestJobBasic{
+		Name: name, QueueName: queue, Priority: priority,
+		RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+		Tasks: []*tasks_fake.TestTaskBasic{{
+			NodeName: "node0", State: pod_status.Running,
+			Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+				map[string]map[v1.ResourceName]string{zoneID: cpu("3")}),
+		}},
+	}
+}
+
+func getNumaBookkeepingTestsMetadata() []test_utils.TestTopologyBasic {
+	return []test_utils.TestTopologyBasic{
+		{
+			Name: "Preempt frees a zone - ledger stays exact through the full pipeline",
+			Jobs: []*jobs_fake.TestJobBasic{
+				runningVictim("victim0", "queue0", constants.PriorityTrainNumber-1, "zone-0"),
+				runningVictim("victim1", "queue0", constants.PriorityTrainNumber, "zone-1"),
+				{
+					Name: "preemptor", QueueName: "queue0", Priority: constants.PriorityBuildNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: twoFullZonesNode(),
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"victim0":   {NodeName: "node0", Status: pod_status.Releasing},
+				"victim1":   {NodeName: "node0", Status: pod_status.Running, NUMAZones: []int{1}},
+				"preemptor": {NodeName: "node0", Status: pod_status.Pipelined, NUMAZones: []int{0}},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("1")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds: 5, NumberOfCacheEvictions: 1, NumberOfPipelineActions: 1,
+			}},
+		},
+		{
+			Name: "Reclaim frees a zone - ledger stays exact through the full pipeline",
+			Jobs: []*jobs_fake.TestJobBasic{
+				runningVictim("victim0", "victim_queue", constants.PriorityTrainNumber-1, "zone-0"),
+				runningVictim("victim1", "victim_queue", constants.PriorityTrainNumber, "zone-1"),
+				{
+					Name: "reclaimer", QueueName: "reclaimer_queue", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: twoFullZonesNode(),
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "victim_queue", DeservedCPUs: test_utils.CreateFloat64Pointer(3000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12), ParentQueue: "d1"},
+				{Name: "reclaimer_queue", DeservedCPUs: test_utils.CreateFloat64Pointer(3000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12), ParentQueue: "d1"},
+			},
+			Departments: []test_utils.TestDepartmentBasic{{Name: "d1"}},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"victim0":   {NodeName: "node0", Status: pod_status.Releasing},
+				"victim1":   {NodeName: "node0", Status: pod_status.Running, NUMAZones: []int{1}},
+				"reclaimer": {NodeName: "node0", Status: pod_status.Pipelined, NUMAZones: []int{0}},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("1")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds: 5, NumberOfCacheEvictions: 1, NumberOfPipelineActions: 1,
+			}},
+		},
+	}
+}

--- a/pkg/scheduler/actions/preempt/preempt_numa_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_numa_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package preempt_test
+
+import (
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/preempt"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+// TestHandlePreemptNuma drives the real preempt action on a single-numa-node node whose zones are
+// both occupied by running Guaranteed victims, so a higher-priority pending pod can only be placed
+// by evicting a victim to free a whole zone. Verifies the right (minimal) victim is evicted, the
+// preemptor lands on the freed zone, and the per-zone ledger is consistent after evict+pipeline.
+func TestHandlePreemptNuma(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+
+	for testNumber, testMetadata := range getNumaPreemptTestsMetadata() {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.Name)
+
+		ssn := test_utils.BuildSession(testMetadata, controller)
+		preempt.New().Execute(ssn)
+
+		test_utils.MatchExpectedAndRealTasks(t, testNumber, testMetadata, ssn)
+	}
+}
+
+func cpu(amount string) map[v1.ResourceName]string {
+	return map[v1.ResourceName]string{v1.ResourceCPU: amount}
+}
+
+func twoFullZonesNode() map[string]nodes_fake.TestNodeBasic {
+	return map[string]nodes_fake.TestNodeBasic{
+		"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+			node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+			nodes_fake.NewNumaZoneWithAllocatable("zone-0", cpu("4"), cpu("1")),
+			nodes_fake.NewNumaZoneWithAllocatable("zone-1", cpu("4"), cpu("1")),
+		)},
+	}
+}
+
+func getNumaPreemptTestsMetadata() []test_utils.TestTopologyBasic {
+	return []test_utils.TestTopologyBasic{
+		{
+			Name: "Preemptor fits only after a zone is freed - lowest-priority victim is evicted, preemptor takes the freed zone",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					// Lower priority than victim1, so this is the one evicted.
+					Name: "victim0", QueueName: "queue0", Priority: constants.PriorityTrainNumber - 1,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{
+						NodeName: "node0", State: pod_status.Running,
+						Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+							map[string]map[v1.ResourceName]string{"zone-0": cpu("3")}),
+					}},
+				},
+				{
+					Name: "victim1", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{
+						NodeName: "node0", State: pod_status.Running,
+						Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+							map[string]map[v1.ResourceName]string{"zone-1": cpu("3")}),
+					}},
+				},
+				{
+					Name: "preemptor", QueueName: "queue0", Priority: constants.PriorityBuildNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: twoFullZonesNode(),
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"victim0":   {NodeName: "node0", Status: pod_status.Releasing},
+				"victim1":   {NodeName: "node0", Status: pod_status.Running, NUMAZones: []int{1}},
+				"preemptor": {NodeName: "node0", Status: pod_status.Pipelined, NUMAZones: []int{0}},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("1")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds: 5, NumberOfCacheEvictions: 1, NumberOfPipelineActions: 1,
+			}},
+		},
+		{
+			Name: "Preemptor cannot be NUMA-aligned even after eviction - no victim is preempted",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					Name: "victim0", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{
+						NodeName: "node0", State: pod_status.Running,
+						Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+							map[string]map[v1.ResourceName]string{"zone-0": cpu("3")}),
+					}},
+				},
+				{
+					Name: "victim1", QueueName: "queue0", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{
+						NodeName: "node0", State: pod_status.Running,
+						Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+							map[string]map[v1.ResourceName]string{"zone-1": cpu("3")}),
+					}},
+				},
+				{
+					// Needs 5 cpu - no single 4-cpu zone can hold it even when fully freed.
+					Name: "preemptor", QueueName: "queue0", Priority: constants.PriorityBuildNumber,
+					RequiredCPUsPerTask: 5, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: twoFullZonesNode(),
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "queue0", DeservedCPUs: test_utils.CreateFloat64Pointer(100000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12)},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"victim0":   {NodeName: "node0", Status: pod_status.Running, NUMAZones: []int{0}},
+				"victim1":   {NodeName: "node0", Status: pod_status.Running, NUMAZones: []int{1}},
+				"preemptor": {Status: pod_status.Pending},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("1")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds: 0, NumberOfCacheEvictions: 0, NumberOfPipelineActions: 0,
+			}},
+		},
+	}
+}

--- a/pkg/scheduler/actions/reclaim/reclaim_numa_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_numa_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim_test
+
+import (
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+	"gopkg.in/h2non/gock.v1"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+// TestHandleReclaimNuma drives the real reclaim action: an under-quota queue reclaims a NUMA zone
+// held by an over-quota queue's victim. Both zones are occupied, so the reclaimer can only land
+// after a victim is evicted to free a whole zone. Verifies the reclaimed victim, the reclaimer's
+// placement on the freed zone, and a consistent per-zone ledger after evict+pipeline.
+func TestHandleReclaimNuma(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+	defer gock.Off()
+
+	for testNumber, testMetadata := range getNumaReclaimTestsMetadata() {
+		t.Logf("Running test %d: %s", testNumber, testMetadata.Name)
+
+		ssn := test_utils.BuildSession(testMetadata, controller)
+		reclaim.New().Execute(ssn)
+
+		test_utils.MatchExpectedAndRealTasks(t, testNumber, testMetadata, ssn)
+	}
+}
+
+func cpu(amount string) map[v1.ResourceName]string {
+	return map[v1.ResourceName]string{v1.ResourceCPU: amount}
+}
+
+func getNumaReclaimTestsMetadata() []test_utils.TestTopologyBasic {
+	return []test_utils.TestTopologyBasic{
+		{
+			Name: "Under-quota queue reclaims a NUMA zone from an over-quota queue's victim",
+			Jobs: []*jobs_fake.TestJobBasic{
+				{
+					// Lower priority within the over-quota queue, so this victim is reclaimed.
+					Name: "victim0", QueueName: "victim_queue", Priority: constants.PriorityTrainNumber - 1,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{
+						NodeName: "node0", State: pod_status.Running,
+						Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+							map[string]map[v1.ResourceName]string{"zone-0": cpu("3")}),
+					}},
+				},
+				{
+					Name: "victim1", QueueName: "victim_queue", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{
+						NodeName: "node0", State: pod_status.Running,
+						Annotations: nodes_fake.NumaObservedPlacementAnnotation(
+							map[string]map[v1.ResourceName]string{"zone-1": cpu("3")}),
+					}},
+				},
+				{
+					Name: "reclaimer", QueueName: "reclaimer_queue", Priority: constants.PriorityTrainNumber,
+					RequiredCPUsPerTask: 3, QOSClass: v1.PodQOSGuaranteed,
+					Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+				},
+			},
+			Nodes: map[string]nodes_fake.TestNodeBasic{
+				"node0": {CPUMillis: 1000, CPUMemory: 1e12, NumaTopology: nodes_fake.NewNumaTopology(
+					node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+					nodes_fake.NewNumaZoneWithAllocatable("zone-0", cpu("4"), cpu("1")),
+					nodes_fake.NewNumaZoneWithAllocatable("zone-1", cpu("4"), cpu("1")),
+				)},
+			},
+			Queues: []test_utils.TestQueueBasic{
+				{Name: "victim_queue", DeservedCPUs: test_utils.CreateFloat64Pointer(3000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12), ParentQueue: "d1"},
+				{Name: "reclaimer_queue", DeservedCPUs: test_utils.CreateFloat64Pointer(3000), DeservedMemory: test_utils.CreateFloat64Pointer(1e12), ParentQueue: "d1"},
+			},
+			Departments: []test_utils.TestDepartmentBasic{
+				{Name: "d1"},
+			},
+			JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+				"victim0":   {NodeName: "node0", Status: pod_status.Releasing},
+				"victim1":   {NodeName: "node0", Status: pod_status.Running, NUMAZones: []int{1}},
+				"reclaimer": {NodeName: "node0", Status: pod_status.Pipelined, NUMAZones: []int{0}},
+			},
+			ExpectedNodesResources: map[string]test_utils.TestExpectedNodesResources{
+				"node0": {NUMAZonesAvailable: map[int]map[v1.ResourceName]string{0: cpu("1"), 1: cpu("1")}},
+			},
+			Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds: 5, NumberOfCacheEvictions: 1, NumberOfPipelineActions: 1,
+			}},
+		},
+	}
+}

--- a/pkg/scheduler/api/node_info/numa_topology.go
+++ b/pkg/scheduler/api/node_info/numa_topology.go
@@ -78,6 +78,15 @@ func (t *NumaTopology) ZoneIndexByID(id string) (int, bool) {
 	return -1, false
 }
 
+// ZoneID returns the durable id of the zone at the given index, or false if out of range. Used to
+// translate the internal index representation to the persisted (id-based) placement at bind.
+func (t *NumaTopology) ZoneID(index int) (string, bool) {
+	if index < 0 || index >= len(t.Zones) {
+		return "", false
+	}
+	return t.Zones[index].ID, true
+}
+
 func (t *NumaTopology) Clone() *NumaTopology {
 	if t == nil {
 		return nil

--- a/pkg/scheduler/api/node_info/numa_topology_test.go
+++ b/pkg/scheduler/api/node_info/numa_topology_test.go
@@ -212,6 +212,26 @@ func TestNumaTopologyClone(t *testing.T) {
 	assert.Nil(t, (*NumaTopology)(nil).Clone())
 }
 
+func TestZoneIDIndexTranslation(t *testing.T) {
+	topo := &NumaTopology{Zones: []*NumaZone{{ID: "node-0"}, {ID: "node-1"}}}
+
+	idx, ok := topo.ZoneIndexByID("node-1")
+	assert.True(t, ok)
+	assert.Equal(t, 1, idx)
+
+	_, ok = topo.ZoneIndexByID("node-9")
+	assert.False(t, ok, "unknown id")
+
+	id, ok := topo.ZoneID(0)
+	assert.True(t, ok)
+	assert.Equal(t, "node-0", id)
+
+	_, ok = topo.ZoneID(5)
+	assert.False(t, ok, "index out of range")
+	_, ok = topo.ZoneID(-1)
+	assert.False(t, ok, "negative index")
+}
+
 func TestNumaNodeID(t *testing.T) {
 	tests := map[string]struct {
 		expectedID int

--- a/pkg/scheduler/api/pod_info/numa_placement.go
+++ b/pkg/scheduler/api/pod_info/numa_placement.go
@@ -11,7 +11,7 @@ import (
 // numa plugin's per-cycle nodeTopology.zones) and the exact per-resource amount
 // placed there. The index is the internal scheduler representation; translation
 // to/from the durable zone id happens only at the persistence boundary (BindRequest
-// field and pod annotation).
+// field and pod annotation), which the numa plugin owns.
 type ZonePlacement struct {
 	ZoneIndex int
 	Amount    v1.ResourceList

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -318,7 +318,7 @@ func (sc *SchedulerCache) WaitForWorkers(stopCh <-chan struct{}) {
 }
 
 // Bind binds task to the target host.
-func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
+func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, predictedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
 	startTime := time.Now()
 	defer metrics.UpdateTaskBindDuration(startTime)
 	sc.StatusUpdater.PreBind(taskInfo.Pod)
@@ -326,7 +326,7 @@ func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bind
 	log.InfraLogger.V(3).Infof(
 		"Creating bind request for task <%v/%v> to node <%v> gpuGroup: <%v>, requires: <%v> GPUs",
 		taskInfo.Namespace, taskInfo.Name, hostname, taskInfo.GPUGroups, taskInfo.ResReqVector)
-	if bindRequestError := sc.createBindRequest(taskInfo, hostname, bindRequestAnnotations, selectedNUMAZones); bindRequestError != nil {
+	if bindRequestError := sc.createBindRequest(taskInfo, hostname, bindRequestAnnotations, predictedNUMAZones); bindRequestError != nil {
 		return sc.StatusUpdater.Bound(taskInfo.Pod, hostname, bindRequestError, sc.getNodPoolName())
 	}
 
@@ -341,7 +341,7 @@ func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bind
 // +kubebuilder:rbac:groups="scheduling.run.ai",resources=bindrequests,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=pods/finalizers,verbs=create;delete;update;patch;get;list
 
-func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
+func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName string, bindRequestAnnotations map[string]string, predictedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
 	labels := map[string]string{
 		"selected-node": nodeName,
 	}
@@ -374,7 +374,7 @@ func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName 
 				Portion: fmt.Sprintf("%.2f", podInfo.AcceptedGpuRequirement.GpuFractionalPortion()),
 			},
 			ResourceClaimAllocations: podInfo.ResourceClaimInfo.ToSlice(),
-			SelectedNUMAZones:        selectedNUMAZones,
+			PredictedNUMAZones:       predictedNUMAZones,
 		},
 	}
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -318,7 +318,7 @@ func (sc *SchedulerCache) WaitForWorkers(stopCh <-chan struct{}) {
 }
 
 // Bind binds task to the target host.
-func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string) error {
+func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
 	startTime := time.Now()
 	defer metrics.UpdateTaskBindDuration(startTime)
 	sc.StatusUpdater.PreBind(taskInfo.Pod)
@@ -326,7 +326,7 @@ func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bind
 	log.InfraLogger.V(3).Infof(
 		"Creating bind request for task <%v/%v> to node <%v> gpuGroup: <%v>, requires: <%v> GPUs",
 		taskInfo.Namespace, taskInfo.Name, hostname, taskInfo.GPUGroups, taskInfo.ResReqVector)
-	if bindRequestError := sc.createBindRequest(taskInfo, hostname, bindRequestAnnotations); bindRequestError != nil {
+	if bindRequestError := sc.createBindRequest(taskInfo, hostname, bindRequestAnnotations, selectedNUMAZones); bindRequestError != nil {
 		return sc.StatusUpdater.Bound(taskInfo.Pod, hostname, bindRequestError, sc.getNodPoolName())
 	}
 
@@ -341,7 +341,7 @@ func (sc *SchedulerCache) Bind(taskInfo *pod_info.PodInfo, hostname string, bind
 // +kubebuilder:rbac:groups="scheduling.run.ai",resources=bindrequests,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=pods/finalizers,verbs=create;delete;update;patch;get;list
 
-func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName string, bindRequestAnnotations map[string]string) error {
+func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error {
 	labels := map[string]string{
 		"selected-node": nodeName,
 	}
@@ -374,6 +374,7 @@ func (sc *SchedulerCache) createBindRequest(podInfo *pod_info.PodInfo, nodeName 
 				Portion: fmt.Sprintf("%.2f", podInfo.AcceptedGpuRequirement.GpuFractionalPortion()),
 			},
 			ResourceClaimAllocations: podInfo.ResourceClaimInfo.ToSlice(),
+			SelectedNUMAZones:        selectedNUMAZones,
 		},
 	}
 

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -51,17 +51,17 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // Bind mocks base method.
-func (m *MockCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []v1alpha2.NUMAZonePlacement) error {
+func (m *MockCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, predictedNUMAZones []v1alpha2.NUMAZonePlacement) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bind", podInfo, hostname, bindRequestAnnotations, selectedNUMAZones)
+	ret := m.ctrl.Call(m, "Bind", podInfo, hostname, bindRequestAnnotations, predictedNUMAZones)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Bind indicates an expected call of Bind.
-func (mr *MockCacheMockRecorder) Bind(podInfo, hostname, bindRequestAnnotations, selectedNUMAZones any) *gomock.Call {
+func (mr *MockCacheMockRecorder) Bind(podInfo, hostname, bindRequestAnnotations, predictedNUMAZones any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bind", reflect.TypeOf((*MockCache)(nil).Bind), podInfo, hostname, bindRequestAnnotations, selectedNUMAZones)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bind", reflect.TypeOf((*MockCache)(nil).Bind), podInfo, hostname, bindRequestAnnotations, predictedNUMAZones)
 }
 
 // Evict mocks base method.

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -12,6 +12,7 @@ package cache
 import (
 	reflect "reflect"
 
+	v1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	api "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	eviction_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	pod_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -50,17 +51,17 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // Bind mocks base method.
-func (m *MockCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string) error {
+func (m *MockCache) Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []v1alpha2.NUMAZonePlacement) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bind", podInfo, hostname, bindRequestAnnotations)
+	ret := m.ctrl.Call(m, "Bind", podInfo, hostname, bindRequestAnnotations, selectedNUMAZones)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Bind indicates an expected call of Bind.
-func (mr *MockCacheMockRecorder) Bind(podInfo, hostname, bindRequestAnnotations any) *gomock.Call {
+func (mr *MockCacheMockRecorder) Bind(podInfo, hostname, bindRequestAnnotations, selectedNUMAZones any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bind", reflect.TypeOf((*MockCache)(nil).Bind), podInfo, hostname, bindRequestAnnotations)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bind", reflect.TypeOf((*MockCache)(nil).Bind), podInfo, hostname, bindRequestAnnotations, selectedNUMAZones)
 }
 
 // Evict mocks base method.

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -367,7 +367,7 @@ var _ = Describe("Cache", func() {
 
 				taskInfo := pod_info.NewTaskInfo(pod, resource_info.NewResourceVectorMap())
 
-				err := cache.Bind(taskInfo, "node-1", map[string]string{})
+				err := cache.Bind(taskInfo, "node-1", map[string]string{}, nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ksf "k8s.io/kube-scheduler/framework"
 
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -37,7 +38,7 @@ type Cache interface {
 	Run(stopCh <-chan struct{})
 	Snapshot() (*api.ClusterInfo, error)
 	WaitForCacheSync(stopCh <-chan struct{})
-	Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string) error
+	Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error
 	Evict(ssnPod *v1.Pod, job *podgroup_info.PodGroupInfo, evictionMetadata eviction_info.EvictionMetadata, message string) error
 	RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error
 	TaskPipelined(task *pod_info.PodInfo, message string)

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -38,7 +38,7 @@ type Cache interface {
 	Run(stopCh <-chan struct{})
 	Snapshot() (*api.ClusterInfo, error)
 	WaitForCacheSync(stopCh <-chan struct{})
-	Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, selectedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error
+	Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, predictedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error
 	Evict(ssnPod *v1.Pod, job *podgroup_info.PodGroupInfo, evictionMetadata eviction_info.EvictionMetadata, message string) error
 	RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error
 	TaskPipelined(task *pod_info.PodInfo, message string)

--- a/pkg/scheduler/framework/bind_numa.go
+++ b/pkg/scheduler/framework/bind_numa.go
@@ -10,10 +10,8 @@ import (
 )
 
 // numaPlacementToZones translates a task's internal, index-based NUMAPlacement into the durable,
-// zone-id-based form carried on the BindRequest. This is the persistence boundary for the write
-// direction: the scheduler reasons in zone indices in-cycle, and only here — where the per-cycle
-// node topology that defines the index↔id mapping is in scope — does it resolve indices to the
-// stable NUMA-node zone ids. Returns nil when the task has no placement or the node has no topology.
+// zone-id-based form carried on the BindRequest. The order of Zones in the NRT CRD is not guaranteed.
+// Returns nil when the task has no placement or the node has no topology.
 func numaPlacementToZones(pod *pod_info.PodInfo, node *node_info.NodeInfo) []schedulingv1alpha2.NUMAZonePlacement {
 	if pod == nil || len(pod.NUMAPlacement) == 0 || node == nil || node.NumaTopology == nil {
 		return nil

--- a/pkg/scheduler/framework/bind_numa.go
+++ b/pkg/scheduler/framework/bind_numa.go
@@ -7,6 +7,7 @@ import (
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
 // numaPlacementToZones translates a task's internal, index-based NUMAPlacement into the durable,
@@ -21,6 +22,7 @@ func numaPlacementToZones(pod *pod_info.PodInfo, node *node_info.NodeInfo) []sch
 	for _, placement := range pod.NUMAPlacement {
 		id, ok := node.NumaTopology.ZoneID(placement.ZoneIndex)
 		if !ok {
+			log.InfraLogger.Errorf("Failed to get zone ID for placement %v for pod %s on node %s", placement, pod.Name, node.Name)
 			continue
 		}
 		zones = append(zones, schedulingv1alpha2.NUMAZonePlacement{Zone: id, Amount: placement.Amount})

--- a/pkg/scheduler/framework/bind_numa.go
+++ b/pkg/scheduler/framework/bind_numa.go
@@ -1,0 +1,31 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+)
+
+// numaPlacementToZones translates a task's internal, index-based NUMAPlacement into the durable,
+// zone-id-based form carried on the BindRequest. This is the persistence boundary for the write
+// direction: the scheduler reasons in zone indices in-cycle, and only here — where the per-cycle
+// node topology that defines the index↔id mapping is in scope — does it resolve indices to the
+// stable NUMA-node zone ids. Returns nil when the task has no placement or the node has no topology.
+func numaPlacementToZones(pod *pod_info.PodInfo, node *node_info.NodeInfo) []schedulingv1alpha2.NUMAZonePlacement {
+	if pod == nil || len(pod.NUMAPlacement) == 0 || node == nil || node.NumaTopology == nil {
+		return nil
+	}
+
+	zones := make([]schedulingv1alpha2.NUMAZonePlacement, 0, len(pod.NUMAPlacement))
+	for _, placement := range pod.NUMAPlacement {
+		id, ok := node.NumaTopology.ZoneID(placement.ZoneIndex)
+		if !ok {
+			continue
+		}
+		zones = append(zones, schedulingv1alpha2.NUMAZonePlacement{Zone: id, Amount: placement.Amount})
+	}
+	return zones
+}

--- a/pkg/scheduler/framework/bind_numa_test.go
+++ b/pkg/scheduler/framework/bind_numa_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+)
+
+func TestNumaPlacementToZones(t *testing.T) {
+	node := &node_info.NodeInfo{
+		Name: "node-a",
+		NumaTopology: &node_info.NumaTopology{
+			Zones: []*node_info.NumaZone{{ID: "node-0"}, {ID: "node-1"}},
+		},
+	}
+	pod := &pod_info.PodInfo{
+		NUMAPlacement: pod_info.NUMAPlacement{
+			{ZoneIndex: 1, Amount: v1.ResourceList{"cpu": resource.MustParse("3")}},
+		},
+	}
+
+	t.Run("translates index to durable zone id", func(t *testing.T) {
+		zones := numaPlacementToZones(pod, node)
+		assert.Len(t, zones, 1)
+		assert.Equal(t, "node-1", zones[0].Zone)
+		cpu := zones[0].Amount["cpu"]
+		assert.Equal(t, int64(3), cpu.Value())
+	})
+
+	t.Run("nil when task has no placement", func(t *testing.T) {
+		assert.Nil(t, numaPlacementToZones(&pod_info.PodInfo{}, node))
+	})
+
+	t.Run("nil when node has no topology", func(t *testing.T) {
+		assert.Nil(t, numaPlacementToZones(pod, &node_info.NodeInfo{Name: "bare"}))
+	})
+
+	t.Run("out-of-range index is skipped", func(t *testing.T) {
+		bad := &pod_info.PodInfo{NUMAPlacement: pod_info.NUMAPlacement{{ZoneIndex: 5}}}
+		assert.Empty(t, numaPlacementToZones(bad, node))
+	})
+}

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -132,7 +132,8 @@ func (ssn *Session) GetNodes() []ksf.NodeInfo {
 
 func (ssn *Session) BindPod(pod *pod_info.PodInfo) error {
 	bindRequestAnnotations := ssn.MutateBindRequestAnnotations(pod, pod.NodeName)
-	if err := ssn.Cache.Bind(pod, pod.NodeName, bindRequestAnnotations); err != nil {
+	selectedNUMAZones := numaPlacementToZones(pod, ssn.ClusterInfo.Nodes[pod.NodeName])
+	if err := ssn.Cache.Bind(pod, pod.NodeName, bindRequestAnnotations, selectedNUMAZones); err != nil {
 		return err
 	}
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -132,8 +132,8 @@ func (ssn *Session) GetNodes() []ksf.NodeInfo {
 
 func (ssn *Session) BindPod(pod *pod_info.PodInfo) error {
 	bindRequestAnnotations := ssn.MutateBindRequestAnnotations(pod, pod.NodeName)
-	selectedNUMAZones := numaPlacementToZones(pod, ssn.ClusterInfo.Nodes[pod.NodeName])
-	if err := ssn.Cache.Bind(pod, pod.NodeName, bindRequestAnnotations, selectedNUMAZones); err != nil {
+	predictedNUMAZones := numaPlacementToZones(pod, ssn.ClusterInfo.Nodes[pod.NodeName])
+	if err := ssn.Cache.Bind(pod, pod.NodeName, bindRequestAnnotations, predictedNUMAZones); err != nil {
 		return err
 	}
 

--- a/pkg/scheduler/plugins/numa/consolidation_discard_test.go
+++ b/pkg/scheduler/plugins/numa/consolidation_discard_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
 
-// scenarioFixture wires up the debug-preempt scenario: one node, two NUMA single-numa-node zones
+// These tests verify bookkeeping and rollback/discard correctness in complicated simulations.
+
+// scenarioFixture wires up the following scenario: one node, two NUMA single-numa-node zones
 // (4 cpu allocatable, 1 cpu available — each already holds a 3-cpu Guaranteed victim), and one
 // pending 3-cpu Guaranteed preemptor that fits neither zone until a victim is evicted.
 type scenarioFixture struct {
@@ -100,11 +102,7 @@ func (f *scenarioFixture) zone(i int) int64 {
 	return q.Value()
 }
 
-// runScenario replays by_pod_solver.solve's core through the real common-action functions:
-// EvictAllPreemptees evicts both victims, then AllocateJob pipelines the preemptor and
-// re-pipelines the victim jobs — each routing through FittingNode + allocateTaskToNode (the
-// NUMA stamp) + statement.Pipeline (the eviction dedup). It stops short of unwinding so the
-// caller can choose Discard vs Rollback+Discard.
+// runScenario simulates the scenario by evicting the victims and allocating the preemptor.
 func (f *scenarioFixture) runScenario(t *testing.T) {
 	t.Helper()
 	require.NoError(t, common.EvictAllPreemptees(f.ssn, f.allVictims, f.preemptorJob, f.stmt, framework.Preempt))
@@ -126,20 +124,8 @@ func (f *scenarioFixture) runScenario(t *testing.T) {
 	require.Equal(t, []int{1}, f.victim0.NUMAPlacement.ZoneIndices(), "victim0 re-homes to the free zone 1, not its stale zone 0")
 }
 
-// TestConsolidationDiscardRestoresLedger guards against a post-Discard negative NUMA ledger,
-// reproduced through the real solver allocation path. (Before the fix it left zone 0 at -2.)
-//
-// Scenario (debug-preempt-like): one node, two single-numa-node zones (4 cpu allocatable each).
-// Two running 3-cpu Guaranteed victims, one per zone (so each zone has 1 cpu available). One
-// pending 3-cpu Guaranteed preemptor. by_pod_solver.solve evicts both victims (crediting both
-// zones to 4), pipelines the preemptor onto zone 0 (charging it to 1), then re-pipelines the
-// victims: victim0 re-homes to zone 1, victim1 fails to fit.
-//
-// On unwind, statement.unpipeline restores task.NodeName to its pre-pipeline value *before*
-// firing DeallocateFunc. For the preemptor that pre-pipeline NodeName is "" (it was pending), so
-// the numa plugin's deallocate looks up ssn.Nodes[""], finds nil, and silently drops the credit —
-// the forward zone-0 charge of the preemptor is never reversed. Undoing victim0's evict then
-// re-charges its original zone-0 placement, driving zone 0's available cpu negative.
+// TestConsolidationDiscardRestoresLedger validates NUMA resource correctness after discard/rollback, verifying
+// that the resources are restored correctly.
 func TestConsolidationDiscardRestoresLedger(t *testing.T) {
 	t.Run("Discard", func(t *testing.T) {
 		f := newScenarioFixture(t)

--- a/pkg/scheduler/plugins/numa/consolidation_discard_test.go
+++ b/pkg/scheduler/plugins/numa/consolidation_discard_test.go
@@ -75,8 +75,10 @@ func newScenarioFixture(t *testing.T) *scenarioFixture {
 	for _, task := range []*pod_info.PodInfo{victim0, victim1, preemptor} {
 		task.Pod.Status.QOSClass = v1.PodQOSGuaranteed
 	}
-	victim0.NUMAPlacement = cpuPlacement(0, "3")
-	victim1.NUMAPlacement = cpuPlacement(1, "3")
+	// Victims carry observed placement records: OnSessionOpen seeds each task's NUMAPlacement from
+	// them and reconstructs zone Available (4 allocatable - 3 observed = 1 per zone).
+	setObservedPlacement(victim0, "node-0", "3")
+	setObservedPlacement(victim1, "node-1", "3")
 
 	ssn := &framework.Session{
 		ClusterInfo: &schedapi.ClusterInfo{PodGroupInfos: jobsInfoMap, Nodes: nodesInfoMap},

--- a/pkg/scheduler/plugins/numa/consolidation_discard_test.go
+++ b/pkg/scheduler/plugins/numa/consolidation_discard_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common"
+	schedapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/numa"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+// scenarioFixture wires up the debug-preempt scenario: one node, two NUMA single-numa-node zones
+// (4 cpu allocatable, 1 cpu available — each already holds a 3-cpu Guaranteed victim), and one
+// pending 3-cpu Guaranteed preemptor that fits neither zone until a victim is evicted.
+type scenarioFixture struct {
+	ssn          *framework.Session
+	stmt         *framework.Statement
+	node         *node_info.NodeInfo
+	preemptorJob *podgroup_info.PodGroupInfo
+	victim0      *pod_info.PodInfo
+	victim1      *pod_info.PodInfo
+	preemptor    *pod_info.PodInfo
+	allVictims   []*pod_info.PodInfo
+	nodes        []*node_info.NodeInfo
+}
+
+func newScenarioFixture(t *testing.T) *scenarioFixture {
+	t.Helper()
+	vectorMap := resource_info.NewResourceVectorMap()
+
+	jobs := []*jobs_fake.TestJobBasic{
+		{Name: "victim0", QueueName: "q", RequiredCPUsPerTask: 3,
+			Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Running, NodeName: "node0"}}},
+		{Name: "victim1", QueueName: "q", RequiredCPUsPerTask: 3,
+			Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Running, NodeName: "node0"}}},
+		{Name: "preemptor", QueueName: "q", RequiredCPUsPerTask: 3,
+			Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}}},
+	}
+	jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(jobs, vectorMap)
+	nodesInfoMap := nodes_fake.BuildNodesInfoMap(
+		map[string]nodes_fake.TestNodeBasic{"node0": {CPUMillis: 16000, CPUMemory: 16e9}},
+		tasksToNodeMap, nil, vectorMap)
+	node := nodesInfoMap["node0"]
+
+	node.NumaTopology = &node_info.NumaTopology{
+		Policy:    node_info.TopologyPolicySingleNUMANode,
+		Scope:     node_info.TopologyScopePod,
+		Zones:     []*node_info.NumaZone{cpuZone("node-0", "4", "1"), cpuZone("node-1", "4", "1")},
+		Resources: sets.New[v1.ResourceName]("cpu"),
+	}
+
+	victim0 := singleTask(jobsInfoMap["victim0"])
+	victim1 := singleTask(jobsInfoMap["victim1"])
+	preemptor := singleTask(jobsInfoMap["preemptor"])
+
+	// The plugin handles Guaranteed pods; the fakes build Burstable pods, so mark QoS explicitly.
+	for _, task := range []*pod_info.PodInfo{victim0, victim1, preemptor} {
+		task.Pod.Status.QOSClass = v1.PodQOSGuaranteed
+	}
+	victim0.NUMAPlacement = cpuPlacement(0, "3")
+	victim1.NUMAPlacement = cpuPlacement(1, "3")
+
+	ssn := &framework.Session{
+		ClusterInfo: &schedapi.ClusterInfo{PodGroupInfos: jobsInfoMap, Nodes: nodesInfoMap},
+	}
+	require.NoError(t, ssn.InitNodeScoringPool()) // OrderedNodesByTask needs the scoring pool
+	numa.New(framework.PluginArguments{}).OnSessionOpen(ssn)
+
+	return &scenarioFixture{
+		ssn:          ssn,
+		stmt:         ssn.Statement(),
+		node:         node,
+		preemptorJob: jobsInfoMap["preemptor"],
+		victim0:      victim0,
+		victim1:      victim1,
+		preemptor:    preemptor,
+		allVictims:   []*pod_info.PodInfo{victim0, victim1},
+		nodes:        []*node_info.NodeInfo{node},
+	}
+}
+
+func (f *scenarioFixture) zone(i int) int64 {
+	q := f.node.NumaTopology.Zones[i].Available["cpu"]
+	return q.Value()
+}
+
+// runScenario replays by_pod_solver.solve's core through the real common-action functions:
+// EvictAllPreemptees evicts both victims, then AllocateJob pipelines the preemptor and
+// re-pipelines the victim jobs — each routing through FittingNode + allocateTaskToNode (the
+// NUMA stamp) + statement.Pipeline (the eviction dedup). It stops short of unwinding so the
+// caller can choose Discard vs Rollback+Discard.
+func (f *scenarioFixture) runScenario(t *testing.T) {
+	t.Helper()
+	require.NoError(t, common.EvictAllPreemptees(f.ssn, f.allVictims, f.preemptorJob, f.stmt, framework.Preempt))
+	require.Equal(t, int64(4), f.zone(0), "evicting both victims frees zone 0")
+	require.Equal(t, int64(4), f.zone(1), "evicting both victims frees zone 1")
+
+	require.True(t, common.AllocateJob(f.ssn, f.stmt, f.nodes, f.preemptorJob, true), "preemptor pipelines onto freed zone 0")
+	// Re-pipeline the evicted victim jobs. victim0 re-homes to the now-only-free zone 1;
+	// victim1 cannot fit and stays evicted — this asymmetry is what the simple hand-trace misses.
+	common.AllocateJob(f.ssn, f.stmt, f.nodes, f.ssn.ClusterInfo.PodGroupInfos["victim0"], true)
+	common.AllocateJob(f.ssn, f.stmt, f.nodes, f.ssn.ClusterInfo.PodGroupInfos["victim1"], true)
+
+	// Mid-scenario (before any unwind): the real allocateTaskToNode stamp must have re-homed
+	// victim0 to the free zone 1 so the dedup did NOT restore+recharge its stale zone-0 placement
+	// onto the preemptor's zone. Otherwise the zone is over-committed and the solver would treat an
+	// infeasible scenario as feasible.
+	require.GreaterOrEqual(t, f.zone(0), int64(0), "zone 0 over-committed mid-scenario (victim re-charged the preemptor's zone)")
+	require.GreaterOrEqual(t, f.zone(1), int64(0), "zone 1 over-committed mid-scenario")
+	require.Equal(t, []int{1}, f.victim0.NUMAPlacement.ZoneIndices(), "victim0 re-homes to the free zone 1, not its stale zone 0")
+}
+
+// TestConsolidationDiscardRestoresLedger guards against a post-Discard negative NUMA ledger,
+// reproduced through the real solver allocation path. (Before the fix it left zone 0 at -2.)
+//
+// Scenario (debug-preempt-like): one node, two single-numa-node zones (4 cpu allocatable each).
+// Two running 3-cpu Guaranteed victims, one per zone (so each zone has 1 cpu available). One
+// pending 3-cpu Guaranteed preemptor. by_pod_solver.solve evicts both victims (crediting both
+// zones to 4), pipelines the preemptor onto zone 0 (charging it to 1), then re-pipelines the
+// victims: victim0 re-homes to zone 1, victim1 fails to fit.
+//
+// On unwind, statement.unpipeline restores task.NodeName to its pre-pipeline value *before*
+// firing DeallocateFunc. For the preemptor that pre-pipeline NodeName is "" (it was pending), so
+// the numa plugin's deallocate looks up ssn.Nodes[""], finds nil, and silently drops the credit —
+// the forward zone-0 charge of the preemptor is never reversed. Undoing victim0's evict then
+// re-charges its original zone-0 placement, driving zone 0's available cpu negative.
+func TestConsolidationDiscardRestoresLedger(t *testing.T) {
+	t.Run("Discard", func(t *testing.T) {
+		f := newScenarioFixture(t)
+		before0, before1 := f.zone(0), f.zone(1)
+
+		f.runScenario(t)
+		f.stmt.Discard() // matches by_pod_solver.handleScenarioSolution's reject path
+
+		assert.Equal(t, before0, f.zone(0), "zone 0 Available after Discard must equal pre-scenario value")
+		assert.Equal(t, before1, f.zone(1), "zone 1 Available after Discard must equal pre-scenario value")
+	})
+
+	t.Run("RollbackThenDiscard", func(t *testing.T) {
+		f := newScenarioFixture(t)
+		before0, before1 := f.zone(0), f.zone(1)
+		checkpoint := f.stmt.Checkpoint()
+
+		f.runScenario(t)
+		require.NoError(t, f.stmt.Rollback(checkpoint)) // matches by_pod_solver.solve's no-solution path
+		f.stmt.Discard()
+
+		assert.Equal(t, before0, f.zone(0), "zone 0 Available after Rollback+Discard must equal pre-scenario value")
+		assert.Equal(t, before1, f.zone(1), "zone 1 Available after Rollback+Discard must equal pre-scenario value")
+	})
+}

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -80,9 +80,18 @@ func (pp *numaPlugin) evaluate(task *pod_info.PodInfo, node *node_info.NodeInfo)
 		return nil, true
 	}
 	topo := node.NumaTopology
-	placement, admit := evaluatorFor(topo.Policy).evaluate(topo, pp.ignoreList, requestUnits(task, topo.Scope))
+	eval := evaluatorFor(topo.Policy)
+	concurrent, serial := requestUnits(task, topo.Scope)
+	placement, admit := eval.evaluate(topo, pp.ignoreList, concurrent)
 	if !admit {
 		return nil, false
+	}
+	// Ordinary init containers run serially before the app containers and free their resources
+	// first, so each must be alignable on its own but is not accumulated into the placement.
+	for _, unit := range serial {
+		if _, ok := eval.evaluate(topo, pp.ignoreList, []resourceAmounts{unit}); !ok {
+			return nil, false
+		}
 	}
 	return placement, true
 }

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -89,7 +89,7 @@ func (pp *numaPlugin) evaluate(task *pod_info.PodInfo, node *node_info.NodeInfo)
 	// Ordinary init containers run serially before the app containers and free their resources
 	// first, so each must be alignable on its own but is not accumulated into the placement.
 	for _, unit := range serial {
-		if _, ok := eval.evaluate(topo, pp.ignoreList, []resourceAmounts{unit}); !ok {
+		if _, ok := eval.evaluate(topo, pp.ignoreList, []v1.ResourceList{unit}); !ok {
 			return nil, false
 		}
 	}

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -206,22 +206,70 @@ func TestRequestUnits(t *testing.T) {
 	}}}
 
 	t.Run("pod scope aggregates into one unit", func(t *testing.T) {
-		units := requestUnits(task, node_info.TopologyScopePod)
-		assert.Len(t, units, 1)
+		concurrent, serial := requestUnits(task, node_info.TopologyScopePod)
+		assert.Len(t, concurrent, 1)
+		assert.Empty(t, serial, "pod scope folds init containers into the effective pod request")
 		// PodRequests = max(init peak 10, sidecar+regulars 1+2+2=5) = 10.
-		got := units[0]["cpu"]
+		got := concurrent[0]["cpu"]
 		assert.Equal(t, int64(10), got.Value())
 	})
 
-	t.Run("container scope yields one unit per concurrent container", func(t *testing.T) {
-		units := requestUnits(task, node_info.TopologyScopeContainer)
-		assert.Len(t, units, 3, "native sidecar + two regular containers (ordinary init excluded)")
+	t.Run("container scope splits concurrent and serial units", func(t *testing.T) {
+		concurrent, serial := requestUnits(task, node_info.TopologyScopeContainer)
+		assert.Len(t, concurrent, 3, "native sidecar + two regular containers")
 		var total int64
-		for _, u := range units {
+		for _, u := range concurrent {
 			q := u["cpu"]
 			total += q.Value()
 		}
 		assert.Equal(t, int64(5), total, "1 (sidecar) + 2 + 2")
+
+		assert.Len(t, serial, 1, "the ordinary init container is a serial unit")
+		initCPU := serial[0]["cpu"]
+		assert.Equal(t, int64(10), initCPU.Value())
+	})
+}
+
+// TestPredicateOrdinaryInitContainer verifies an ordinary init container is checked for
+// alignability on its own (rejected if it cannot fit a zone) but is not accumulated into the
+// concurrent app containers' headroom.
+func TestPredicateOrdinaryInitContainer(t *testing.T) {
+	always := v1.ContainerRestartPolicyAlways
+	cpu := func(q string) v1.ResourceRequirements {
+		return v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse(q)}}
+	}
+	build := func(initCPU string, restartable bool) *pod_info.PodInfo {
+		init := v1.Container{Resources: cpu(initCPU)}
+		if restartable {
+			init.RestartPolicy = &always
+		}
+		return &pod_info.PodInfo{Pod: &v1.Pod{
+			Status: v1.PodStatus{QOSClass: v1.PodQOSGuaranteed},
+			Spec: v1.PodSpec{
+				InitContainers: []v1.Container{init},
+				Containers:     []v1.Container{{Resources: cpu("2")}},
+			},
+		}}
+	}
+
+	t.Run("ordinary init within a zone is admitted, not accumulated", func(t *testing.T) {
+		pp, _, node := wiredPlugin(singleNUMANodeTopology(node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{"cpu": "4"}),
+			numaZone("node-1", map[string]string{"cpu": "4"}),
+		))
+		// init wants 4 (fits a 4-CPU zone alone); app wants 2. If init were accumulated with the
+		// app container, the two together (6) would not fit a single zone — admission proves it isn't.
+		_, admit := pp.evaluate(build("4", false), node)
+		assert.True(t, admit)
+	})
+
+	t.Run("ordinary init larger than any zone is rejected", func(t *testing.T) {
+		pp, _, node := wiredPlugin(singleNUMANodeTopology(node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{"cpu": "4"}),
+			numaZone("node-1", map[string]string{"cpu": "4"}),
+		))
+		_, admit := pp.evaluate(build("5", false), node)
+		assert.False(t, admit, "an init container that fits no single zone cannot be NUMA-aligned")
 	})
 }
 

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -450,7 +450,7 @@ func TestSeedObservedPlacements(t *testing.T) {
 			bindrequest_info.NewKeyFromPod(fromBindRequest.Pod): &bindrequest_info.BindRequestInfo{
 				BindRequest: &schedulingv1alpha2.BindRequest{
 					Spec: schedulingv1alpha2.BindRequestSpec{
-						SelectedNUMAZones: []schedulingv1alpha2.NUMAZonePlacement{observedZone("node-0", "2")},
+						PredictedNUMAZones: []schedulingv1alpha2.NUMAZonePlacement{observedZone("node-0", "2")},
 					},
 				},
 			},

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -15,6 +15,7 @@ import (
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	schedapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/bindrequest_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -308,23 +309,72 @@ func TestPlacementFromObserved(t *testing.T) {
 	})
 }
 
+// TestResolvePlacementRecord covers the precedence the plugin applies when reconstructing a pod's
+// durable placement: observed annotation > BindRequest zones > predicted annotation > nil.
+func TestResolvePlacementRecord(t *testing.T) {
+	observed := []schedulingv1alpha2.NUMAZonePlacement{observedZone("node-0", "1")}
+	predicted := []schedulingv1alpha2.NUMAZonePlacement{observedZone("node-1", "2")}
+	bindReq := []schedulingv1alpha2.NUMAZonePlacement{observedZone("node-2", "3")}
+
+	podWith := func(ann map[string]string) *v1.Pod {
+		pod := &v1.Pod{}
+		pod.Annotations = ann
+		return pod
+	}
+
+	t.Run("observed annotation wins over everything", func(t *testing.T) {
+		pod := podWith(map[string]string{
+			commonconstants.NumaPlacementObserved:  observedAnnotation(observed...),
+			commonconstants.NumaPlacementPredicted: observedAnnotation(predicted...),
+		})
+		assert.Equal(t, "node-0", resolvePlacementRecord(pod, bindReq)[0].Zone)
+	})
+
+	t.Run("BindRequest beats predicted annotation when no observed", func(t *testing.T) {
+		pod := podWith(map[string]string{commonconstants.NumaPlacementPredicted: observedAnnotation(predicted...)})
+		assert.Equal(t, "node-2", resolvePlacementRecord(pod, bindReq)[0].Zone, "BindRequest is the freshest prediction")
+	})
+
+	t.Run("predicted annotation used when no observed and no BindRequest", func(t *testing.T) {
+		pod := podWith(map[string]string{commonconstants.NumaPlacementPredicted: observedAnnotation(predicted...)})
+		assert.Equal(t, "node-1", resolvePlacementRecord(pod, nil)[0].Zone)
+	})
+
+	t.Run("none present yields nil", func(t *testing.T) {
+		assert.Nil(t, resolvePlacementRecord(podWith(nil), nil))
+	})
+
+	t.Run("malformed observed is ignored, falls through to predicted", func(t *testing.T) {
+		pod := podWith(map[string]string{
+			commonconstants.NumaPlacementObserved:  "{not json",
+			commonconstants.NumaPlacementPredicted: observedAnnotation(predicted...),
+		})
+		assert.Equal(t, "node-1", resolvePlacementRecord(pod, nil)[0].Zone, "malformed observed ignored, predicted used")
+	})
+}
+
 func TestSeedObservedPlacements(t *testing.T) {
 	topo := singleNUMANodeTopology(node_info.TopologyScopePod,
 		numaZone("node-0", map[string]string{"cpu": "4"}),
 		numaZone("node-1", map[string]string{"cpu": "4"}),
 	)
 
+	// Seeded from the observed annotation.
 	withObserved := gPod("observed", map[string]string{"cpu": "2"})
 	withObserved.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
+
+	// Seeded from the BindRequest (no annotation), read via the session's clone-independent map.
+	fromBindRequest := gPod("from-bind-request", map[string]string{"cpu": "2"})
+	fromBindRequest.Pod.Namespace, fromBindRequest.Pod.Name = "ns", "from-bind-request"
 
 	alreadyPlaced := gPod("already", map[string]string{"cpu": "2"})
 	alreadyPlaced.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
 	alreadyPlaced.NUMAPlacement = pod_info.NUMAPlacement{{ZoneIndex: 0, Amount: v1.ResourceList{"cpu": resource.MustParse("2")}}}
 
-	noAnnotation := gPod("none", map[string]string{"cpu": "2"})
+	noRecord := gPod("none", map[string]string{"cpu": "2"})
 
-	malformed := gPod("malformed", map[string]string{"cpu": "2"})
-	malformed.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: "{not json"}
+	unknownZone := gPod("unknown-zone", map[string]string{"cpu": "2"})
+	unknownZone.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-9", "2"))}
 
 	burstable := gPod("burstable", map[string]string{"cpu": "2"})
 	burstable.Pod.Status.QOSClass = v1.PodQOSBurstable
@@ -342,21 +392,31 @@ func TestSeedObservedPlacements(t *testing.T) {
 		NumaTopology: topo,
 		PodInfos:     map[common_info.PodID]*pod_info.PodInfo{withObserved.UID: nodeCopy},
 	}
-	job := podgroup_info.NewPodGroupInfo("job", withObserved, alreadyPlaced, noAnnotation, malformed, burstable, pending)
+	job := podgroup_info.NewPodGroupInfo("job", withObserved, fromBindRequest, alreadyPlaced, noRecord, unknownZone, burstable, pending)
 
 	pp := &numaPlugin{ignoreList: sets.New[v1.ResourceName]()}
 	ssn := &framework.Session{ClusterInfo: &schedapi.ClusterInfo{
 		Nodes:         map[string]*node_info.NodeInfo{"node-a": node},
 		PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{"job": job},
+		BindRequests: bindrequest_info.BindRequestMap{
+			bindrequest_info.NewKeyFromPod(fromBindRequest.Pod): &bindrequest_info.BindRequestInfo{
+				BindRequest: &schedulingv1alpha2.BindRequest{
+					Spec: schedulingv1alpha2.BindRequestSpec{
+						SelectedNUMAZones: []schedulingv1alpha2.NUMAZonePlacement{observedZone("node-0", "2")},
+					},
+				},
+			},
+		},
 	}}
 
 	pp.seedPlacements(ssn)
 
 	assert.Equal(t, []int{1}, withObserved.NUMAPlacement.ZoneIndices(), "observed annotation translated onto the canonical job task")
+	assert.Equal(t, []int{0}, fromBindRequest.NUMAPlacement.ZoneIndices(), "BindRequest zones seeded when no annotation")
 	assert.Empty(t, nodeCopy.NUMAPlacement, "the node's clone is not the seed target (job task is)")
 	assert.Equal(t, []int{0}, alreadyPlaced.NUMAPlacement.ZoneIndices(), "existing placement not overwritten")
-	assert.Empty(t, noAnnotation.NUMAPlacement, "no annotation ⇒ unaccounted")
-	assert.Empty(t, malformed.NUMAPlacement, "malformed annotation ⇒ unaccounted")
+	assert.Empty(t, noRecord.NUMAPlacement, "no record ⇒ unaccounted")
+	assert.Empty(t, unknownZone.NUMAPlacement, "record naming an unknown zone ⇒ unaccounted")
 	assert.Empty(t, burstable.NUMAPlacement, "non-Guaranteed pod is not seeded")
 	assert.Empty(t, pending.NUMAPlacement, "pending pod (no node assigned) is not seeded")
 }

--- a/pkg/scheduler/plugins/numa/reclaim_repipeline_test.go
+++ b/pkg/scheduler/plugins/numa/reclaim_repipeline_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	schedapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/numa"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+func cpuZone(id, allocatable, available string) *node_info.NumaZone {
+	return &node_info.NumaZone{
+		ID:          id,
+		Allocatable: map[v1.ResourceName]resource.Quantity{"cpu": resource.MustParse(allocatable)},
+		Available:   map[v1.ResourceName]resource.Quantity{"cpu": resource.MustParse(available)},
+	}
+}
+
+func singleTask(job *podgroup_info.PodGroupInfo) *pod_info.PodInfo {
+	for _, task := range job.GetAllPodsMap() {
+		return task
+	}
+	return nil
+}
+
+func cpuPlacement(zoneIndex int, cpu string) pod_info.NUMAPlacement {
+	return pod_info.NUMAPlacement{{ZoneIndex: zoneIndex, Amount: v1.ResourceList{"cpu": resource.MustParse(cpu)}}}
+}
+
+// TestReclaimRepipelineDoesNotGoNegative reproduces the preemption bookkeeping bug through the real
+// statement flow (Evict → Pipeline → dedup/Unevict), so candidate fixes are judged against the
+// actual code path rather than a hand-simulated one.
+//
+// One node, two NUMA zones (4 cpu allocatable each), single-numa-node. Two running victims use 3
+// cpu each — one per zone — so the in-cycle availability is 1 cpu per zone, and each victim's
+// observed placement is seeded. A preemptor needs 3 cpu; it fits neither zone (1 < 3), so reclaim
+// evicts the victims to free a zone.
+//
+// The solver evicts BOTH victims (crediting both zones to 4), pipelines the preemptor onto the
+// freed zone 0 (charging it to 1), then re-pipelines a victim. The re-pipelined victim still
+// carries its stale zone-0 placement, and because the plugin evaluates lazily inside AllocateFunc
+// (after the dedup), the numaPlacementChanged gate sees stale-vs-stale and lets the dedup fire:
+// Unevict restores the zone-0 placement and re-charges zone 0, driving its available cpu negative.
+func TestReclaimRepipelineDoesNotGoNegative(t *testing.T) {
+	vectorMap := resource_info.NewResourceVectorMap()
+
+	jobs := []*jobs_fake.TestJobBasic{
+		{Name: "victim0", QueueName: "q", RequiredCPUsPerTask: 3,
+			Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Running, NodeName: "node0"}}},
+		{Name: "victim1", QueueName: "q", RequiredCPUsPerTask: 3,
+			Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Running, NodeName: "node0"}}},
+		{Name: "preemptor", QueueName: "q", RequiredCPUsPerTask: 3,
+			Tasks: []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}}},
+	}
+	jobsInfoMap, tasksToNodeMap, _ := jobs_fake.BuildJobsAndTasksMaps(jobs, vectorMap)
+	nodesInfoMap := nodes_fake.BuildNodesInfoMap(
+		map[string]nodes_fake.TestNodeBasic{"node0": {CPUMillis: 16000, CPUMemory: 16000}},
+		tasksToNodeMap, nil, vectorMap)
+	node := nodesInfoMap["node0"]
+
+	node.NumaTopology = &node_info.NumaTopology{
+		Policy:    node_info.TopologyPolicySingleNUMANode,
+		Scope:     node_info.TopologyScopePod,
+		Zones:     []*node_info.NumaZone{cpuZone("node-0", "4", "1"), cpuZone("node-1", "4", "1")},
+		Resources: sets.New[v1.ResourceName]("cpu"),
+	}
+
+	victim0 := singleTask(jobsInfoMap["victim0"])
+	victim1 := singleTask(jobsInfoMap["victim1"])
+	preemptor := singleTask(jobsInfoMap["preemptor"])
+
+	// The plugin handles Guaranteed pods; the fakes build Burstable pods, so mark QoS explicitly.
+	for _, task := range []*pod_info.PodInfo{victim0, victim1, preemptor} {
+		task.Pod.Status.QOSClass = v1.PodQOSGuaranteed
+	}
+	victim0.NUMAPlacement = cpuPlacement(0, "3")
+	victim1.NUMAPlacement = cpuPlacement(1, "3")
+
+	ssn := &framework.Session{
+		ClusterInfo: &schedapi.ClusterInfo{PodGroupInfos: jobsInfoMap, Nodes: nodesInfoMap},
+	}
+	numa.New(framework.PluginArguments{}).OnSessionOpen(ssn) // registers the charge/credit EventHandler
+
+	zone := func(i int) int64 { q := node.NumaTopology.Zones[i].Available["cpu"]; return q.Value() }
+	stmt := ssn.Statement()
+
+	// pipeline mirrors allocateTaskToNode: the allocation path stamps the task's NUMA placement for
+	// the chosen node (via the NumaPlacementFn) before the statement op, then pipelines.
+	pipeline := func(task *pod_info.PodInfo) error {
+		task.NUMAPlacement = ssn.GetNumaPlacement(task, node)
+		return stmt.Pipeline(task, "node0", false)
+	}
+
+	// Evict both victims → credits both zones back to full.
+	require.NoError(t, stmt.Evict(victim0, "reclaim", eviction_info.EvictionMetadata{}))
+	require.NoError(t, stmt.Evict(victim1, "reclaim", eviction_info.EvictionMetadata{}))
+	assert.Equal(t, int64(4), zone(0), "evicting the victims frees zone 0")
+
+	// Pipeline the preemptor → fresh evaluate picks the freed zone 0 and charges it.
+	require.NoError(t, pipeline(preemptor))
+	assert.Equal(t, int64(1), zone(0), "preemptor placed on zone 0")
+
+	// Re-pipeline a victim (the solver re-allocates evicted victims to see who can stay). Its old
+	// placement was zone 0, but zone 0 is now the preemptor's; the fresh placement re-homes it to
+	// zone 1, so the dedup does not fire and zone 0 is not re-charged.
+	require.NoError(t, pipeline(victim0))
+
+	assert.GreaterOrEqual(t, zone(0), int64(0),
+		"node NUMA cpu went negative — re-pipelined victim re-charged its stale zone-0 placement")
+	assert.Equal(t, []int{1}, victim0.NUMAPlacement.ZoneIndices(), "victim re-homed to the free zone 1")
+	assert.Equal(t, int64(1), zone(1), "victim charged on zone 1")
+	assert.Equal(t, int64(1), zone(0), "zone 0 unchanged (preemptor only)")
+}

--- a/pkg/scheduler/plugins/numa/reclaim_repipeline_test.go
+++ b/pkg/scheduler/plugins/numa/reclaim_repipeline_test.go
@@ -4,6 +4,7 @@
 package numa_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	schedapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
@@ -41,8 +44,18 @@ func singleTask(job *podgroup_info.PodGroupInfo) *pod_info.PodInfo {
 	return nil
 }
 
-func cpuPlacement(zoneIndex int, cpu string) pod_info.NUMAPlacement {
-	return pod_info.NUMAPlacement{{ZoneIndex: zoneIndex, Amount: v1.ResourceList{"cpu": resource.MustParse(cpu)}}}
+// setObservedPlacement stamps the pod's observed NUMA placement record, from which OnSessionOpen
+// seeds the task's NUMAPlacement and reconstructs the zone's Available.
+func setObservedPlacement(task *pod_info.PodInfo, zoneID, cpu string) {
+	record := []schedulingv1alpha2.NUMAZonePlacement{{Zone: zoneID, Amount: v1.ResourceList{"cpu": resource.MustParse(cpu)}}}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		panic(err)
+	}
+	if task.Pod.Annotations == nil {
+		task.Pod.Annotations = map[string]string{}
+	}
+	task.Pod.Annotations[commonconstants.NumaPlacementObserved] = string(raw)
 }
 
 // TestReclaimRepipelineDoesNotGoNegative reproduces the preemption bookkeeping bug through the real
@@ -91,8 +104,10 @@ func TestReclaimRepipelineDoesNotGoNegative(t *testing.T) {
 	for _, task := range []*pod_info.PodInfo{victim0, victim1, preemptor} {
 		task.Pod.Status.QOSClass = v1.PodQOSGuaranteed
 	}
-	victim0.NUMAPlacement = cpuPlacement(0, "3")
-	victim1.NUMAPlacement = cpuPlacement(1, "3")
+	// Victims carry observed placement records: OnSessionOpen seeds each task's NUMAPlacement from
+	// them and reconstructs zone Available (4 allocatable - 3 observed = 1 per zone).
+	setObservedPlacement(victim0, "node-0", "3")
+	setObservedPlacement(victim1, "node-1", "3")
 
 	ssn := &framework.Session{
 		ClusterInfo: &schedapi.ClusterInfo{PodGroupInfos: jobsInfoMap, Nodes: nodesInfoMap},

--- a/pkg/scheduler/plugins/numa/reconstruct.go
+++ b/pkg/scheduler/plugins/numa/reconstruct.go
@@ -13,13 +13,13 @@ import (
 )
 
 // reconstructNodeAvailable discards each modeled node's NRT-reported per-zone Available and
-// recomputes it as Allocatable minus the observed placements of the pods currently consuming the
-// node. NRT Available lags across cycles (the exporter republishes on a delay, in both directions —
-// missing a just-bound pod or still counting a just-deleted one); Allocatable is static and the pod
-// set is read from the live snapshot, so the reconstructed Available reflects the node's real free
-// capacity with no lag. Each pod's zone comes from its observed (agent-published) record; a pod with
-// no observed record contributes nothing — never guess a zone. Gated by the reconstructAvailable
-// flag, which the operator sets when the placement agent (the observed-placement source) is deployed.
+// recomputes it as Allocatable minus the placements of the pods currently consuming the node. NRT
+// Available lags across cycles (the exporter republishes on a delay, in both directions — missing a
+// just-bound pod or still counting a just-deleted one); Allocatable is static and the pod set is read
+// from the live snapshot, so the reconstructed Available reflects the node's real free capacity with
+// no lag. Each pod's zone comes from its placement record (observed > BindRequest > predicted); a pod
+// with no record contributes nothing — never guess a zone. Gated by the reconstructAvailable flag,
+// which the operator sets when the placement agent (the observed-placement source) is deployed.
 func (pp *numaPlugin) reconstructNodeAvailable(ssn *framework.Session) {
 	for _, node := range ssn.ClusterInfo.Nodes {
 		topo := node.NumaTopology
@@ -31,7 +31,8 @@ func (pp *numaPlugin) reconstructNodeAvailable(ssn *framework.Session) {
 			if !pod_status.IsActiveAllocatedStatus(task.Status) {
 				continue
 			}
-			numaAllocate(topo, placementFromRecord(observedRecord(task.Pod), topo))
+			record := resolvePlacementRecord(task.Pod, bindRequestZones(ssn, task.Pod))
+			numaAllocate(topo, placementFromRecord(record, topo))
 		}
 	}
 }

--- a/pkg/scheduler/plugins/numa/requests.go
+++ b/pkg/scheduler/plugins/numa/requests.go
@@ -11,34 +11,37 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 )
 
-// requestUnits decomposes a task into the alignment units the kubelet Topology
-// Manager hints for, under the node's scope: one unit for the whole pod (pod
-// scope) or one per concurrently-running container (container scope). Each unit
-// is a request the evaluator places on NUMA zone(s); the evaluator intersects it
-// with the node's topology-aware resources, so non-aligned resources drop out.
-func requestUnits(task *pod_info.PodInfo, scope node_info.TopologyManagerScope) []v1.ResourceList {
+// requestUnits decomposes a task into the alignment units the kubelet Topology Manager hints for,
+// under the node's scope. It returns the concurrently-running units, which are charged against the
+// per-zone ledger, and the serial init-container units, which must each be alignable on their own
+// but are not accumulated (an ordinary init container completes and frees its resources before the
+// app containers run). The evaluator intersects each unit with the node's topology-aware resources,
+// so non-aligned resources drop out.
+func requestUnits(task *pod_info.PodInfo, scope node_info.TopologyManagerScope) (concurrent, serial []v1.ResourceList) {
 	if scope == node_info.TopologyScopePod {
-		return []v1.ResourceList{toAmounts(resourcehelper.PodRequests(task.Pod, resourcehelper.PodResourcesOptions{}))}
+		return []v1.ResourceList{toAmounts(resourcehelper.PodRequests(task.Pod, resourcehelper.PodResourcesOptions{}))}, nil
 	}
 	return containerUnits(task.Pod)
 }
 
-// containerUnits returns one request per concurrently-running container: the
-// regular containers plus native sidecars (restartable init containers). Ordinary
-// init containers run serially before the app containers and are not modeled here
-// (see follow-ups); the common single-container and sidecar cases are exact.
-func containerUnits(pod *v1.Pod) []v1.ResourceList {
-	units := make([]v1.ResourceList, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+// containerUnits splits a pod into container-scope alignment units. Native sidecars (restartable
+// init containers) keep running alongside the app containers, so they are concurrent and
+// accumulated. An ordinary init container runs serially before the app containers and frees its
+// resources first, so it is returned as a serial unit: checked for alignability on its own, never
+// accumulated into the concurrent set.
+func containerUnits(pod *v1.Pod) (concurrent, serial []v1.ResourceList) {
 	for i := range pod.Spec.InitContainers {
 		c := &pod.Spec.InitContainers[i]
 		if c.RestartPolicy != nil && *c.RestartPolicy == v1.ContainerRestartPolicyAlways {
-			units = append(units, toAmounts(c.Resources.Requests))
+			concurrent = append(concurrent, toAmounts(c.Resources.Requests))
+		} else {
+			serial = append(serial, toAmounts(c.Resources.Requests))
 		}
 	}
 	for i := range pod.Spec.Containers {
-		units = append(units, toAmounts(pod.Spec.Containers[i].Resources.Requests))
+		concurrent = append(concurrent, toAmounts(pod.Spec.Containers[i].Resources.Requests))
 	}
-	return units
+	return concurrent, serial
 }
 
 func toAmounts(list v1.ResourceList) v1.ResourceList {

--- a/pkg/scheduler/plugins/numa/seed_placements.go
+++ b/pkg/scheduler/plugins/numa/seed_placements.go
@@ -14,13 +14,16 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
-// seedPlacements translates each already-placed pod's observed NUMA placement into the internal
-// index-based NUMAPlacement, so virtual eviction can credit the pod's actual zones. A pod with no
-// observed record, or whose record names a zone the node no longer reports, is left unaccounted — v1
-// never guesses a zone. Only pods the plugin would handle are seeded, keeping allocate/deallocate
-// charging symmetric.
+// seedPlacements reconstructs each already-placed pod's NUMA placement from its persisted, durable
+// (zone-id-based) record and stamps it onto the task as the internal index-based NUMAPlacement, so
+// virtual eviction can credit the pod's actual zones. The record is resolved here with precedence
+// observed > BindRequest > predicted (resolvePlacementRecord), then translated to the per-cycle zone
+// indices. A pod with no record, or whose record names a zone the node no longer reports, is left
+// unaccounted — v1 never guesses a zone. Only pods the plugin would handle are seeded, keeping
+// allocate/deallocate charging symmetric.
 //
 // Seeding targets the canonical task objects on the PodGroupInfos, NOT NodeInfo.PodInfos: the node
 // holds *clones* (NodeInfo.addTask deep-copies), while preemption/reclaim evict the job task
@@ -36,24 +39,60 @@ func (pp *numaPlugin) seedPlacements(ssn *framework.Session) {
 			if node == nil || !pp.shouldHandle(task, node.NumaTopology) {
 				continue
 			}
-			task.NUMAPlacement = placementFromRecord(observedRecord(task.Pod), node.NumaTopology)
+			record := resolvePlacementRecord(task.Pod, bindRequestZones(ssn, task.Pod))
+			task.NUMAPlacement = placementFromRecord(record, node.NumaTopology)
 		}
 	}
 }
 
-// observedRecord returns the pod's agent-published (observed) durable NUMA placement, or nil when the
-// annotation is absent or malformed. v1 consumes the observed placement only; the scheduler-predicted
-// record is a follow-up.
-func observedRecord(pod *v1.Pod) []schedulingv1alpha2.NUMAZonePlacement {
-	raw, ok := pod.Annotations[commonconstants.NumaPlacementObserved]
-	if !ok {
+// bindRequestZones returns the pod's predicted NUMA zones carried on its (non-failed) BindRequest, or
+// nil. Read from the session's BindRequest map rather than PodInfo.BindRequest because the latter is
+// dropped by PodInfo.Clone; the map is clone-independent.
+func bindRequestZones(ssn *framework.Session, pod *v1.Pod) []schedulingv1alpha2.NUMAZonePlacement {
+	bindRequest := ssn.ClusterInfo.BindRequests.GetBindRequestForPod(pod)
+	if bindRequest == nil {
 		return nil
+	}
+	return bindRequest.BindRequest.Spec.SelectedNUMAZones
+}
+
+// resolvePlacementRecord returns a pod's persisted (zone-id-based) NUMA placement, with precedence
+// observed (agent-published, ground truth) > BindRequest (this cycle's freshest prediction, readable
+// before the binder patches the pod) > predicted annotation (the binder-written durable form).
+// Returns nil when none is present — v1 never guesses a zone.
+func resolvePlacementRecord(pod *v1.Pod, bindRequestZones []schedulingv1alpha2.NUMAZonePlacement) []schedulingv1alpha2.NUMAZonePlacement {
+	if observed, ok := parsePlacementAnnotation(pod, commonconstants.NumaPlacementObserved); ok {
+		return observed
+	}
+	if len(bindRequestZones) > 0 {
+		return bindRequestZones
+	}
+	if predicted, ok := parsePlacementAnnotation(pod, commonconstants.NumaPlacementPredicted); ok {
+		return predicted
+	}
+	return nil
+}
+
+// parsePlacementAnnotation decodes a JSON-encoded []NUMAZonePlacement annotation. A missing
+// annotation yields no record silently; a present-but-malformed one is logged at warning level (it
+// likely means an incompatible NUMA agent).
+func parsePlacementAnnotation(pod *v1.Pod, key string) ([]schedulingv1alpha2.NUMAZonePlacement, bool) {
+	raw, ok := pod.Annotations[key]
+	if !ok || raw == "" {
+		return nil, false
 	}
 	var record []schedulingv1alpha2.NUMAZonePlacement
 	if err := json.Unmarshal([]byte(raw), &record); err != nil {
-		return nil
+		log.InfraLogger.Warningf("numa: ignoring malformed %s annotation on pod <%s/%s>: %v "+
+			"(possible incompatible NUMA agent)", key, pod.Namespace, pod.Name, err)
+		return nil, false
 	}
-	return record
+	if len(record) == 0 {
+		log.InfraLogger.Warningf("numa: ignoring empty %s annotation on pod <%s/%s> "+
+			"(possible incompatible NUMA agent)", key, pod.Namespace, pod.Name)
+		return nil, false
+	}
+	return record, true
 }
 
 // placementFromRecord maps a persisted (zone-id-based) NUMA placement record to the internal index

--- a/pkg/scheduler/plugins/numa/seed_placements.go
+++ b/pkg/scheduler/plugins/numa/seed_placements.go
@@ -53,7 +53,7 @@ func bindRequestZones(ssn *framework.Session, pod *v1.Pod) []schedulingv1alpha2.
 	if bindRequest == nil {
 		return nil
 	}
-	return bindRequest.BindRequest.Spec.SelectedNUMAZones
+	return bindRequest.BindRequest.Spec.PredictedNUMAZones
 }
 
 // resolvePlacementRecord returns a pod's persisted (zone-id-based) NUMA placement, with precedence

--- a/pkg/scheduler/test_utils/jobs_fake/jobs.go
+++ b/pkg/scheduler/test_utils/jobs_fake/jobs.go
@@ -49,6 +49,7 @@ type TestJobBasic struct {
 	Tasks                               []*tasks_fake.TestTaskBasic
 	RootSubGroupSet                     *subgroup_info.SubGroupSet
 	StaleDuration                       *time.Duration
+	QOSClass                            v1.PodQOSClass
 }
 
 func BuildJobsAndTasksMaps(Jobs []*TestJobBasic, vectorMap *resource_info.ResourceVectorMap, draClaims ...runtime.Object) (
@@ -203,6 +204,9 @@ func generateTasks(
 
 		podOfTask := createPodOfTask(job, taskIndex, task, podResourceList, gpuFraction,
 			gpuMemory, gpuGroups)
+		if job.QOSClass != "" {
+			podOfTask.Status.QOSClass = job.QOSClass
+		}
 
 		var draPodClaims []*resourceapi.ResourceClaim
 		if len(draClaimsMap) > 0 {

--- a/pkg/scheduler/test_utils/nodes_fake/nodes.go
+++ b/pkg/scheduler/test_utils/nodes_fake/nodes.go
@@ -4,6 +4,7 @@
 package nodes_fake
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -13,7 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/resources"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
@@ -53,6 +56,7 @@ type TestNodeBasic struct {
 	GpuMemorySynced *bool
 	MaxTaskNum      *int
 	Labels          map[string]string
+	NumaTopology    *node_info.NumaTopology
 }
 
 func BuildNodesInfoMap(
@@ -195,6 +199,7 @@ func buildNodeInfo(
 	}
 	podAffinityInfo := cluster_info.NewK8sNodePodAffinityInfo(node, clusterPodAffinityInfo)
 	nodeInfo := node_info.NewNodeInfo(node, podAffinityInfo, vectorMap)
+	nodeInfo.NumaTopology = nodeMetadata.NumaTopology
 
 	// Count GPUs from node-specific slices
 	var draGPUCount int64
@@ -242,4 +247,56 @@ func toSorted(tasks pod_info.PodsMap) []*pod_info.PodInfo {
 	}
 
 	return sortedTasks
+}
+
+// NewNumaZone builds a NUMA zone whose Allocatable equals its Available (no in-flight usage).
+// Amounts are resource-name to quantity-string, e.g. {"cpu": "4", "memory": "16Gi"}.
+func NewNumaZone(id string, available map[v1.ResourceName]string) *node_info.NumaZone {
+	return NewNumaZoneWithAllocatable(id, available, available)
+}
+
+// NewNumaZoneWithAllocatable builds a NUMA zone with distinct static capacity (allocatable) and
+// current headroom (available) — used to model zones already partly consumed by running pods.
+func NewNumaZoneWithAllocatable(id string, allocatable, available map[v1.ResourceName]string) *node_info.NumaZone {
+	return &node_info.NumaZone{
+		ID:          id,
+		Allocatable: parseQuantities(allocatable),
+		Available:   parseQuantities(available),
+	}
+}
+
+// NewNumaTopology builds a NumaTopology, deriving the per-zone Resources set from the zones.
+func NewNumaTopology(
+	policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope, zones ...*node_info.NumaZone,
+) *node_info.NumaTopology {
+	resources := sets.New[v1.ResourceName]()
+	for _, zone := range zones {
+		for name := range zone.Available {
+			resources.Insert(name)
+		}
+	}
+	return &node_info.NumaTopology{Policy: policy, Scope: scope, Zones: zones, Resources: resources}
+}
+
+func parseQuantities(amounts map[v1.ResourceName]string) map[v1.ResourceName]resource.Quantity {
+	out := make(map[v1.ResourceName]resource.Quantity, len(amounts))
+	for name, qty := range amounts {
+		out[name] = resource.MustParse(qty)
+	}
+	return out
+}
+
+// NumaObservedPlacementAnnotation builds the kai.scheduler/numa-placement-observed pod annotation
+// (zone id to per-resource amount) the binder would have persisted for a running pod. The numa
+// plugin reconstructs the pod's NUMAPlacement from it at session open. Merge it via TestTaskBasic.Annotations.
+func NumaObservedPlacementAnnotation(zonePlacements map[string]map[v1.ResourceName]string) map[string]string {
+	record := make([]schedulingv1alpha2.NUMAZonePlacement, 0, len(zonePlacements))
+	for zoneID, amounts := range zonePlacements {
+		record = append(record, schedulingv1alpha2.NUMAZonePlacement{Zone: zoneID, Amount: parseQuantities(amounts)})
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		panic(err)
+	}
+	return map[string]string{commonconstants.NumaPlacementObserved: string(data)}
 }

--- a/pkg/scheduler/test_utils/tasks_fake/tasks.go
+++ b/pkg/scheduler/test_utils/tasks_fake/tasks.go
@@ -39,6 +39,7 @@ type TestTaskBasic struct {
 	ResourceClaimTemplates     map[string]string
 	ResourceClaimNames         []string
 	PersistentVolumeClaimNames []string
+	Annotations                map[string]string
 }
 
 func BuildPod(
@@ -120,6 +121,8 @@ func BuildPod(
 	for migInstance, count := range task.RequiredMigInstances {
 		pod.Annotations[migInstance.String()] = fmt.Sprintf("%d", count)
 	}
+
+	maps.Copy(pod.Annotations, task.Annotations)
 
 	for _, claimName := range task.ResourceClaimNames {
 		pod.Spec.ResourceClaims = append(pod.Spec.ResourceClaims, v1.PodResourceClaim{

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -14,6 +14,8 @@ import (
 	// lint:ignore ST1001 we want to use gomock here
 	. "go.uber.org/mock/gomock"
 	"golang.org/x/exp/slices"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -25,6 +27,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/cache"
@@ -117,11 +120,17 @@ type TestExpectedResultBasic struct {
 	DontValidateGPUGroup        bool
 	LastStartTimestampOlderThan *time.Duration
 	ExpectedErrorMessage        string
+	// NUMAZones, when non-nil, asserts the task's resulting NUMA placement zone indices
+	// (order-insensitive). An empty (non-nil) slice asserts the task has no NUMA placement.
+	NUMAZones []int
 }
 
 type TestExpectedNodesResources struct {
 	ReleasingGPUs float64
 	IdleGPUs      float64
+	// NUMAZonesAvailable, when non-nil, asserts each zone's per-resource Available ledger after
+	// scheduling: zone index to resource name to quantity string.
+	NUMAZonesAvailable map[int]map[v1.ResourceName]string
 }
 
 func MatchExpectedAndRealTasks(t *testing.T, testNumber int, testMetadata TestTopologyBasic, ssn *framework.Session) {
@@ -146,6 +155,10 @@ func MatchExpectedAndRealTasks(t *testing.T, testNumber int, testMetadata TestTo
 
 			if len(jobExpectedResult.NodeName) > 0 && taskInfo.NodeName != jobExpectedResult.NodeName {
 				t.Errorf("Test number: %d, name: %s, has failed. Task name: %s, actual uses node: %s, was expecting node: %s", testNumber, testMetadata.Name, taskInfo.Name, taskInfo.NodeName, jobExpectedResult.NodeName)
+			}
+
+			if jobExpectedResult.NUMAZones != nil && !sameZoneIndices(taskInfo.NUMAPlacement.ZoneIndices(), jobExpectedResult.NUMAZones) {
+				t.Errorf("Test number: %d, name: %s, has failed. Task name: %s, actual NUMA zones: %v, was expecting zones: %v", testNumber, testMetadata.Name, taskInfo.Name, taskInfo.NUMAPlacement.ZoneIndices(), jobExpectedResult.NUMAZones)
 			}
 
 			sumOfJobRequestedGPU += taskInfo.GpuRequirement.GPUs()
@@ -316,6 +329,44 @@ func MatchExpectedAndRealTasks(t *testing.T, testNumber int, testMetadata TestTo
 
 		if nodeExpectedResources.IdleGPUs != ssnNode.IdleVector.Get(gpuIdx) {
 			t.Errorf("Test number: %d, name: %v, has failed. Node name: %v, actual Idle GPUs: %v, was expecting Idle GPUs: %v", testNumber, testMetadata.Name, nodeName, ssnNode.IdleVector.Get(gpuIdx), nodeExpectedResources.IdleGPUs)
+		}
+
+		matchNUMAZonesAvailable(t, testNumber, testMetadata.Name, nodeName, ssnNode, nodeExpectedResources.NUMAZonesAvailable)
+	}
+}
+
+// sameZoneIndices reports whether two zone-index slices hold the same indices, ignoring order.
+func sameZoneIndices(got, want []int) bool {
+	gotSorted := append([]int(nil), got...)
+	wantSorted := append([]int(nil), want...)
+	slices.Sort(gotSorted)
+	slices.Sort(wantSorted)
+	return slices.Equal(gotSorted, wantSorted)
+}
+
+func matchNUMAZonesAvailable(
+	t *testing.T, testNumber int, testName, nodeName string,
+	ssnNode *node_info.NodeInfo, expected map[int]map[v1.ResourceName]string,
+) {
+	if expected == nil {
+		return
+	}
+	if ssnNode.NumaTopology == nil {
+		t.Errorf("Test number: %d, name: %v, has failed. Node %v has no NumaTopology but NUMAZonesAvailable was expected", testNumber, testName, nodeName)
+		return
+	}
+	for zoneIndex, resources := range expected {
+		if zoneIndex < 0 || zoneIndex >= len(ssnNode.NumaTopology.Zones) {
+			t.Errorf("Test number: %d, name: %v, has failed. Node %v zone index %d out of range (%d zones)", testNumber, testName, nodeName, zoneIndex, len(ssnNode.NumaTopology.Zones))
+			continue
+		}
+		zone := ssnNode.NumaTopology.Zones[zoneIndex]
+		for name, want := range resources {
+			expectedQty := resource.MustParse(want)
+			actualQty := zone.Available[name]
+			if actualQty.Cmp(expectedQty) != 0 {
+				t.Errorf("Test number: %d, name: %v, has failed. Node %v zone %d resource %v: actual Available %v, was expecting %v", testNumber, testName, nodeName, zoneIndex, name, actualQty.String(), want)
+			}
 		}
 	}
 }

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -331,7 +331,7 @@ func GetTestCacheMock(
 	}
 
 	if cacheRequirements.NumberOfCacheBinds != 0 {
-		cacheMock.EXPECT().Bind(Any(), Any(), Any()).Return(nil).MaxTimes(cacheRequirements.NumberOfCacheBinds)
+		cacheMock.EXPECT().Bind(Any(), Any(), Any(), Any()).Return(nil).MaxTimes(cacheRequirements.NumberOfCacheBinds)
 	}
 
 	fakeClient := fake.NewSimpleClientset(additionalObjects...)

--- a/pkg/scheduler/test_utils/test_utils_builder.go
+++ b/pkg/scheduler/test_utils/test_utils_builder.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/numa"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
 )
@@ -93,11 +94,26 @@ func CreateFakeSession(schedulerConfig *TestSessionConfig,
 		addSessionPlugins(&ssn, schedulerConfig.Plugins, createCacheMockIfNotExists, schedulerConfig.CachePlugins)
 	}
 
+	// The numa plugin isn't in the default test config; enable it whenever a node carries a
+	// NumaTopology so NUMA scenarios are driven purely by node/job metadata. Inert otherwise.
+	if anyNodeHasNumaTopology(nodesInfoMap) {
+		numa.New(framework.PluginArguments{}).OnSessionOpen(&ssn)
+	}
+
 	// Some plugins are using informers wrappers (such as the DRA manager) which require a moment to sync
 	// without this some tests might have flaky results.
 	time.Sleep(time.Millisecond)
 
 	return &ssn
+}
+
+func anyNodeHasNumaTopology(nodesInfoMap map[string]*node_info.NodeInfo) bool {
+	for _, node := range nodesInfoMap {
+		if node.NumaTopology != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func BuildQueueInfoMap(testMetadata TestTopologyBasic) map[common_info.QueueID]*queue_info.QueueInfo {


### PR DESCRIPTION
## Description

This PR adds a mechanism that persists the predicted NUMA placement of a pod on a node, and uses that in the scheduling cycle as a fallback for cases where the NUMA placement exporter is unavailable.

Notes for review:
- The NUMA placement in the annotation uses the full Zone ID string (i.e. `node-0`, `node-`) to be explicit (the order of Zones in the NRT CRD is not guaranteed), but the in-cycle uses slice indices for convenience and performance - thus the need for translation methods like `func (t *NumaTopology) ZoneID(index int) (string, bool) `, `numaPlacementToZones`
- This PR adds unit tests for the different actions (allocate, reclaim, preempt), and some full-cycle integration tests
- Added support for NUMA alignment for init containers

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
