### PR TITLE
feat: Added NodeResourceTopologies to the snapshot tool

### DIFF
--- a/cmd/snapshot-tool/main.go
+++ b/cmd/snapshot-tool/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	nrtfake "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	version "k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -70,11 +71,12 @@ func main() {
 	actions.InitDefaultActions()
 	plugins.InitDefaultPlugins()
 
-	kubeClient, kaiClient := loadClientsWithSnapshot(snapshot.RawObjects, snapshot.Discovery)
+	kubeClient, kaiClient, nrtClient := loadClientsWithSnapshot(snapshot.RawObjects, snapshot.Discovery)
 
 	schedulerCacheParams := &cache.SchedulerCacheParams{
 		KubeClient:                  kubeClient,
 		KAISchedulerClient:          kaiClient,
+		NRTClient:                   nrtClient,
 		SchedulerName:               snapshot.SchedulerParams.SchedulerName,
 		NodePoolParams:              snapshot.SchedulerParams.PartitionParams,
 		RestrictNodeScheduling:      snapshot.SchedulerParams.RestrictSchedulingNodes,
@@ -194,9 +196,10 @@ func loadSnapshot(filename string) (*snapshot.Snapshot, error) {
 	return nil, os.ErrNotExist
 }
 
-func loadClientsWithSnapshot(rawObjects *snapshot.RawKubernetesObjects, discoverySnapshot *snapshot.DiscoverySnapshot) (kubernetes.Interface, *kaischedulerfake.Clientset) {
+func loadClientsWithSnapshot(rawObjects *snapshot.RawKubernetesObjects, discoverySnapshot *snapshot.DiscoverySnapshot) (kubernetes.Interface, *kaischedulerfake.Clientset, *nrtfake.Clientset) {
 	kubeClient := fake.NewSimpleClientset()
 	kaiClient := kaischedulerfake.NewSimpleClientset()
+	nrtClient := nrtfake.NewSimpleClientset()
 
 	if discoverySnapshot == nil {
 		discoverySnapshot = synthesizeDiscoveryFromSnapshot(rawObjects)
@@ -294,6 +297,13 @@ func loadClientsWithSnapshot(rawObjects *snapshot.RawKubernetesObjects, discover
 		}
 	}
 
+	for _, nrt := range rawObjects.NodeResourceTopologies {
+		_, err := nrtClient.TopologyV1alpha2().NodeResourceTopologies().Create(context.TODO(), nrt, v1.CreateOptions{})
+		if err != nil {
+			log.InfraLogger.Errorf("Failed to create node resource topology: %v", err)
+		}
+	}
+
 	draClient := draversionawareclient.NewDRAAwareClient(kubeClient)
 
 	for _, resourceClaim := range rawObjects.ResourceClaims {
@@ -317,31 +327,46 @@ func loadClientsWithSnapshot(rawObjects *snapshot.RawKubernetesObjects, discover
 		}
 	}
 
-	return draClient, kaiClient
+	return draClient, kaiClient, nrtClient
 }
 
 func synthesizeDiscoveryFromSnapshot(rawObjects *snapshot.RawKubernetesObjects) *snapshot.DiscoverySnapshot {
 	hasDRAResources := len(rawObjects.ResourceClaims) > 0 ||
 		len(rawObjects.ResourceSlices) > 0 ||
 		len(rawObjects.DeviceClasses) > 0
-	if !hasDRAResources {
+	hasNRTResources := len(rawObjects.NodeResourceTopologies) > 0
+
+	if !hasDRAResources && !hasNRTResources {
 		return nil
 	}
 
-	log.InfraLogger.V(2).Infof("Synthesizing discovery data from snapshot DRA resources")
-	return &snapshot.DiscoverySnapshot{
+	discoverySnapshot := &snapshot.DiscoverySnapshot{
 		ServerVersion: &version.Info{Major: "1", Minor: "32"},
-		Resources: []*v1.APIResourceList{
-			{
-				GroupVersion: "resource.k8s.io/v1",
-				APIResources: []v1.APIResource{
-					{Name: "resourceclaims", Kind: "ResourceClaim", Namespaced: true},
-					{Name: "resourceslices", Kind: "ResourceSlice"},
-					{Name: "deviceclasses", Kind: "DeviceClass"},
-				},
-			},
-		},
 	}
+
+	if hasDRAResources {
+		log.InfraLogger.V(2).Infof("Synthesizing discovery data from snapshot DRA resources")
+		discoverySnapshot.Resources = append(discoverySnapshot.Resources, &v1.APIResourceList{
+			GroupVersion: "resource.k8s.io/v1",
+			APIResources: []v1.APIResource{
+				{Name: "resourceclaims", Kind: "ResourceClaim", Namespaced: true},
+				{Name: "resourceslices", Kind: "ResourceSlice"},
+				{Name: "deviceclasses", Kind: "DeviceClass"},
+			},
+		})
+	}
+
+	if hasNRTResources {
+		log.InfraLogger.V(2).Infof("Synthesizing discovery data from snapshot NRT resources")
+		discoverySnapshot.Resources = append(discoverySnapshot.Resources, &v1.APIResourceList{
+			GroupVersion: "topology.node.k8s.io/v1alpha2",
+			APIResources: []v1.APIResource{
+				{Name: "noderesourcetopologies", Kind: "NodeResourceTopology"},
+			},
+		})
+	}
+
+	return discoverySnapshot
 }
 
 func applyDiscoverySnapshot(kubeClient *fake.Clientset, discoverySnapshot *snapshot.DiscoverySnapshot) {

--- a/pkg/scheduler/plugins/snapshot/snapshot.go
+++ b/pkg/scheduler/plugins/snapshot/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	v14 "k8s.io/api/scheduling/v1"
@@ -35,22 +36,23 @@ const (
 
 // RawKubernetesObjects contains the raw Kubernetes objects from the cluster
 type RawKubernetesObjects struct {
-	Pods                   []*v1.Pod                         `json:"pods"`
-	Nodes                  []*v1.Node                        `json:"nodes"`
-	Queues                 []*enginev2.Queue                 `json:"queues"`
-	PodGroups              []*enginev2alpha2.PodGroup        `json:"podGroups"`
-	BindRequests           []*schedulingv1alpha2.BindRequest `json:"bindRequests"`
-	PriorityClasses        []*v14.PriorityClass              `json:"priorityClasses"`
-	ConfigMaps             []*v1.ConfigMap                   `json:"configMaps"`
-	PersistentVolumes      []*v1.PersistentVolume            `json:"persistentVolumes"`
-	PersistentVolumeClaims []*v1.PersistentVolumeClaim       `json:"persistentVolumeClaims"`
-	CSIStorageCapacities   []*storage.CSIStorageCapacity     `json:"csiStorageCapacities"`
-	StorageClasses         []*storage.StorageClass           `json:"storageClasses"`
-	CSIDrivers             []*storage.CSIDriver              `json:"csiDrivers"`
-	ResourceClaims         []*resourceapi.ResourceClaim      `json:"resourceClaims"`
-	ResourceSlices         []*resourceapi.ResourceSlice      `json:"resourceSlices"`
-	DeviceClasses          []*resourceapi.DeviceClass        `json:"deviceClasses"`
-	Topologies             []*kaiv1alpha1.Topology           `json:"topologies"`
+	Pods                   []*v1.Pod                           `json:"pods"`
+	Nodes                  []*v1.Node                          `json:"nodes"`
+	Queues                 []*enginev2.Queue                   `json:"queues"`
+	PodGroups              []*enginev2alpha2.PodGroup          `json:"podGroups"`
+	BindRequests           []*schedulingv1alpha2.BindRequest   `json:"bindRequests"`
+	PriorityClasses        []*v14.PriorityClass                `json:"priorityClasses"`
+	ConfigMaps             []*v1.ConfigMap                     `json:"configMaps"`
+	PersistentVolumes      []*v1.PersistentVolume              `json:"persistentVolumes"`
+	PersistentVolumeClaims []*v1.PersistentVolumeClaim         `json:"persistentVolumeClaims"`
+	CSIStorageCapacities   []*storage.CSIStorageCapacity       `json:"csiStorageCapacities"`
+	StorageClasses         []*storage.StorageClass             `json:"storageClasses"`
+	CSIDrivers             []*storage.CSIDriver                `json:"csiDrivers"`
+	ResourceClaims         []*resourceapi.ResourceClaim        `json:"resourceClaims"`
+	ResourceSlices         []*resourceapi.ResourceSlice        `json:"resourceSlices"`
+	DeviceClasses          []*resourceapi.DeviceClass          `json:"deviceClasses"`
+	Topologies             []*kaiv1alpha1.Topology             `json:"topologies"`
+	NodeResourceTopologies []*nrtv1alpha2.NodeResourceTopology `json:"nodeResourceTopologies"`
 }
 
 type DiscoverySnapshot struct {
@@ -155,6 +157,8 @@ func (sp *snapshotPlugin) writeRawObjects(stream *jsonStream) error {
 			listedSliceField("resourceSlices", dataLister.ListResourceSlices, "Error getting raw resource slices"),
 			listedSliceField("deviceClasses", dataLister.ListDeviceClasses, "Error getting raw device classes"),
 			listedSliceField("topologies", dataLister.ListTopologies, "Error getting raw topologies"),
+			listedSliceField("nodeResourceTopologies", dataLister.ListNodeResourceTopologies,
+				"Error getting raw node resource topologies"),
 		)
 	})
 }


### PR DESCRIPTION
## Description

This PR adds the NRT objects from the cluster to the published snapshot, and adds it to the snapshot tool

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
