### PR TITLE
bugfix: NUMA placement exporter operand

### DIFF
--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -243,4 +243,37 @@ spec:
     externalPrometheusUrl: {{ .Values.prometheus.externalPrometheusUrl | quote }}
     {{- end }}
   {{- end }}
+
+  numaPlacementExporter:
+    service:
+      {{- if not (kindIs "invalid" .Values.numaPlacementExporter.enabled) }}
+      enabled: {{ .Values.numaPlacementExporter.enabled }}
+      {{- end }}
+      image:
+        name: {{ .Values.numaPlacementExporter.image.name }}
+        repository: {{ .Values.global.registry }}
+        tag: {{ .Values.numaPlacementExporter.image.tag | default .Values.global.tag | default .Chart.AppVersion }}
+        pullPolicy: {{ .Values.numaPlacementExporter.image.pullPolicy | default .Values.global.imagePullPolicy }}
+      {{- if .Values.numaPlacementExporter.resources }}
+      resources:
+        {{- toYaml .Values.numaPlacementExporter.resources | nindent 8 }}
+      {{- end }}
+      {{- if .Values.numaPlacementExporter.affinity }}
+      affinity:
+        {{- toYaml .Values.numaPlacementExporter.affinity | nindent 8 }}
+      {{- end }}
+    {{- if .Values.numaPlacementExporter.nodeSelector }}
+    nodeSelector:
+      {{- toYaml .Values.numaPlacementExporter.nodeSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.numaPlacementExporter.tolerations }}
+    tolerations:
+      {{- toYaml .Values.numaPlacementExporter.tolerations | nindent 6 }}
+    {{- end }}
+    {{- if .Values.numaPlacementExporter.pollInterval }}
+    pollInterval: {{ .Values.numaPlacementExporter.pollInterval | quote }}
+    {{- end }}
+    {{- if .Values.numaPlacementExporter.driftResyncInterval }}
+    driftResyncInterval: {{ .Values.numaPlacementExporter.driftResyncInterval | quote }}
+    {{- end }}
 {{- end -}}

--- a/pkg/operator/operands/numa_placement_exporter/numa_placement_exporter_test.go
+++ b/pkg/operator/operands/numa_placement_exporter/numa_placement_exporter_test.go
@@ -131,4 +131,31 @@ var _ = Describe("NumaPlacementExporter DesiredState", func() {
 		}
 		Expect(envNames).To(ContainElement("NODE_NAME"))
 	})
+
+	It("is idempotent across reconciles (no duplicate volumes/mounts)", func(ctx context.Context) {
+		cfg.Spec.NumaPlacementExporter.Service.Enabled = ptr.To(true)
+		c := fakeClient()
+		operand := &NumaPlacementExporter{}
+
+		first, err := operand.DesiredState(ctx, c, cfg)
+		Expect(err).To(BeNil())
+		for _, o := range first {
+			Expect(c.Create(ctx, o)).To(Succeed())
+		}
+
+		// Second reconcile builds from the now-existing object; appending would duplicate.
+		second, err := operand.DesiredState(ctx, c, cfg)
+		Expect(err).To(BeNil())
+
+		var ds *appsv1.DaemonSet
+		for _, o := range second {
+			if d, ok := o.(*appsv1.DaemonSet); ok {
+				ds = d
+			}
+		}
+		Expect(ds).ToNot(BeNil())
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(HaveLen(1))
+	})
 })

--- a/pkg/operator/operands/numa_placement_exporter/resources.go
+++ b/pkg/operator/operands/numa_placement_exporter/resources.go
@@ -42,27 +42,27 @@ func (e *NumaPlacementExporter) daemonSetForKAIConfig(
 
 	container := &ds.Spec.Template.Spec.Containers[0]
 	container.Args = buildArgsList(config)
-	container.Env = append(container.Env, v1.EnvVar{
+	container.Env = []v1.EnvVar{{
 		Name:      "NODE_NAME",
 		ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}},
-	})
+	}}
 	// The kubelet podresources socket and its parent directory are root-owned; read as root.
 	container.SecurityContext = &v1.SecurityContext{
 		RunAsUser:    ptr.To(int64(0)),
 		RunAsNonRoot: ptr.To(false),
 	}
-	container.VolumeMounts = append(container.VolumeMounts,
-		v1.VolumeMount{Name: "podresources", MountPath: podResourcesDir, ReadOnly: true},
-		v1.VolumeMount{Name: "sysfs", MountPath: sysfsMountPath, ReadOnly: true},
-	)
+	container.VolumeMounts = []v1.VolumeMount{
+		{Name: "podresources", MountPath: podResourcesDir, ReadOnly: true},
+		{Name: "sysfs", MountPath: sysfsMountPath, ReadOnly: true},
+	}
 
 	hostPathDir := v1.HostPathDirectory
-	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes,
-		v1.Volume{Name: "podresources", VolumeSource: v1.VolumeSource{
+	ds.Spec.Template.Spec.Volumes = []v1.Volume{
+		{Name: "podresources", VolumeSource: v1.VolumeSource{
 			HostPath: &v1.HostPathVolumeSource{Path: podResourcesDir, Type: &hostPathDir}}},
-		v1.Volume{Name: "sysfs", VolumeSource: v1.VolumeSource{
+		{Name: "sysfs", VolumeSource: v1.VolumeSource{
 			HostPath: &v1.HostPathVolumeSource{Path: sysfsHostPath, Type: &hostPathDir}}},
-	)
+	}
 
 	return []client.Object{ds}, nil
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in the NPE operand that didn't check duplicate volumes on reconciles.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
