### PR TITLE
perf(scheduler): deduplicate equivalent reclaim scenario candidates before simulation

### DIFF
--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -186,8 +186,16 @@ func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState,
 	scenarioBuilder := NewPodAccumulatedScenarioBuilder(
 		ssn, partialPendingJob, state.recordedVictimsJobs, s.generateVictimsQueue(), feasibleNodeMap)
 
+	seenScenarios := make(map[uint64]struct{})
 	for scenarioToSolve := scenarioBuilder.GetValidScenario(); scenarioToSolve != nil; scenarioToSolve =
 		scenarioBuilder.GetNextScenario() {
+		fp := scenarioToSolve.Fingerprint()
+		if _, seen := seenScenarios[fp]; seen {
+			metrics.IncScenarioDedupedByAction()
+			continue
+		}
+		seenScenarios[fp] = struct{}{}
+
 		scenarioSolver := newByPodSolver(feasibleNodeMap, s.solutionValidator, ssn.AllowConsolidatingReclaim(),
 			s.actionType)
 

--- a/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario.go
@@ -4,6 +4,10 @@
 package scenario
 
 import (
+	"fmt"
+	"hash/fnv"
+	"sort"
+
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -66,6 +70,50 @@ func (bns *ByNodeScenario) VictimsTasksFromNodes(nodeNames []string) []*pod_info
 	}
 
 	return tasks
+}
+
+// Fingerprint returns a deterministic, order-independent hash of this scenario's victim set.
+// Two scenarios with the same preemptor, the same specific victim tasks (and therefore the same
+// node assignment), and the same recorded victims produce the same fingerprint regardless of
+// insertion order. Scoped to a single job/probe search — not reused across different preemptors.
+func (bns *ByNodeScenario) Fingerprint() uint64 {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s|", bns.preemptor.UID)
+
+	// Hash victim jobs with their specific task UIDs so scenarios that select different
+	// tasks from the same job (i.e. different node assignments) get distinct fingerprints.
+	type victimEntry struct {
+		jobID    string
+		taskUIDs []string
+	}
+	entries := make([]victimEntry, 0, len(bns.victims))
+	for id, v := range bns.victims {
+		taskUIDs := make([]string, 0, len(v.Tasks))
+		for _, t := range v.Tasks {
+			taskUIDs = append(taskUIDs, string(t.UID))
+		}
+		sort.Strings(taskUIDs)
+		entries = append(entries, victimEntry{string(id), taskUIDs})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].jobID < entries[j].jobID })
+	for _, e := range entries {
+		fmt.Fprintf(h, "%s:", e.jobID)
+		for _, uid := range e.taskUIDs {
+			fmt.Fprintf(h, "%s,", uid)
+		}
+		fmt.Fprintf(h, "|")
+	}
+
+	recorded := make([]string, 0, len(bns.recordedVictimsTasks))
+	for _, t := range bns.recordedVictimsTasks {
+		recorded = append(recorded, string(t.UID))
+	}
+	sort.Strings(recorded)
+	for _, uid := range recorded {
+		fmt.Fprintf(h, "%s|", uid)
+	}
+
+	return h.Sum64()
 }
 
 func (bns *ByNodeScenario) potentialVictimsJobsFromNodes(nodeNames []string) []common_info.PodGroupID {

--- a/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario/by_node_scenario_test.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
@@ -523,4 +524,108 @@ func TestPodByNodeScenario_VictimsTasksFromNodes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestTask(name, namespace, nodeName, uid, pgUID string, vectorMap *resource_info.ResourceVectorMap) *pod_info.PodInfo {
+	return pod_info.NewTaskInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       k8stypes.UID(uid),
+			Annotations: map[string]string{
+				commonconstants.PodGroupAnnotationForPod: pgUID,
+			},
+		},
+		Spec: v1.PodSpec{NodeName: nodeName},
+		Status: v1.PodStatus{Phase: v1.PodRunning},
+	}, vectorMap)
+}
+
+func newTestJob(uid string, tasks ...*pod_info.PodInfo) *podgroup_info.PodGroupInfo {
+	return podgroup_info.NewPodGroupInfo(common_info.PodGroupID(uid), tasks...)
+}
+
+func buildFingerprintSession(vm *resource_info.ResourceVectorMap) (
+	*framework.Session, *podgroup_info.PodGroupInfo, *podgroup_info.PodGroupInfo,
+	*pod_info.PodInfo, *pod_info.PodInfo, *pod_info.PodInfo, *pod_info.PodInfo,
+) {
+	taskA1 := newTestTask("a1", "ns", "node1", "uid-a1", "victimA", vm)
+	taskA2 := newTestTask("a2", "ns", "node1", "uid-a2", "victimA", vm)
+	taskB1 := newTestTask("b1", "ns", "node2", "uid-b1", "victimB", vm)
+	taskC1 := newTestTask("c1", "ns", "node3", "uid-c1", "victimC", vm)
+
+	jobA := newTestJob("victimA", taskA1, taskA2)
+	jobB := newTestJob("victimB", taskB1)
+	jobC := newTestJob("victimC", taskC1)
+
+	preemptor := newTestJob("preemptor-uid")
+
+	ssn := &framework.Session{ClusterInfo: &api.ClusterInfo{
+		PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+			"victimA": jobA,
+			"victimB": jobB,
+			"victimC": jobC,
+		},
+	}}
+	return ssn, preemptor, newTestJob("preemptor-uid-2"), taskA1, taskA2, taskB1, taskC1
+}
+
+func TestByNodeScenario_Fingerprint(t *testing.T) {
+	vm := resource_info.NewResourceVectorMap()
+
+	t.Run("same victims different insertion order → same fingerprint", func(t *testing.T) {
+		ssn, preemptor, _, taskA1, taskA2, taskB1, _ := buildFingerprintSession(vm)
+		s1 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1, taskA2, taskB1}, nil)
+		s2 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskB1, taskA1, taskA2}, nil)
+		if s1.Fingerprint() != s2.Fingerprint() {
+			t.Errorf("expected same fingerprint for same victim set, got %d vs %d", s1.Fingerprint(), s2.Fingerprint())
+		}
+	})
+
+	t.Run("different victim sets → different fingerprints", func(t *testing.T) {
+		ssn, preemptor, _, taskA1, _, taskB1, taskC1 := buildFingerprintSession(vm)
+		s1 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1, taskB1}, nil)
+		s2 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1, taskC1}, nil)
+		if s1.Fingerprint() == s2.Fingerprint() {
+			t.Errorf("expected different fingerprints for different victim sets, got %d", s1.Fingerprint())
+		}
+	})
+
+	t.Run("same victim job different task count → different fingerprints", func(t *testing.T) {
+		ssn, preemptor, _, taskA1, taskA2, _, _ := buildFingerprintSession(vm)
+		s1 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1}, nil)
+		s2 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1, taskA2}, nil)
+		if s1.Fingerprint() == s2.Fingerprint() {
+			t.Errorf("expected different fingerprints for different task counts, got %d", s1.Fingerprint())
+		}
+	})
+
+	t.Run("empty scenario fingerprint is stable", func(t *testing.T) {
+		ssn, preemptor, _, _, _, _, _ := buildFingerprintSession(vm)
+		s1 := NewByNodeScenario(ssn, preemptor, nil, nil, nil)
+		s2 := NewByNodeScenario(ssn, preemptor, nil, nil, nil)
+		if s1.Fingerprint() != s2.Fingerprint() {
+			t.Errorf("expected stable fingerprint for empty scenario, got %d vs %d", s1.Fingerprint(), s2.Fingerprint())
+		}
+	})
+
+	t.Run("different preemptors → different fingerprints", func(t *testing.T) {
+		ssn, preemptor, preemptor2, taskA1, _, _, _ := buildFingerprintSession(vm)
+		s1 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1}, nil)
+		s2 := NewByNodeScenario(ssn, preemptor2, nil, []*pod_info.PodInfo{taskA1}, nil)
+		if s1.Fingerprint() == s2.Fingerprint() {
+			t.Errorf("expected different fingerprints for different preemptors, got %d", s1.Fingerprint())
+		}
+	})
+
+	t.Run("same job different tasks (different node assignment) → different fingerprints", func(t *testing.T) {
+		// taskA1 and taskA2 belong to the same job (victimA) but are on different nodes.
+		// Evicting only taskA1 vs only taskA2 are not equivalent scenarios.
+		ssn, preemptor, _, taskA1, taskA2, _, _ := buildFingerprintSession(vm)
+		s1 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA1}, nil)
+		s2 := NewByNodeScenario(ssn, preemptor, nil, []*pod_info.PodInfo{taskA2}, nil)
+		if s1.Fingerprint() == s2.Fingerprint() {
+			t.Errorf("expected different fingerprints for different task selections from the same job, got %d", s1.Fingerprint())
+		}
+	})
 }

--- a/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
@@ -10,9 +10,12 @@ import (
 	. "go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
@@ -50,6 +53,84 @@ func BenchmarkReclaimUnschedulableDistributedJob_500Node(b *testing.B) {
 
 func BenchmarkReclaimUnschedulableDistributedJob_1000Node(b *testing.B) {
 	benchmarkReclaimUnschedulableDistributedJob(b, 1000)
+}
+
+// TestReclaimDeduplicatesEquivalentScenarios verifies that the scenario dedup cache
+// actually skips duplicate candidates before simulation. It uses a topology where the
+// distributed job needs fewer nodes than are available, so multiple outer accumulation
+// orderings produce the same K-prefix sub-scenarios — confirming dedup fires.
+func TestReclaimDeduplicatesEquivalentScenarios(t *testing.T) {
+	defer gock.Off()
+	test_utils.InitTestingInfrastructure()
+
+	// 20 nodes, distributed job needs 5 nodes (40 GPUs).
+	// queue-0 deserved = 121 GPUs → reclaimable = 160 - 121 = 39 GPUs < 40 needed → unschedulable.
+	// With 20 nodes available but only ~5 needed, multiple accumulation orderings produce
+	// the same K-prefix sub-scenarios — exactly the duplicate pattern from #1719.
+	const numNodes = 20
+	const gpusPerNode = 8
+	const distributedJobTasks = 5
+	const distributedJobGPUsPerTask = gpusPerNode
+
+	nodes := make(map[string]nodes_fake.TestNodeBasic, numNodes)
+	for i := 0; i < numNodes; i++ {
+		nodes[fmt.Sprintf("node%d", i)] = nodes_fake.TestNodeBasic{GPUs: gpusPerNode}
+	}
+
+	totalRunning := numNodes * gpusPerNode
+	jobs := make([]*jobs_fake.TestJobBasic, 0, totalRunning+1)
+	for i := 0; i < totalRunning; i++ {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("running-job-%d", i),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           "queue-0",
+			Tasks: []*tasks_fake.TestTaskBasic{
+				{NodeName: fmt.Sprintf("node%d", i%numNodes), State: pod_status.Running},
+			},
+		})
+	}
+
+	distributedTasks := make([]*tasks_fake.TestTaskBasic, distributedJobTasks)
+	for i := range distributedTasks {
+		distributedTasks[i] = &tasks_fake.TestTaskBasic{State: pod_status.Pending}
+	}
+	jobs = append(jobs, &jobs_fake.TestJobBasic{
+		Name:                "dedup-test-distributed-job",
+		RequiredGPUsPerTask: float64(distributedJobGPUsPerTask),
+		Priority:            constants.PriorityTrainNumber,
+		QueueName:           "queue-1",
+		Tasks:               distributedTasks,
+	})
+
+	topology := test_utils.TestTopologyBasic{
+		Name:  "dedup test topology",
+		Jobs:  jobs,
+		Nodes: nodes,
+		Queues: []test_utils.TestQueueBasic{
+			// queue-0 deserved = 121 → only 39 GPUs reclaimable, job needs 40 → unschedulable
+			{Name: "queue-0", DeservedGPUs: float64(numNodes*gpusPerNode - distributedJobTasks*distributedJobGPUsPerTask + 1), GPUOverQuotaWeight: 0},
+			{Name: "queue-1", DeservedGPUs: float64(distributedJobTasks * distributedJobGPUsPerTask), GPUOverQuotaWeight: 0},
+		},
+		Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{}},
+	}
+
+	controller := NewController(t)
+	defer controller.Finish()
+
+	before := testutil.ToFloat64(metrics.ScenariosDedupedByAction().WithLabelValues("reclaim"))
+
+	ssn := test_utils.BuildSession(topology, controller)
+	metrics.SetCurrentAction("reclaim")
+	action := reclaim.New()
+	action.Execute(ssn)
+
+	after := testutil.ToFloat64(metrics.ScenariosDedupedByAction().WithLabelValues("reclaim"))
+	deduped := after - before
+	if deduped == 0 {
+		t.Errorf("expected scenarios_deduped_by_action to increase, got delta=0 — deduplication is not working")
+	}
+	t.Logf("scenarios_deduped_by_action delta = %.0f", deduped)
 }
 
 func benchmarkReclaimUnschedulableDistributedJob(b *testing.B, numNodes int) {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -47,6 +47,7 @@ var (
 	podgroupsConsideredByAction *prometheus.CounterVec
 	scenariosSimulatedByAction  *prometheus.CounterVec
 	scenariosFilteredByAction   *prometheus.CounterVec
+	scenariosDedupedByAction    *prometheus.CounterVec
 	preemptionAttempts          prometheus.Counter
 	queueFairShareCPU           *prometheus.GaugeVec
 	queueFairShareMemory        *prometheus.GaugeVec
@@ -145,6 +146,13 @@ func InitMetrics(namespace string) {
 			Namespace: namespace,
 			Name:      "scenarios_filtered_by_action",
 			Help:      "Count of scenarios filtered per action",
+		}, []string{"action"})
+
+	scenariosDedupedByAction = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "scenarios_deduped_by_action",
+			Help:      "Count of duplicate scenarios skipped before simulation per action",
 		}, []string{"action"})
 
 	preemptionAttempts = promauto.NewCounter(
@@ -260,6 +268,15 @@ func IncScenarioSimulatedByAction() {
 
 func IncScenarioFilteredByAction() {
 	scenariosFilteredByAction.WithLabelValues(currentAction).Inc()
+}
+
+func IncScenarioDedupedByAction() {
+	scenariosDedupedByAction.WithLabelValues(currentAction).Inc()
+}
+
+// ScenariosDedupedByAction returns the counter vec for testing.
+func ScenariosDedupedByAction() *prometheus.CounterVec {
+	return scenariosDedupedByAction
 }
 
 // UpdateTaskBindDuration updates single task bind latency, including bind request creation


### PR DESCRIPTION
## Description

Addresses #1719.

In the 100-node unschedulable reclaim benchmark, 1,207 scenario candidates were generated of which 1,020 (84%) were duplicates — the same victim set reached via different accumulation orderings, each triggering full scheduler simulation unnecessarily.

### What this PR does

**Adds `Fingerprint() uint64` to `ByNodeScenario`** (`pkg/scheduler/actions/common/solvers/scenario/by_node_scenario.go`):
- Hashes preemptor UID + sorted victim job entries (each with sorted task UIDs) + sorted recorded-victim UIDs using FNV-64a
- Deterministic and order-independent: same victim set in any insertion order → same fingerprint
- Includes task UIDs (not just counts), so scenarios selecting different tasks from the same job — i.e. different node assignments — get distinct fingerprints

**Deduplicates in `solvePartialJob`** (`pkg/scheduler/actions/common/solvers/job_solver.go`):
- Maintains a `map[uint64]struct{}` scoped to the current job/probe search
- Skips simulation for any scenario whose fingerprint was already processed
- Sits above all generators — catches duplicates within a single generator and across the portfolio (NodeLocalGreedy, MultiNodeGang, and future generators)
- Generator-side quality checks remain intact

**Adds `scenarios_deduped_by_action` Prometheus counter** (`pkg/scheduler/metrics/metrics.go`):
- Mirrors `scenarios_simulation_by_action` and `scenarios_filtered_by_action`
- Lets operators observe deduplication rate in production

### Tests

- **6 fingerprint unit tests** in `by_node_scenario_test.go`: same victim set different order → same fingerprint; different victim sets → different fingerprints; same job different tasks (different node assignment) → different fingerprints; empty scenario is stable; different preemptors are distinct
- **`TestReclaimDeduplicatesEquivalentScenarios`** in `reclaim_benchmark_test.go`: 20-node topology where the distributed job needs 5 of 20 nodes — multiple accumulation orderings produce duplicate K-prefix sub-scenarios — asserts `scenarios_deduped_by_action` counter increments > 0, directly proving dedup fires

## Related Issues

Part of #1719

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None