### PR TITLE
perf(scheduler): skip redundant full-job probe when allocation is infeasible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed redundant `PodDisruptionBudgetImplemented` guard from operator PDB creation helper [#1613](https://github.com/kai-scheduler/KAI-Scheduler/pull/1613) [dttung2905](https://github.com/dttung2905)
 - Updated Go toolchain and base build images to v1.26.3.
 - **Breaking:** The podgroup produced for JobSet is now produces as a single PodGroup per JobSet with a two-level SubGroup hierarchy (one parent SubGroup per `replicatedJob`, one leaf SubGroup per replica) regardless of `startupPolicyOrder`. The `kai.scheduler/batch-min-member` annotation on the JobSet now overrides the root `minSubGroup`; the same annotation on `replicatedJobs[].template.metadata.annotations` overrides the leaf `minMember` (defaulting to `template.spec.parallelism`). [#1617](https://github.com/kai-scheduler/KAI-Scheduler/pull/1617) [davidLif](https://github.com/davidLif)
+- Optimized the job solver to skip a redundant, guaranteed-failing full-job allocation probe when the search already determined a full solution is infeasible, avoiding an extra scenario simulation on the unsolvable path.
 
 ### Fixed
 - Reduced scheduler heap retention after scheduling cycles by clearing completed session snapshots and callback references, and by releasing the node scoring pool without waiting for finalizers.

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -69,7 +69,11 @@ func (s *JobSolver) Solve(
 	}
 
 	maxSolvedK := s.searchMaxSolvableK(ssn, &state, pendingJob, tasksToAllocate)
-	if maxSolvedK == 0 {
+	// The search relies on solvability being monotonic in k, so maxSolvedK < n means a
+	// full allocation is infeasible. Probing at n would only repeat a known-failing
+	// simulation; only maxSolvedK == n can yield a committable solution. The probe at n
+	// is still required to rebuild the live statement the search discards.
+	if maxSolvedK < n {
 		return false, nil, calcVictimNames(state.recordedVictimsTasks)
 	}
 


### PR DESCRIPTION
## Description

`JobSolver.Solve` runs `searchMaxSolvableK`, an exponential-doubling + binary search that finds the largest `k` for which a probe (a full eviction/allocation scenario simulation) succeeds. That search is only correct under the assumption that solvability is **monotonic** in `k` (if `k` tasks can't be placed, neither can `k' > k`).

Previously, after the search, `Solve` always ran one more probe at the full count `n`:

```go
maxSolvedK := s.searchMaxSolvableK(...)
if maxSolvedK == 0 {
    return false, nil, ...
}
result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n) // always at n
```

When `0 < maxSolvedK < n`, the monotonicity assumption the search already relies on guarantees the probe at `n` fails — so this was an extra, guaranteed-failing scenario simulation on the unsolvable path.

This PR gates the final probe on `maxSolvedK == n` (returning early otherwise). The probe at `n` is still performed when the full set is solvable, because the search discards every `Statement` to keep the session clean, so the committable live statement must be rebuilt.

`tasksToAllocate` represents the next all-or-nothing allocation unit (gang minimum gap, or one elastic step), so there is no partial-commit case being lost.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. The early return produces the same `(false, nil)` result the failing probe would have returned.

## Additional Notes

- Behavior-preserving optimization under the monotonicity assumption the binary search already depends on; the win is avoiding one full scenario simulation per job that can be partially but not fully placed.
- No new dedicated test: the change is output-identical, so a regression would surface in the existing end-to-end solver suites rather than a new unit test. Verified locally:
  - `go test ./pkg/scheduler/actions/common/solvers/...`
  - `go test ./pkg/scheduler/actions/{reclaim,preempt,consolidation,allocate}/...`
  - all green; `gofmt`/`go vet` clean.