### PR TITLE
feat(scheduler): add scenario search budget model

### DIFF
--- a/pkg/scheduler/actions/common/solvers/search_budget.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget.go
@@ -23,22 +23,23 @@ type ActionSearchBudget struct {
 	jobLimit        time.Duration
 	minJobSearch    time.Duration
 	generatorLimits map[string]time.Duration
-	startedAt       time.Time
-	now             func() time.Time
+	deadline        deadlineBudget
+}
+
+type deadlineBudget struct {
+	deadline  time.Time
+	unlimited bool
+	now       func() time.Time
 }
 
 type jobSearchBudget struct {
-	remainingAtStart time.Duration
-	reducedBudget    bool
-	startedAt        time.Time
-	now              func() time.Time
-	generatorLimits  map[string]time.Duration
+	deadline      deadlineBudget
+	reducedBudget bool
+	actionBudget  *ActionSearchBudget
 }
 
 type generatorSearchBudget struct {
-	remainingAtStart time.Duration
-	startedAt        time.Time
-	now              func() time.Time
+	deadline deadlineBudget
 }
 
 // NewActionSearchBudget parses scenario search budget config for one scheduler action.
@@ -86,41 +87,31 @@ func newActionSearchBudgetWithClock(
 		jobLimit:        jobLimit,
 		minJobSearch:    minJobSearch,
 		generatorLimits: generatorLimits,
-		startedAt:       now(),
-		now:             now,
+		deadline:        newDeadlineBudget(searchDurationForLimit(actionLimit), now),
 	}, nil
 }
 
 func (b *ActionSearchBudget) BeginJob() *jobSearchBudget {
 	if b == nil {
-		now := time.Now
 		return &jobSearchBudget{
-			startedAt: now(),
-			now:       now,
+			deadline: newDeadlineBudget(0, time.Now),
 		}
 	}
-	now := clockOrDefault(b.now)
+	now := b.clock()
 
 	actionRemaining := b.Remaining()
-	if actionRemaining <= 0 {
-		return &jobSearchBudget{
-			startedAt:       now(),
-			now:             now,
-			generatorLimits: b.generatorLimits,
-		}
-	}
-
 	remaining := actionRemaining
 	if b.jobLimit != 0 && b.jobLimit < remaining {
 		remaining = b.jobLimit
 	}
+	if b.minJobSearch > remaining {
+		remaining = b.minJobSearch
+	}
 
 	return &jobSearchBudget{
-		remainingAtStart: remaining,
-		reducedBudget:    b.minJobSearch > 0 && actionRemaining < b.minJobSearch,
-		startedAt:        now(),
-		now:              now,
-		generatorLimits:  b.generatorLimits,
+		deadline:      newDeadlineBudget(remaining, now),
+		reducedBudget: b.jobLimit > 0 && actionRemaining < b.jobLimit,
+		actionBudget:  b,
 	}
 }
 
@@ -128,10 +119,7 @@ func (b *ActionSearchBudget) Remaining() time.Duration {
 	if b == nil {
 		return 0
 	}
-	if b.actionLimit == 0 {
-		return unlimitedRemaining
-	}
-	return remainingFromStart(b.actionLimit, b.startedAt, b.now)
+	return b.deadline.Remaining()
 }
 
 func (b *ActionSearchBudget) Exhausted() bool {
@@ -140,22 +128,13 @@ func (b *ActionSearchBudget) Exhausted() bool {
 
 func (b *jobSearchBudget) BeginGenerator(name string) *generatorSearchBudget {
 	if b == nil {
-		now := time.Now
 		return &generatorSearchBudget{
-			startedAt: now(),
-			now:       now,
+			deadline: newDeadlineBudget(0, time.Now),
 		}
 	}
-	now := clockOrDefault(b.now)
+	now := b.clock()
 
 	jobRemaining := b.Remaining()
-	if jobRemaining <= 0 {
-		return &generatorSearchBudget{
-			startedAt: now(),
-			now:       now,
-		}
-	}
-
 	generatorRemaining := jobRemaining
 	generatorLimit := b.generatorLimit(name)
 	if generatorLimit != 0 && generatorLimit < generatorRemaining {
@@ -163,9 +142,7 @@ func (b *jobSearchBudget) BeginGenerator(name string) *generatorSearchBudget {
 	}
 
 	return &generatorSearchBudget{
-		remainingAtStart: generatorRemaining,
-		startedAt:        now(),
-		now:              now,
+		deadline: newDeadlineBudget(generatorRemaining, now),
 	}
 }
 
@@ -173,7 +150,7 @@ func (b *jobSearchBudget) Remaining() time.Duration {
 	if b == nil {
 		return 0
 	}
-	return remainingFromStart(b.remainingAtStart, b.startedAt, b.now)
+	return b.deadline.Remaining()
 }
 
 func (b *jobSearchBudget) ReducedBudget() bool {
@@ -187,7 +164,7 @@ func (b *generatorSearchBudget) Remaining() time.Duration {
 	if b == nil {
 		return 0
 	}
-	return remainingFromStart(b.remainingAtStart, b.startedAt, b.now)
+	return b.deadline.Remaining()
 }
 
 func (b *generatorSearchBudget) Exhausted() bool {
@@ -195,24 +172,65 @@ func (b *generatorSearchBudget) Exhausted() bool {
 }
 
 func (b *jobSearchBudget) generatorLimit(name string) time.Duration {
-	if b == nil || b.generatorLimits == nil {
+	if b == nil || b.actionBudget == nil || b.actionBudget.generatorLimits == nil {
 		return 0
 	}
-	if limit, found := b.generatorLimits[name]; found {
+	if limit, found := b.actionBudget.generatorLimits[name]; found {
 		return limit
 	}
-	return b.generatorLimits[constants.ActionDefault]
+	return b.actionBudget.generatorLimits[constants.ActionDefault]
 }
 
-func remainingFromStart(limit time.Duration, startedAt time.Time, now func() time.Time) time.Duration {
-	if limit <= 0 || now == nil {
+func newDeadlineBudget(remaining time.Duration, now func() time.Time) deadlineBudget {
+	now = clockOrDefault(now)
+	if remaining == unlimitedRemaining {
+		return deadlineBudget{
+			unlimited: true,
+			now:       now,
+		}
+	}
+	if remaining < 0 {
+		remaining = 0
+	}
+	return deadlineBudget{
+		deadline: now().Add(remaining),
+		now:      now,
+	}
+}
+
+func (b deadlineBudget) Remaining() time.Duration {
+	if b.now == nil {
 		return 0
 	}
-	remaining := limit - now().Sub(startedAt)
+	if b.unlimited {
+		return unlimitedRemaining
+	}
+	remaining := b.deadline.Sub(b.now())
 	if remaining <= 0 {
 		return 0
 	}
 	return remaining
+}
+
+func (b *ActionSearchBudget) clock() func() time.Time {
+	if b == nil {
+		return time.Now
+	}
+	return clockOrDefault(b.deadline.now)
+}
+
+func (b *jobSearchBudget) clock() func() time.Time {
+	if b == nil || b.actionBudget == nil {
+		return time.Now
+	}
+	return b.actionBudget.clock()
+}
+
+func searchDurationForLimit(limit time.Duration) time.Duration {
+	if limit == 0 {
+		return unlimitedRemaining
+	}
+	return limit
 }
 
 func clockOrDefault(now func() time.Time) func() time.Time {

--- a/pkg/scheduler/actions/common/solvers/search_budget.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget.go
@@ -1,0 +1,372 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+const unlimitedRemaining = time.Duration(1<<63 - 1)
+
+// ActionSearchBudget tracks the top-level deadline for one scheduling action search.
+type ActionSearchBudget struct {
+	action          framework.ActionType
+	actionLimit     time.Duration
+	jobLimit        time.Duration
+	minJobSearch    time.Duration
+	generatorLimits map[string]time.Duration
+	startedAt       time.Time
+	now             func() time.Time
+}
+
+type jobSearchBudget struct {
+	remainingAtStart time.Duration
+	reducedBudget    bool
+	startedAt        time.Time
+	now              func() time.Time
+	generatorLimits  map[string]time.Duration
+}
+
+type generatorSearchBudget struct {
+	remainingAtStart time.Duration
+	startedAt        time.Time
+	now              func() time.Time
+}
+
+// NewActionSearchBudget parses scenario search budget config for one scheduler action.
+func NewActionSearchBudget(ssn *framework.Session, action framework.ActionType) (*ActionSearchBudget, error) {
+	return newActionSearchBudgetWithClock(ssn, action, time.Now)
+}
+
+func newActionSearchBudgetWithClock(
+	ssn *framework.Session, action framework.ActionType, now func() time.Time,
+) (*ActionSearchBudget, error) {
+	now = clockOrDefault(now)
+
+	budgets := scenarioSearchBudgets(ssn)
+	actionLimit, err := parseActionLimit(budgets, action)
+	if err != nil {
+		return nil, err
+	}
+	jobLimit, err := parseDurationWithDefault(
+		"maxJobSearchDuration", budgetFieldValue(budgets, func(b *kaiv1.ScenarioSearchBudgets) *metav1.Duration {
+			return b.MaxJobSearchDuration
+		}), constants.DefaultJobBudget,
+	)
+	if err != nil {
+		return nil, err
+	}
+	minJobSearch, err := parseDurationWithDefault(
+		"minJobSearchDuration", budgetFieldValue(budgets, func(b *kaiv1.ScenarioSearchBudgets) *metav1.Duration {
+			return b.MinJobSearchDuration
+		}), constants.DefaultMinJobBudget,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if jobLimit != 0 && minJobSearch >= jobLimit {
+		return nil, fmt.Errorf("minJobSearchDuration must be less than maxJobSearchDuration")
+	}
+	generatorLimits, err := parseGeneratorLimits(budgets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ActionSearchBudget{
+		action:          action,
+		actionLimit:     actionLimit,
+		jobLimit:        jobLimit,
+		minJobSearch:    minJobSearch,
+		generatorLimits: generatorLimits,
+		startedAt:       now(),
+		now:             now,
+	}, nil
+}
+
+func (b *ActionSearchBudget) BeginJob() *jobSearchBudget {
+	if b == nil {
+		now := time.Now
+		return &jobSearchBudget{
+			startedAt: now(),
+			now:       now,
+		}
+	}
+	now := clockOrDefault(b.now)
+
+	actionRemaining := b.Remaining()
+	if actionRemaining <= 0 {
+		return &jobSearchBudget{
+			startedAt:       now(),
+			now:             now,
+			generatorLimits: b.generatorLimits,
+		}
+	}
+
+	remaining := actionRemaining
+	if b.jobLimit != 0 && b.jobLimit < remaining {
+		remaining = b.jobLimit
+	}
+
+	return &jobSearchBudget{
+		remainingAtStart: remaining,
+		reducedBudget:    b.minJobSearch > 0 && actionRemaining < b.minJobSearch,
+		startedAt:        now(),
+		now:              now,
+		generatorLimits:  b.generatorLimits,
+	}
+}
+
+func (b *ActionSearchBudget) Remaining() time.Duration {
+	if b == nil {
+		return 0
+	}
+	if b.actionLimit == 0 {
+		return unlimitedRemaining
+	}
+	return remainingFromStart(b.actionLimit, b.startedAt, b.now)
+}
+
+func (b *ActionSearchBudget) Exhausted() bool {
+	return b.Remaining() <= 0
+}
+
+func (b *jobSearchBudget) BeginGenerator(name string) *generatorSearchBudget {
+	if b == nil {
+		now := time.Now
+		return &generatorSearchBudget{
+			startedAt: now(),
+			now:       now,
+		}
+	}
+	now := clockOrDefault(b.now)
+
+	jobRemaining := b.Remaining()
+	if jobRemaining <= 0 {
+		return &generatorSearchBudget{
+			startedAt: now(),
+			now:       now,
+		}
+	}
+
+	generatorRemaining := jobRemaining
+	generatorLimit := b.generatorLimit(name)
+	if generatorLimit != 0 && generatorLimit < generatorRemaining {
+		generatorRemaining = generatorLimit
+	}
+
+	return &generatorSearchBudget{
+		remainingAtStart: generatorRemaining,
+		startedAt:        now(),
+		now:              now,
+	}
+}
+
+func (b *jobSearchBudget) Remaining() time.Duration {
+	if b == nil {
+		return 0
+	}
+	return remainingFromStart(b.remainingAtStart, b.startedAt, b.now)
+}
+
+func (b *jobSearchBudget) ReducedBudget() bool {
+	if b == nil {
+		return false
+	}
+	return b.reducedBudget
+}
+
+func (b *generatorSearchBudget) Remaining() time.Duration {
+	if b == nil {
+		return 0
+	}
+	return remainingFromStart(b.remainingAtStart, b.startedAt, b.now)
+}
+
+func (b *generatorSearchBudget) Exhausted() bool {
+	return b.Remaining() <= 0
+}
+
+func (b *jobSearchBudget) generatorLimit(name string) time.Duration {
+	if b == nil || b.generatorLimits == nil {
+		return 0
+	}
+	if limit, found := b.generatorLimits[name]; found {
+		return limit
+	}
+	return b.generatorLimits[constants.ActionDefault]
+}
+
+func remainingFromStart(limit time.Duration, startedAt time.Time, now func() time.Time) time.Duration {
+	if limit <= 0 || now == nil {
+		return 0
+	}
+	remaining := limit - now().Sub(startedAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
+}
+
+func clockOrDefault(now func() time.Time) func() time.Time {
+	if now == nil {
+		return time.Now
+	}
+	return now
+}
+
+func scenarioSearchBudgets(ssn *framework.Session) *kaiv1.ScenarioSearchBudgets {
+	if ssn == nil || ssn.Config == nil {
+		return nil
+	}
+	return ssn.Config.ScenarioSearchBudgets
+}
+
+func budgetFieldValue(
+	budgets *kaiv1.ScenarioSearchBudgets, valueFn func(*kaiv1.ScenarioSearchBudgets) *metav1.Duration,
+) *metav1.Duration {
+	if budgets == nil {
+		return nil
+	}
+	return valueFn(budgets)
+}
+
+func parseActionLimit(budgets *kaiv1.ScenarioSearchBudgets, action framework.ActionType) (time.Duration, error) {
+	configuredLimits, err := parseDurationMap(
+		"maxActionSearchDuration", actionLimitValues(budgets),
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	actionKey := scenarioSearchActionKey(action)
+	if limit, found := configuredLimits[actionKey]; found {
+		return limit, nil
+	}
+	if limit, found := configuredLimits[constants.ActionDefault]; found {
+		return limit, nil
+	}
+	return mustParseDuration(defaultActionLimit()), nil
+}
+
+func parseGeneratorLimits(budgets *kaiv1.ScenarioSearchBudgets) (map[string]time.Duration, error) {
+	configuredLimits, err := parseDurationMap(
+		"maxGeneratorSearchDuration", generatorLimitValues(budgets),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultLimit, hasConfiguredDefault := configuredLimits[constants.ActionDefault]
+	if !hasConfiguredDefault {
+		defaultLimit = mustParseDuration(constants.DefaultGeneratorBudget)
+	}
+
+	generatorLimits := map[string]time.Duration{
+		constants.ActionDefault: defaultLimit,
+	}
+	for name, limit := range configuredLimits {
+		if name != constants.ActionDefault {
+			generatorLimits[name] = limit
+		}
+	}
+	setKnownGeneratorLimit(
+		generatorLimits, configuredLimits, constants.GeneratorNodeLocalGreedy,
+		constants.DefaultNodeLocalGreedy, defaultLimit, hasConfiguredDefault,
+	)
+	setKnownGeneratorLimit(
+		generatorLimits, configuredLimits, constants.GeneratorMultiNodeGang,
+		constants.DefaultMultiNodeGang, defaultLimit, hasConfiguredDefault,
+	)
+	return generatorLimits, nil
+}
+
+func setKnownGeneratorLimit(
+	generatorLimits map[string]time.Duration,
+	configuredLimits map[string]time.Duration,
+	name string,
+	defaultValue string,
+	defaultLimit time.Duration,
+	hasConfiguredDefault bool,
+) {
+	if _, found := configuredLimits[name]; found {
+		return
+	}
+	if hasConfiguredDefault {
+		generatorLimits[name] = defaultLimit
+		return
+	}
+	generatorLimits[name] = mustParseDuration(defaultValue)
+}
+
+func actionLimitValues(budgets *kaiv1.ScenarioSearchBudgets) map[string]metav1.Duration {
+	if budgets == nil {
+		return nil
+	}
+	return budgets.MaxActionSearchDuration
+}
+
+func generatorLimitValues(budgets *kaiv1.ScenarioSearchBudgets) map[string]metav1.Duration {
+	if budgets == nil {
+		return nil
+	}
+	return budgets.MaxGeneratorSearchDuration
+}
+
+func parseDurationWithDefault(fieldName string, value *metav1.Duration, defaultValue string) (time.Duration, error) {
+	if value == nil {
+		return validateDuration(fieldName, mustParseDuration(defaultValue))
+	}
+	return validateDuration(fieldName, value.Duration)
+}
+
+func parseDurationMap(fieldName string, durationValues map[string]metav1.Duration) (map[string]time.Duration, error) {
+	durations := map[string]time.Duration{}
+	for key, durationValue := range durationValues {
+		duration, err := validateDuration(fmt.Sprintf("%s[%q]", fieldName, key), durationValue.Duration)
+		if err != nil {
+			return nil, err
+		}
+		durations[key] = duration
+	}
+	return durations, nil
+}
+
+func validateDuration(fieldName string, duration time.Duration) (time.Duration, error) {
+	if duration < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", fieldName)
+	}
+	return duration, nil
+}
+
+func mustParseDuration(value string) time.Duration {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		panic(err)
+	}
+	return duration
+}
+
+func scenarioSearchActionKey(action framework.ActionType) string {
+	switch action {
+	case framework.Reclaim:
+		return constants.ActionReclaim
+	case framework.Preempt:
+		return constants.ActionPreempt
+	case framework.Consolidation:
+		return constants.ActionConsolidation
+	default:
+		return constants.ActionDefault
+	}
+}
+
+func defaultActionLimit() string {
+	return constants.DefaultActionBudget
+}

--- a/pkg/scheduler/actions/common/solvers/search_budget.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget.go
@@ -153,6 +153,10 @@ func (b *jobSearchBudget) Remaining() time.Duration {
 	return b.deadline.Remaining()
 }
 
+func (b *jobSearchBudget) Exhausted() bool {
+	return b.Remaining() <= 0
+}
+
 func (b *jobSearchBudget) ReducedBudget() bool {
 	if b == nil {
 		return false

--- a/pkg/scheduler/actions/common/solvers/search_budget.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget.go
@@ -33,9 +33,9 @@ type deadlineBudget struct {
 }
 
 type jobSearchBudget struct {
-	deadline      deadlineBudget
-	reducedBudget bool
-	actionBudget  *ActionSearchBudget
+	deadline        deadlineBudget
+	reducedBudget   bool
+	generatorLimits map[string]time.Duration
 }
 
 type generatorSearchBudget struct {
@@ -109,9 +109,9 @@ func (b *ActionSearchBudget) BeginJob() *jobSearchBudget {
 	}
 
 	return &jobSearchBudget{
-		deadline:      newDeadlineBudget(remaining, now),
-		reducedBudget: b.jobLimit > 0 && actionRemaining < b.jobLimit,
-		actionBudget:  b,
+		deadline:        newDeadlineBudget(remaining, now),
+		reducedBudget:   b.jobLimit > 0 && actionRemaining < b.jobLimit,
+		generatorLimits: b.generatorLimits,
 	}
 }
 
@@ -176,13 +176,13 @@ func (b *generatorSearchBudget) Exhausted() bool {
 }
 
 func (b *jobSearchBudget) generatorLimit(name string) time.Duration {
-	if b == nil || b.actionBudget == nil || b.actionBudget.generatorLimits == nil {
+	if b == nil || b.generatorLimits == nil {
 		return 0
 	}
-	if limit, found := b.actionBudget.generatorLimits[name]; found {
+	if limit, found := b.generatorLimits[name]; found {
 		return limit
 	}
-	return b.actionBudget.generatorLimits[constants.ActionDefault]
+	return b.generatorLimits[constants.ActionDefault]
 }
 
 func newDeadlineBudget(remaining time.Duration, now func() time.Time) deadlineBudget {
@@ -224,10 +224,10 @@ func (b *ActionSearchBudget) clock() func() time.Time {
 }
 
 func (b *jobSearchBudget) clock() func() time.Time {
-	if b == nil || b.actionBudget == nil {
+	if b == nil {
 		return time.Now
 	}
-	return b.actionBudget.clock()
+	return clockOrDefault(b.deadline.now)
 }
 
 func searchDurationForLimit(limit time.Duration) time.Duration {

--- a/pkg/scheduler/actions/common/solvers/search_budget_test.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget_test.go
@@ -1,0 +1,341 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.now
+}
+
+func (c *fakeClock) Advance(duration time.Duration) {
+	c.now = c.now.Add(duration)
+}
+
+func TestActionSearchBudgetDefaults(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+
+	budget, err := newActionSearchBudgetWithClock(&framework.Session{}, framework.Reclaim, clock.Now)
+
+	require.NoError(t, err)
+	require.Equal(t, framework.Reclaim, budget.action)
+	require.Equal(t, 5*time.Minute, budget.actionLimit)
+	require.Equal(t, 4*time.Minute, budget.jobLimit)
+	require.Equal(t, time.Duration(0), budget.minJobSearch)
+	require.Equal(t, 30*time.Second, budget.generatorLimits[constants.GeneratorNodeLocalGreedy])
+	require.Equal(t, 2*time.Minute, budget.generatorLimits[constants.GeneratorMultiNodeGang])
+	require.Equal(t, 2*time.Minute, budget.generatorLimits[constants.ActionDefault])
+}
+
+func TestActionSearchBudgetUsesConfiguredDurations(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	ssn := sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+		MaxActionSearchDuration: map[string]metav1.Duration{
+			constants.ActionDefault: scenarioSearchDurationForTest("30s"),
+			constants.ActionPreempt: scenarioSearchDurationForTest("3s"),
+		},
+		MaxJobSearchDuration: scenarioSearchDurationPtrForTest("750ms"),
+		MinJobSearchDuration: scenarioSearchDurationPtrForTest("100ms"),
+		MaxGeneratorSearchDuration: map[string]metav1.Duration{
+			constants.ActionDefault:            scenarioSearchDurationForTest("400ms"),
+			constants.GeneratorNodeLocalGreedy: scenarioSearchDurationForTest("75ms"),
+		},
+	})
+
+	budget, err := newActionSearchBudgetWithClock(ssn, framework.Preempt, clock.Now)
+
+	require.NoError(t, err)
+	require.Equal(t, 3*time.Second, budget.actionLimit)
+	require.Equal(t, 750*time.Millisecond, budget.jobLimit)
+	require.Equal(t, 100*time.Millisecond, budget.minJobSearch)
+	require.Equal(t, 75*time.Millisecond, budget.generatorLimits[constants.GeneratorNodeLocalGreedy])
+	require.Equal(t, 400*time.Millisecond, budget.generatorLimits[constants.GeneratorMultiNodeGang])
+	require.Equal(t, 400*time.Millisecond, budget.generatorLimits[constants.ActionDefault])
+}
+
+func TestActionSearchBudgetRejectsNegativeDurations(t *testing.T) {
+	tests := []struct {
+		name    string
+		budgets *kaiv1.ScenarioSearchBudgets
+	}{
+		{
+			name: "action",
+			budgets: &kaiv1.ScenarioSearchBudgets{
+				MaxActionSearchDuration: map[string]metav1.Duration{
+					constants.ActionReclaim: scenarioSearchDurationForTest("-1s"),
+				},
+			},
+		},
+		{
+			name: "job",
+			budgets: &kaiv1.ScenarioSearchBudgets{
+				MaxJobSearchDuration: scenarioSearchDurationPtrForTest("-1s"),
+			},
+		},
+		{
+			name: "min job",
+			budgets: &kaiv1.ScenarioSearchBudgets{
+				MinJobSearchDuration: scenarioSearchDurationPtrForTest("-1s"),
+			},
+		},
+		{
+			name: "generator",
+			budgets: &kaiv1.ScenarioSearchBudgets{
+				MaxGeneratorSearchDuration: map[string]metav1.Duration{
+					constants.GeneratorNodeLocalGreedy: scenarioSearchDurationForTest("-1s"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newActionSearchBudgetWithClock(
+				sessionWithScenarioSearchBudgets(test.budgets),
+				framework.Reclaim,
+				time.Now,
+			)
+
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestActionSearchBudgetRejectsMinJobAtOrAboveMaxJob(t *testing.T) {
+	tests := []struct {
+		name string
+		min  string
+		max  string
+	}{
+		{
+			name: "equal",
+			min:  "250ms",
+			max:  "250ms",
+		},
+		{
+			name: "above",
+			min:  "251ms",
+			max:  "250ms",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newActionSearchBudgetWithClock(
+				sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+					MaxJobSearchDuration: scenarioSearchDurationPtrForTest(test.max),
+					MinJobSearchDuration: scenarioSearchDurationPtrForTest(test.min),
+				}),
+				framework.Reclaim,
+				time.Now,
+			)
+
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestBeginJobMarksReducedBudgetWhenRemainingBelowMin(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("100ms"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+			MinJobSearchDuration: scenarioSearchDurationPtrForTest("50ms"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	clock.Advance(75 * time.Millisecond)
+	jobBudget := budget.BeginJob()
+
+	require.True(t, jobBudget.ReducedBudget())
+	require.Equal(t, 25*time.Millisecond, jobBudget.Remaining())
+}
+
+func TestBeginJobReturnsNotAttemptedWhenActionBudgetExpired(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("100ms"),
+			},
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	clock.Advance(100 * time.Millisecond)
+	jobBudget := budget.BeginJob()
+
+	require.False(t, jobBudget.ReducedBudget())
+	require.True(t, budget.Exhausted())
+	require.Equal(t, time.Duration(0), jobBudget.Remaining())
+}
+
+func TestNilActionSearchBudgetBeginJobAndGeneratorAreSafe(t *testing.T) {
+	var budget *ActionSearchBudget
+
+	var jobBudget *jobSearchBudget
+	var generatorBudget *generatorSearchBudget
+	require.NotPanics(t, func() {
+		jobBudget = budget.BeginJob()
+		generatorBudget = jobBudget.BeginGenerator("x")
+	})
+
+	require.False(t, jobBudget.ReducedBudget())
+	require.Equal(t, time.Duration(0), jobBudget.Remaining())
+	require.True(t, generatorBudget.Exhausted())
+	require.Equal(t, time.Duration(0), generatorBudget.Remaining())
+}
+
+func TestUnlimitedActionBudgetUsesJobLimit(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("0"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("100ms"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	require.False(t, budget.Exhausted())
+	require.Equal(t, unlimitedRemaining, budget.Remaining())
+
+	jobBudget := budget.BeginJob()
+	require.False(t, jobBudget.ReducedBudget())
+	require.Equal(t, 100*time.Millisecond, jobBudget.Remaining())
+}
+
+func TestUnlimitedJobBudgetUsesActionRemaining(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("500ms"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("0"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	clock.Advance(100 * time.Millisecond)
+	jobBudget := budget.BeginJob()
+	require.Equal(t, 400*time.Millisecond, jobBudget.Remaining())
+
+	clock.Advance(250 * time.Millisecond)
+	require.Equal(t, 150*time.Millisecond, jobBudget.Remaining())
+}
+
+func TestGeneratorBudgetUsesSpecificThenDefaultLimit(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("1s"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+			MaxGeneratorSearchDuration: map[string]metav1.Duration{
+				constants.ActionDefault:            scenarioSearchDurationForTest("400ms"),
+				constants.GeneratorNodeLocalGreedy: scenarioSearchDurationForTest("75ms"),
+			},
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	jobBudget := budget.BeginJob()
+	require.Equal(t, 75*time.Millisecond, jobBudget.BeginGenerator(constants.GeneratorNodeLocalGreedy).Remaining())
+	require.Equal(t, 400*time.Millisecond, jobBudget.BeginGenerator("unknown").Remaining())
+	require.Equal(t, 400*time.Millisecond, jobBudget.BeginGenerator(constants.GeneratorMultiNodeGang).Remaining())
+}
+
+func TestGeneratorBudgetMovesToNextGeneratorWhenExpired(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("1s"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+			MaxGeneratorSearchDuration: map[string]metav1.Duration{
+				constants.ActionDefault:            scenarioSearchDurationForTest("200ms"),
+				constants.GeneratorNodeLocalGreedy: scenarioSearchDurationForTest("50ms"),
+				constants.GeneratorMultiNodeGang:   scenarioSearchDurationForTest("0"),
+			},
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	jobBudget := budget.BeginJob()
+	firstGeneratorBudget := jobBudget.BeginGenerator(constants.GeneratorNodeLocalGreedy)
+	clock.Advance(60 * time.Millisecond)
+
+	require.True(t, firstGeneratorBudget.Exhausted())
+	require.Equal(t, time.Duration(0), firstGeneratorBudget.Remaining())
+
+	secondGeneratorBudget := jobBudget.BeginGenerator(constants.GeneratorMultiNodeGang)
+	clock.Advance(500 * time.Millisecond)
+
+	require.False(t, secondGeneratorBudget.Exhausted())
+	require.Equal(t, 440*time.Millisecond, secondGeneratorBudget.Remaining())
+}
+
+func TestSearchResultNilReceiver(t *testing.T) {
+	var result *SearchResult
+
+	require.Empty(t, result.Reason())
+	require.False(t, result.ReducedBudget())
+	require.False(t, result.EnteredSearch())
+}
+
+func sessionWithScenarioSearchBudgets(budgets *kaiv1.ScenarioSearchBudgets) *framework.Session {
+	return &framework.Session{
+		Config: &conf.SchedulerConfiguration{
+			ScenarioSearchBudgets: budgets,
+		},
+	}
+}
+
+func scenarioSearchDurationForTest(value string) metav1.Duration {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		panic(err)
+	}
+	return metav1.Duration{Duration: duration}
+}
+
+func scenarioSearchDurationPtrForTest(value string) *metav1.Duration {
+	return ptr.To(scenarioSearchDurationForTest(value))
+}

--- a/pkg/scheduler/actions/common/solvers/search_budget_test.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget_test.go
@@ -152,7 +152,7 @@ func TestActionSearchBudgetRejectsMinJobAtOrAboveMaxJob(t *testing.T) {
 	}
 }
 
-func TestBeginJobMarksReducedBudgetWhenRemainingBelowMin(t *testing.T) {
+func TestBeginJobGuaranteesMinSearchWhenRemainingBelowMin(t *testing.T) {
 	clock := &fakeClock{now: time.Unix(0, 0)}
 	budget, err := newActionSearchBudgetWithClock(
 		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
@@ -171,7 +171,52 @@ func TestBeginJobMarksReducedBudgetWhenRemainingBelowMin(t *testing.T) {
 	jobBudget := budget.BeginJob()
 
 	require.True(t, jobBudget.ReducedBudget())
-	require.Equal(t, 25*time.Millisecond, jobBudget.Remaining())
+	require.Equal(t, 50*time.Millisecond, jobBudget.Remaining())
+}
+
+func TestBeginJobMarksReducedBudgetWhenRemainingBelowJobLimit(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("1s"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("500ms"),
+			MinJobSearchDuration: scenarioSearchDurationPtrForTest("50ms"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	clock.Advance(750 * time.Millisecond)
+	jobBudget := budget.BeginJob()
+
+	require.True(t, jobBudget.ReducedBudget())
+	require.Equal(t, 250*time.Millisecond, jobBudget.Remaining())
+}
+
+func TestBeginJobGuaranteesMinSearchWhenActionBudgetExpired(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	budget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("100ms"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+			MinJobSearchDuration: scenarioSearchDurationPtrForTest("50ms"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	clock.Advance(100 * time.Millisecond)
+	jobBudget := budget.BeginJob()
+
+	require.True(t, budget.Exhausted())
+	require.True(t, jobBudget.ReducedBudget())
+	require.Equal(t, 50*time.Millisecond, jobBudget.Remaining())
 }
 
 func TestBeginJobReturnsNotAttemptedWhenActionBudgetExpired(t *testing.T) {
@@ -190,7 +235,7 @@ func TestBeginJobReturnsNotAttemptedWhenActionBudgetExpired(t *testing.T) {
 	clock.Advance(100 * time.Millisecond)
 	jobBudget := budget.BeginJob()
 
-	require.False(t, jobBudget.ReducedBudget())
+	require.True(t, jobBudget.ReducedBudget())
 	require.True(t, budget.Exhausted())
 	require.Equal(t, time.Duration(0), jobBudget.Remaining())
 }

--- a/pkg/scheduler/actions/common/solvers/search_budget_test.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget_test.go
@@ -237,6 +237,7 @@ func TestBeginJobReturnsNotAttemptedWhenActionBudgetExpired(t *testing.T) {
 
 	require.True(t, jobBudget.ReducedBudget())
 	require.True(t, budget.Exhausted())
+	require.True(t, jobBudget.Exhausted())
 	require.Equal(t, time.Duration(0), jobBudget.Remaining())
 }
 

--- a/pkg/scheduler/actions/common/solvers/search_result.go
+++ b/pkg/scheduler/actions/common/solvers/search_result.go
@@ -1,0 +1,61 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+// SearchResultReason describes why a scenario search stopped.
+type SearchResultReason string
+
+const (
+	SearchResultSolved              SearchResultReason = "solved"
+	SearchResultDeadlineExhausted   SearchResultReason = "deadline_exhausted"
+	SearchResultGeneratorsExhausted SearchResultReason = "generators_exhausted"
+	SearchResultNoGenerator         SearchResultReason = "no_generator"
+	SearchResultNotAttempted        SearchResultReason = "not_attempted"
+)
+
+// SearchResult records the outcome and budget state of a scenario search attempt.
+type SearchResult struct {
+	reason        SearchResultReason
+	solution      *solutionResult
+	reducedBudget bool
+	enteredSearch bool
+}
+
+func (r *SearchResult) Reason() SearchResultReason {
+	if r == nil {
+		return ""
+	}
+	return r.reason
+}
+
+func (r *SearchResult) ReducedBudget() bool {
+	if r == nil {
+		return false
+	}
+	return r.reducedBudget
+}
+
+func (r *SearchResult) EnteredSearch() bool {
+	if r == nil {
+		return false
+	}
+	return r.enteredSearch
+}
+
+func solvedSearchResult(solution *solutionResult, reducedBudget bool) *SearchResult {
+	return &SearchResult{
+		reason:        SearchResultSolved,
+		solution:      solution,
+		reducedBudget: reducedBudget,
+		enteredSearch: true,
+	}
+}
+
+func terminalSearchResult(reason SearchResultReason, reducedBudget bool, enteredSearch bool) *SearchResult {
+	return &SearchResult{
+		reason:        reason,
+		reducedBudget: reducedBudget,
+		enteredSearch: enteredSearch,
+	}
+}

--- a/pkg/scheduler/actions/common/solvers/search_result.go
+++ b/pkg/scheduler/actions/common/solvers/search_result.go
@@ -17,7 +17,6 @@ const (
 // SearchResult records the outcome and budget state of a scenario search attempt.
 type SearchResult struct {
 	reason        SearchResultReason
-	solution      *solutionResult
 	reducedBudget bool
 	enteredSearch bool
 }
@@ -41,21 +40,4 @@ func (r *SearchResult) EnteredSearch() bool {
 		return false
 	}
 	return r.enteredSearch
-}
-
-func solvedSearchResult(solution *solutionResult, reducedBudget bool) *SearchResult {
-	return &SearchResult{
-		reason:        SearchResultSolved,
-		solution:      solution,
-		reducedBudget: reducedBudget,
-		enteredSearch: true,
-	}
-}
-
-func terminalSearchResult(reason SearchResultReason, reducedBudget bool, enteredSearch bool) *SearchResult {
-	return &SearchResult{
-		reason:        reason,
-		reducedBudget: reducedBudget,
-		enteredSearch: enteredSearch,
-	}
 }


### PR DESCRIPTION
## Description

Stack slice 3 of 9 for the reclaim generator portfolio.

References:
- Full implementation PR: #1716
- Design: #1696 (`docs/developer/designs/reclaim-generator-portfolio-design.md`)
- Original issue: #1660

This PR adds the search budget model:
- Adds `ActionSearchBudget`.
- Adds job/generator budget tracking, parsing, and default fallback behavior.
- Adds `SearchResult` for later solver outcome reporting.

Runtime behavior remains unchanged beyond making these model types and helpers available to later PRs.

## Related Issues

Related to #1660.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Stacking:
- Base: `erez/reclaim-generator-portfolio-02-generator-registration`
- Next PR: `erez/reclaim-generator-portfolio-04-wire-budgets`

Verification for the rebuilt stack:
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache go test ./pkg/scheduler/plugins/scenariogenerators ./pkg/scheduler/conf_util ./pkg/operator/operands/scheduler ./pkg/scheduler/actions/common/solvers ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/preempt ./pkg/scheduler/actions/consolidation ./pkg/scheduler/actions/integration_tests/reclaim ./pkg/scheduler/cache ./pkg/scheduler/cache/status_updater ./pkg/scheduler/metrics ./pkg/apis/scheduling/v2alpha2 -count=1`
- `git diff --check`
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache make validate`
