### PR TITLE
feat(scheduler): wire scenario search budgets into solver

### DIFF
--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -57,13 +57,6 @@ func NewJobsSolver(
 	}
 }
 
-func (s *JobSolver) ensureActionBudget() *ActionSearchBudget {
-	if s.actionBudget == nil {
-		s.actionBudget = newUnlimitedActionSearchBudget(s.actionType)
-	}
-	return s.actionBudget
-}
-
 func newUnlimitedActionSearchBudget(action framework.ActionType) *ActionSearchBudget {
 	now := time.Now
 	return &ActionSearchBudget{
@@ -102,30 +95,25 @@ func (s *JobSolver) SolveWithResult(
 	n := len(tasksToAllocate)
 	if n == 0 {
 		return false, nil, calcVictimNames(state.recordedVictimsTasks),
-			terminalSearchResult(SearchResultGeneratorsExhausted, false, false)
+			terminalSearchResult(SearchResultGeneratorsExhausted, false)
 	}
 
-	actionBudget := s.ensureActionBudget()
-	jobBudget := actionBudget.BeginJob()
+	jobBudget := s.actionBudget.BeginJob()
 	if jobBudget.Exhausted() {
 		return false, nil, calcVictimNames(state.recordedVictimsTasks),
-			terminalSearchResult(SearchResultNotAttempted, false, false)
+			terminalSearchResult(SearchResultNotAttempted, false)
 	}
 
-	enteredSearch := false
 	maxSolvedK, searchResult := s.searchMaxSolvableK(ssn, &state, pendingJob, tasksToAllocate, jobBudget)
-	enteredSearch = searchResultEntered(searchResult) || maxSolvedK > 0
 	if maxSolvedK == 0 {
 		if searchResult == nil {
-			searchResult = terminalSearchResult(SearchResultGeneratorsExhausted, false, false)
+			searchResult = terminalSearchResult(SearchResultGeneratorsExhausted, false)
 		}
-		preserveEnteredSearch(searchResult, enteredSearch)
 		return false, nil, calcVictimNames(state.recordedVictimsTasks), searchResult
 	}
 
 	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n, jobBudget)
 	if !resultSolved(result) {
-		preserveEnteredSearch(result, enteredSearch)
 		return false, nil, calcVictimNames(state.recordedVictimsTasks), result
 	}
 
@@ -172,13 +160,10 @@ func searchMaxSolvableK(n int, probe func(k int) *SearchResult) (int, *SearchRes
 	lo := 0
 	var hi int
 	var lastUnsolvedResult *SearchResult
-	enteredSearch := false
 	k := 1
 	for {
 		result := probe(k)
-		enteredSearch = enteredSearch || searchResultEntered(result) || resultSolved(result)
 		if shouldStopSearch(result) {
-			preserveEnteredSearch(result, enteredSearch)
 			return 0, result
 		}
 		if !resultSolved(result) {
@@ -199,9 +184,7 @@ func searchMaxSolvableK(n int, probe func(k int) *SearchResult) (int, *SearchRes
 	for hi-lo > 1 {
 		mid := (lo + hi) / 2
 		result := probe(mid)
-		enteredSearch = enteredSearch || searchResultEntered(result) || resultSolved(result)
 		if shouldStopSearch(result) {
-			preserveEnteredSearch(result, enteredSearch)
 			return 0, result
 		}
 		if resultSolved(result) {
@@ -260,7 +243,7 @@ func (s *JobSolver) solvePartialJob(
 	jobBudget *jobSearchBudget,
 ) *SearchResult {
 	if jobBudget == nil {
-		jobBudget = s.ensureActionBudget().BeginJob()
+		jobBudget = newUnlimitedActionSearchBudget(s.actionType).BeginJob()
 	}
 
 	feasibleNodeMap := map[string]*node_info.NodeInfo{}
@@ -273,21 +256,20 @@ func (s *JobSolver) solvePartialJob(
 	}
 
 	if s.generateVictimsQueue == nil {
-		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget(), false)
+		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
 	}
 	victimsQueue := s.generateVictimsQueue()
 	if victimsQueue == nil {
-		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget(), false)
+		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
 	}
 
 	scenarioBuilder := NewPodAccumulatedScenarioBuilder(
 		ssn, partialPendingJob, state.recordedVictimsJobs, victimsQueue, feasibleNodeMap)
 
-	enteredSearch := false
 	firstScenario := true
 	for {
 		if jobBudget.Exhausted() {
-			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
+			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget())
 		}
 		var scenarioToSolve *solverscenario.ByNodeScenario
 		if firstScenario {
@@ -296,16 +278,9 @@ func (s *JobSolver) solvePartialJob(
 		} else {
 			scenarioToSolve = scenarioBuilder.GetNextScenario()
 		}
-		if jobBudget.Exhausted() {
-			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
-		}
 		if scenarioToSolve == nil {
-			if jobBudget.Exhausted() {
-				return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
-			}
 			break
 		}
-		enteredSearch = true
 		scenarioSolver := newByPodSolver(feasibleNodeMap, s.solutionValidator, ssn.AllowConsolidatingReclaim(),
 			s.actionType)
 
@@ -318,17 +293,7 @@ func (s *JobSolver) solvePartialJob(
 		}
 	}
 
-	return terminalSearchResult(SearchResultGeneratorsExhausted, jobBudget.ReducedBudget(), enteredSearch)
-}
-
-func searchResultEntered(result *SearchResult) bool {
-	return result != nil && result.EnteredSearch()
-}
-
-func preserveEnteredSearch(result *SearchResult, enteredSearch bool) {
-	if result != nil && enteredSearch {
-		result.enteredSearch = true
-	}
+	return terminalSearchResult(SearchResultGeneratorsExhausted, jobBudget.ReducedBudget())
 }
 
 func shouldStopSearch(result *SearchResult) bool {

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -107,7 +107,7 @@ func (s *JobSolver) SolveWithResult(
 
 	actionBudget := s.ensureActionBudget()
 	jobBudget := actionBudget.BeginJob()
-	if jobBudget.Remaining() <= 0 {
+	if jobBudget.Exhausted() {
 		return false, nil, calcVictimNames(state.recordedVictimsTasks),
 			terminalSearchResult(SearchResultNotAttempted, false, false)
 	}
@@ -286,7 +286,7 @@ func (s *JobSolver) solvePartialJob(
 	enteredSearch := false
 	firstScenario := true
 	for {
-		if jobBudget.Remaining() <= 0 {
+		if jobBudget.Exhausted() {
 			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
 		}
 		var scenarioToSolve *solverscenario.ByNodeScenario
@@ -296,11 +296,11 @@ func (s *JobSolver) solvePartialJob(
 		} else {
 			scenarioToSolve = scenarioBuilder.GetNextScenario()
 		}
-		if jobBudget.Remaining() <= 0 {
+		if jobBudget.Exhausted() {
 			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
 		}
 		if scenarioToSolve == nil {
-			if jobBudget.Remaining() <= 0 {
+			if jobBudget.Exhausted() {
 				return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
 			}
 			break

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -67,9 +67,8 @@ func (s *JobSolver) ensureActionBudget() *ActionSearchBudget {
 func newUnlimitedActionSearchBudget(action framework.ActionType) *ActionSearchBudget {
 	now := time.Now
 	return &ActionSearchBudget{
-		action:    action,
-		startedAt: now(),
-		now:       now,
+		action:   action,
+		deadline: newDeadlineBudget(unlimitedRemaining, now),
 	}
 }
 
@@ -108,7 +107,7 @@ func (s *JobSolver) SolveWithResult(
 
 	actionBudget := s.ensureActionBudget()
 	jobBudget := actionBudget.BeginJob()
-	if actionBudget.Exhausted() {
+	if jobBudget.Remaining() <= 0 {
 		return false, nil, calcVictimNames(state.recordedVictimsTasks),
 			terminalSearchResult(SearchResultNotAttempted, false, false)
 	}
@@ -260,9 +259,8 @@ func (s *JobSolver) solvePartialJob(
 	ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo,
 	jobBudget *jobSearchBudget,
 ) *SearchResult {
-	actionBudget := s.ensureActionBudget()
 	if jobBudget == nil {
-		jobBudget = actionBudget.BeginJob()
+		jobBudget = s.ensureActionBudget().BeginJob()
 	}
 
 	feasibleNodeMap := map[string]*node_info.NodeInfo{}
@@ -288,7 +286,7 @@ func (s *JobSolver) solvePartialJob(
 	enteredSearch := false
 	firstScenario := true
 	for {
-		if actionBudget.Exhausted() || jobBudget.Remaining() <= 0 {
+		if jobBudget.Remaining() <= 0 {
 			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
 		}
 		var scenarioToSolve *solverscenario.ByNodeScenario
@@ -298,11 +296,11 @@ func (s *JobSolver) solvePartialJob(
 		} else {
 			scenarioToSolve = scenarioBuilder.GetNextScenario()
 		}
-		if actionBudget.Exhausted() || jobBudget.Remaining() <= 0 {
+		if jobBudget.Remaining() <= 0 {
 			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
 		}
 		if scenarioToSolve == nil {
-			if actionBudget.Exhausted() || jobBudget.Remaining() <= 0 {
+			if jobBudget.Remaining() <= 0 {
 				return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
 			}
 			break

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -6,7 +6,9 @@ package solvers
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	solverscenario "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -24,6 +26,7 @@ type JobSolver struct {
 	solutionValidator    SolutionValidator
 	generateVictimsQueue GenerateVictimsQueue
 	actionType           framework.ActionType
+	actionBudget         *ActionSearchBudget
 }
 
 type solvingState struct {
@@ -36,12 +39,37 @@ func NewJobsSolver(
 	solutionValidator SolutionValidator,
 	generateVictimsQueue GenerateVictimsQueue,
 	action framework.ActionType,
+	actionBudget ...*ActionSearchBudget,
 ) *JobSolver {
+	var budget *ActionSearchBudget
+	if len(actionBudget) > 0 {
+		budget = actionBudget[0]
+	}
+	if budget == nil {
+		budget = newUnlimitedActionSearchBudget(action)
+	}
 	return &JobSolver{
 		feasibleNodes:        feasibleNodes,
 		solutionValidator:    solutionValidator,
 		generateVictimsQueue: generateVictimsQueue,
 		actionType:           action,
+		actionBudget:         budget,
+	}
+}
+
+func (s *JobSolver) ensureActionBudget() *ActionSearchBudget {
+	if s.actionBudget == nil {
+		s.actionBudget = newUnlimitedActionSearchBudget(s.actionType)
+	}
+	return s.actionBudget
+}
+
+func newUnlimitedActionSearchBudget(action framework.ActionType) *ActionSearchBudget {
+	now := time.Now
+	return &ActionSearchBudget{
+		action:    action,
+		startedAt: now(),
+		now:       now,
 	}
 }
 
@@ -59,25 +87,50 @@ func NewJobsSolver(
 // returned statement) and is left unchanged on failure.
 func (s *JobSolver) Solve(
 	ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo) (bool, *framework.Statement, []string) {
+	solved, statement, victimTaskNames, _ := s.SolveWithResult(ssn, pendingJob)
+	return solved, statement, victimTaskNames
+}
+
+// SolveWithResult attempts to solve pendingJob and returns a structured search result
+// describing why the scenario search stopped.
+func (s *JobSolver) SolveWithResult(
+	ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo,
+) (bool, *framework.Statement, []string, *SearchResult) {
 	state := solvingState{}
 	originalNumActiveTasks := pendingJob.GetNumActiveUsedTasks()
 
 	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
 	n := len(tasksToAllocate)
 	if n == 0 {
-		return false, nil, calcVictimNames(state.recordedVictimsTasks)
+		return false, nil, calcVictimNames(state.recordedVictimsTasks),
+			terminalSearchResult(SearchResultGeneratorsExhausted, false, false)
 	}
 
-	maxSolvedK := s.searchMaxSolvableK(ssn, &state, pendingJob, tasksToAllocate)
+	actionBudget := s.ensureActionBudget()
+	jobBudget := actionBudget.BeginJob()
+	if actionBudget.Exhausted() {
+		return false, nil, calcVictimNames(state.recordedVictimsTasks),
+			terminalSearchResult(SearchResultNotAttempted, false, false)
+	}
+
+	enteredSearch := false
+	maxSolvedK, searchResult := s.searchMaxSolvableK(ssn, &state, pendingJob, tasksToAllocate, jobBudget)
+	enteredSearch = searchResultEntered(searchResult) || maxSolvedK > 0
 	if maxSolvedK == 0 {
-		return false, nil, calcVictimNames(state.recordedVictimsTasks)
+		if searchResult == nil {
+			searchResult = terminalSearchResult(SearchResultGeneratorsExhausted, false, false)
+		}
+		preserveEnteredSearch(searchResult, enteredSearch)
+		return false, nil, calcVictimNames(state.recordedVictimsTasks), searchResult
 	}
 
-	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n)
-	if result == nil || !result.solved {
-		return false, nil, calcVictimNames(state.recordedVictimsTasks)
+	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n, jobBudget)
+	if !resultSolved(result) {
+		preserveEnteredSearch(result, enteredSearch)
+		return false, nil, calcVictimNames(state.recordedVictimsTasks), result
 	}
 
+	solution := result.solution
 	numActiveTasks := pendingJob.GetNumActiveUsedTasks()
 	jobSolved := pendingJob.IsGangSatisfied()
 	if originalNumActiveTasks >= numActiveTasks {
@@ -86,8 +139,8 @@ func (s *JobSolver) Solve(
 
 	log.InfraLogger.V(4).Infof(
 		"Scenario solved for %d tasks to allocate for %s. Victims: %s",
-		n, pendingJob.Name, victimPrintingStruct{result.victimsTasks})
-	return jobSolved, result.statement, calcVictimNames(result.victimsTasks)
+		n, pendingJob.Name, victimPrintingStruct{solution.victimsTasks})
+	return jobSolved, solution.statement, calcVictimNames(solution.victimsTasks), result
 }
 
 // searchMaxSolvableK returns the largest k in [0, n] for which a probe at k succeeds.
@@ -100,23 +153,43 @@ func (s *JobSolver) searchMaxSolvableK(
 	state *solvingState,
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
-) int {
+	jobBudget *jobSearchBudget,
+) (int, *SearchResult) {
 	n := len(tasksToAllocate)
 	if n == 0 {
-		return 0
+		return 0, nil
+	}
+
+	return searchMaxSolvableK(n, func(k int) *SearchResult {
+		return s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, k, jobBudget)
+	})
+}
+
+func searchMaxSolvableK(n int, probe func(k int) *SearchResult) (int, *SearchResult) {
+	if n == 0 {
+		return 0, nil
 	}
 
 	lo := 0
 	var hi int
+	var lastUnsolvedResult *SearchResult
+	enteredSearch := false
 	k := 1
 	for {
-		if !s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, k) {
+		result := probe(k)
+		enteredSearch = enteredSearch || searchResultEntered(result) || resultSolved(result)
+		if shouldStopSearch(result) {
+			preserveEnteredSearch(result, enteredSearch)
+			return 0, result
+		}
+		if !resultSolved(result) {
+			lastUnsolvedResult = result
 			hi = k
 			break
 		}
 		lo = k
 		if k == n {
-			return n
+			return n, lastUnsolvedResult
 		}
 		k *= 2
 		if k > n {
@@ -126,39 +199,48 @@ func (s *JobSolver) searchMaxSolvableK(
 
 	for hi-lo > 1 {
 		mid := (lo + hi) / 2
-		if s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, mid) {
+		result := probe(mid)
+		enteredSearch = enteredSearch || searchResultEntered(result) || resultSolved(result)
+		if shouldStopSearch(result) {
+			preserveEnteredSearch(result, enteredSearch)
+			return 0, result
+		}
+		if resultSolved(result) {
 			lo = mid
 		} else {
+			lastUnsolvedResult = result
 			hi = mid
 		}
 	}
-	return lo
+	return lo, lastUnsolvedResult
 }
 
-// tryProbeAndDiscard probes at k and always discards the resulting statement so the session
-// is left clean. On success, hints are written to state; returns whether the probe succeeded.
+// tryProbeAndDiscard probes at k and always discards a solved statement so the session
+// is left clean. On success, hints are written to state.
 func (s *JobSolver) tryProbeAndDiscard(
 	ssn *framework.Session,
 	state *solvingState,
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
-) bool {
-	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k)
-	if result == nil || !result.solved {
+	jobBudget *jobSearchBudget,
+) *SearchResult {
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k, jobBudget)
+	if !resultSolved(result) {
 		log.InfraLogger.V(5).Infof("No solution found for %d tasks out of %d tasks to allocate for %s",
 			k, len(tasksToAllocate), pendingJob.Name)
-		return false
+		return result
 	}
+	solution := result.solution
 	log.InfraLogger.V(5).Infof(
 		"Scenario probed for %d tasks out of %d tasks to allocate for %s. Victims: %s",
-		k, len(tasksToAllocate), pendingJob.Name, victimPrintingStruct{result.victimsTasks})
-	state.recordedVictimsTasks = result.victimsTasks
-	state.recordedVictimsJobs = result.victimJobs
-	if result.statement != nil {
-		result.statement.Discard()
+		k, len(tasksToAllocate), pendingJob.Name, victimPrintingStruct{solution.victimsTasks})
+	state.recordedVictimsTasks = solution.victimsTasks
+	state.recordedVictimsJobs = solution.victimJobs
+	if solution.statement != nil {
+		solution.statement.Discard()
 	}
-	return true
+	return result
 }
 
 func (s *JobSolver) probeAtK(
@@ -167,13 +249,22 @@ func (s *JobSolver) probeAtK(
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
-) *solutionResult {
+	jobBudget *jobSearchBudget,
+) *SearchResult {
 	pendingTasks := tasksToAllocate[:k]
 	partialPendingJob := getPartialJobRepresentative(pendingJob, pendingTasks)
-	return s.solvePartialJob(ssn, state, partialPendingJob)
+	return s.solvePartialJob(ssn, state, partialPendingJob, jobBudget)
 }
 
-func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo) *solutionResult {
+func (s *JobSolver) solvePartialJob(
+	ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo,
+	jobBudget *jobSearchBudget,
+) *SearchResult {
+	actionBudget := s.ensureActionBudget()
+	if jobBudget == nil {
+		jobBudget = actionBudget.BeginJob()
+	}
+
 	feasibleNodeMap := map[string]*node_info.NodeInfo{}
 	for _, node := range s.feasibleNodes {
 		feasibleNodeMap[node.Name] = node
@@ -183,11 +274,40 @@ func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState,
 		feasibleNodeMap[task.NodeName] = node
 	}
 
-	scenarioBuilder := NewPodAccumulatedScenarioBuilder(
-		ssn, partialPendingJob, state.recordedVictimsJobs, s.generateVictimsQueue(), feasibleNodeMap)
+	if s.generateVictimsQueue == nil {
+		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget(), false)
+	}
+	victimsQueue := s.generateVictimsQueue()
+	if victimsQueue == nil {
+		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget(), false)
+	}
 
-	for scenarioToSolve := scenarioBuilder.GetValidScenario(); scenarioToSolve != nil; scenarioToSolve =
-		scenarioBuilder.GetNextScenario() {
+	scenarioBuilder := NewPodAccumulatedScenarioBuilder(
+		ssn, partialPendingJob, state.recordedVictimsJobs, victimsQueue, feasibleNodeMap)
+
+	enteredSearch := false
+	firstScenario := true
+	for {
+		if actionBudget.Exhausted() || jobBudget.Remaining() <= 0 {
+			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
+		}
+		var scenarioToSolve *solverscenario.ByNodeScenario
+		if firstScenario {
+			scenarioToSolve = scenarioBuilder.GetValidScenario()
+			firstScenario = false
+		} else {
+			scenarioToSolve = scenarioBuilder.GetNextScenario()
+		}
+		if actionBudget.Exhausted() || jobBudget.Remaining() <= 0 {
+			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
+		}
+		if scenarioToSolve == nil {
+			if actionBudget.Exhausted() || jobBudget.Remaining() <= 0 {
+				return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget(), enteredSearch)
+			}
+			break
+		}
+		enteredSearch = true
 		scenarioSolver := newByPodSolver(feasibleNodeMap, s.solutionValidator, ssn.AllowConsolidatingReclaim(),
 			s.actionType)
 
@@ -196,11 +316,35 @@ func (s *JobSolver) solvePartialJob(ssn *framework.Session, state *solvingState,
 
 		result := scenarioSolver.solve(ssn, scenarioToSolve)
 		if result.solved {
-			return result
+			return solvedSearchResult(result, jobBudget.ReducedBudget())
 		}
 	}
 
-	return nil
+	return terminalSearchResult(SearchResultGeneratorsExhausted, jobBudget.ReducedBudget(), enteredSearch)
+}
+
+func searchResultEntered(result *SearchResult) bool {
+	return result != nil && result.EnteredSearch()
+}
+
+func preserveEnteredSearch(result *SearchResult, enteredSearch bool) {
+	if result != nil && enteredSearch {
+		result.enteredSearch = true
+	}
+}
+
+func shouldStopSearch(result *SearchResult) bool {
+	switch result.Reason() {
+	case SearchResultDeadlineExhausted, SearchResultNotAttempted, SearchResultNoGenerator:
+		return true
+	default:
+		return false
+	}
+}
+
+func resultSolved(result *SearchResult) bool {
+	return result != nil && result.Reason() == SearchResultSolved &&
+		result.solution != nil && result.solution.solved
 }
 
 func getPartialJobRepresentative(

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 )
 
@@ -49,7 +50,6 @@ func TestSolveWithResultReturnsTerminalResultWhenNoTasksToAllocate(t *testing.T)
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultGeneratorsExhausted, result.Reason())
 	require.False(t, result.ReducedBudget())
-	require.False(t, result.EnteredSearch())
 }
 
 func TestSolveWithResultReturnsNoGeneratorWhenGeneratorFuncIsNil(t *testing.T) {
@@ -63,7 +63,6 @@ func TestSolveWithResultReturnsNoGeneratorWhenGeneratorFuncIsNil(t *testing.T) {
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultNoGenerator, result.Reason())
 	require.False(t, result.ReducedBudget())
-	require.False(t, result.EnteredSearch())
 }
 
 func TestSolveWithResultReturnsNoGeneratorWhenGeneratorReturnsNil(t *testing.T) {
@@ -85,7 +84,6 @@ func TestSolveWithResultReturnsNoGeneratorWhenGeneratorReturnsNil(t *testing.T) 
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultNoGenerator, result.Reason())
 	require.False(t, result.ReducedBudget())
-	require.False(t, result.EnteredSearch())
 }
 
 func TestSolveWithResultUsesMinJobBudgetAfterActionBudgetExpired(t *testing.T) {
@@ -113,10 +111,9 @@ func TestSolveWithResultUsesMinJobBudgetAfterActionBudgetExpired(t *testing.T) {
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultNoGenerator, result.Reason())
 	require.True(t, result.ReducedBudget())
-	require.False(t, result.EnteredSearch())
 }
 
-func TestSolveWithResultReportsDeadlineBeforeScenarioSimulation(t *testing.T) {
+func TestSolveWithResultReportsDeadlineWhenBudgetExhaustsDuringScenarioSearch(t *testing.T) {
 	clock := &fakeClock{now: time.Unix(0, 0)}
 	actionBudget, err := newActionSearchBudgetWithClock(
 		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
@@ -130,8 +127,13 @@ func TestSolveWithResultReportsDeadlineBeforeScenarioSimulation(t *testing.T) {
 	)
 	require.NoError(t, err)
 	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	node := node_info.NewNodeInfo(
+		common_info.BuildNode("node-0", common_info.BuildResourceList("4", "16Gi")),
+		nil, resource_info.NewResourceVectorMap(),
+	)
+	ssn.ClusterInfo.Nodes[node.Name] = node
 	solver := NewJobsSolver(
-		nil,
+		[]*node_info.NodeInfo{node},
 		nil,
 		func() *utils.JobsOrderByQueues {
 			clock.Advance(time.Millisecond)
@@ -147,13 +149,12 @@ func TestSolveWithResultReportsDeadlineBeforeScenarioSimulation(t *testing.T) {
 	require.Nil(t, statement)
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
-	require.False(t, result.EnteredSearch())
 }
 
-func TestSearchMaxSolvableKPreservesEnteredSearchAfterTerminalPartialProbe(t *testing.T) {
+func TestSearchMaxSolvableKStopsAfterTerminalPartialProbe(t *testing.T) {
 	probes := map[int]*SearchResult{
 		1: solvedSearchResult(&solutionResult{solved: true}, false),
-		2: terminalSearchResult(SearchResultDeadlineExhausted, false, false),
+		2: terminalSearchResult(SearchResultDeadlineExhausted, false),
 	}
 
 	maxSolvedK, result := searchMaxSolvableK(3, func(k int) *SearchResult {
@@ -162,15 +163,6 @@ func TestSearchMaxSolvableKPreservesEnteredSearchAfterTerminalPartialProbe(t *te
 
 	require.Equal(t, 0, maxSolvedK)
 	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
-	require.True(t, result.EnteredSearch())
-}
-
-func TestPreserveEnteredSearchMarksTerminalResult(t *testing.T) {
-	result := terminalSearchResult(SearchResultDeadlineExhausted, false, false)
-
-	preserveEnteredSearch(result, true)
-
-	require.True(t, result.EnteredSearch())
 }
 
 func newJobSolverResultTestSession(t *testing.T, tasksCount int) (*framework.Session, *podgroup_info.PodGroupInfo) {

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -1,0 +1,168 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestNewJobsSolverDefaultsNilBudgetToUnlimited(t *testing.T) {
+	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim, nil)
+
+	require.NotNil(t, solver.actionBudget)
+	require.False(t, solver.actionBudget.Exhausted())
+	require.Greater(t, solver.actionBudget.BeginJob().Remaining(), time.Hour)
+}
+
+func TestNewJobsSolverDefaultsOmittedBudgetToUnlimited(t *testing.T) {
+	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim)
+
+	require.NotNil(t, solver.actionBudget)
+	require.False(t, solver.actionBudget.Exhausted())
+	require.Greater(t, solver.actionBudget.BeginJob().Remaining(), time.Hour)
+}
+
+func TestSolveWithResultReturnsTerminalResultWhenNoTasksToAllocate(t *testing.T) {
+	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim, nil)
+	pendingJob := podgroup_info.NewPodGroupInfo("pending-job")
+
+	solved, statement, victims, result := solver.SolveWithResult(&framework.Session{}, pendingJob)
+
+	require.False(t, solved)
+	require.Nil(t, statement)
+	require.Empty(t, victims)
+	require.Equal(t, SearchResultGeneratorsExhausted, result.Reason())
+	require.False(t, result.ReducedBudget())
+	require.False(t, result.EnteredSearch())
+}
+
+func TestSolveWithResultReturnsNoGeneratorWhenGeneratorFuncIsNil(t *testing.T) {
+	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim, nil)
+
+	solved, statement, victims, result := solver.SolveWithResult(ssn, pendingJob)
+
+	require.False(t, solved)
+	require.Nil(t, statement)
+	require.Empty(t, victims)
+	require.Equal(t, SearchResultNoGenerator, result.Reason())
+	require.False(t, result.ReducedBudget())
+	require.False(t, result.EnteredSearch())
+}
+
+func TestSolveWithResultReturnsNoGeneratorWhenGeneratorReturnsNil(t *testing.T) {
+	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	solver := NewJobsSolver(
+		nil,
+		nil,
+		func() *utils.JobsOrderByQueues {
+			return nil
+		},
+		framework.Reclaim,
+		nil,
+	)
+
+	solved, statement, victims, result := solver.SolveWithResult(ssn, pendingJob)
+
+	require.False(t, solved)
+	require.Nil(t, statement)
+	require.Empty(t, victims)
+	require.Equal(t, SearchResultNoGenerator, result.Reason())
+	require.False(t, result.ReducedBudget())
+	require.False(t, result.EnteredSearch())
+}
+
+func TestSolveWithResultReportsDeadlineBeforeScenarioSimulation(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	actionBudget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("10ms"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1ms"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	solver := NewJobsSolver(
+		nil,
+		nil,
+		func() *utils.JobsOrderByQueues {
+			clock.Advance(time.Millisecond)
+			return utils.GetVictimsQueue(ssn, nil)
+		},
+		framework.Reclaim,
+		actionBudget,
+	)
+
+	solved, statement, victims, result := solver.SolveWithResult(ssn, pendingJob)
+
+	require.False(t, solved)
+	require.Nil(t, statement)
+	require.Empty(t, victims)
+	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
+	require.False(t, result.EnteredSearch())
+}
+
+func TestSearchMaxSolvableKPreservesEnteredSearchAfterTerminalPartialProbe(t *testing.T) {
+	probes := map[int]*SearchResult{
+		1: solvedSearchResult(&solutionResult{solved: true}, false),
+		2: terminalSearchResult(SearchResultDeadlineExhausted, false, false),
+	}
+
+	maxSolvedK, result := searchMaxSolvableK(3, func(k int) *SearchResult {
+		return probes[k]
+	})
+
+	require.Equal(t, 0, maxSolvedK)
+	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
+	require.True(t, result.EnteredSearch())
+}
+
+func TestPreserveEnteredSearchMarksTerminalResult(t *testing.T) {
+	result := terminalSearchResult(SearchResultDeadlineExhausted, false, false)
+
+	preserveEnteredSearch(result, true)
+
+	require.True(t, result.EnteredSearch())
+}
+
+func newJobSolverResultTestSession(t *testing.T, tasksCount int) (*framework.Session, *podgroup_info.PodGroupInfo) {
+	t.Helper()
+
+	pendingJob, _ := createJobWithTasks(tasksCount, 1, "team-a", v1.PodPending, nil)
+	defaultQueue := createQueue("default")
+	defaultQueue.ParentQueue = ""
+	submitQueue := createQueue("team-a")
+
+	return &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+				pendingJob.UID: pendingJob,
+			},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				defaultQueue.UID: defaultQueue,
+				submitQueue.UID:  submitQueue,
+			},
+			Nodes: map[string]*node_info.NodeInfo{},
+		},
+	}, pendingJob
+}

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -88,6 +88,34 @@ func TestSolveWithResultReturnsNoGeneratorWhenGeneratorReturnsNil(t *testing.T) 
 	require.False(t, result.EnteredSearch())
 }
 
+func TestSolveWithResultUsesMinJobBudgetAfterActionBudgetExpired(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	actionBudget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("10ms"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+			MinJobSearchDuration: scenarioSearchDurationPtrForTest("50ms"),
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim, actionBudget)
+
+	clock.Advance(10 * time.Millisecond)
+	solved, statement, victims, result := solver.SolveWithResult(ssn, pendingJob)
+
+	require.False(t, solved)
+	require.Nil(t, statement)
+	require.Empty(t, victims)
+	require.Equal(t, SearchResultNoGenerator, result.Reason())
+	require.True(t, result.ReducedBudget())
+	require.False(t, result.EnteredSearch())
+}
+
 func TestSolveWithResultReportsDeadlineBeforeScenarioSimulation(t *testing.T) {
 	clock := &fakeClock{now: time.Unix(0, 0)}
 	actionBudget, err := newActionSearchBudgetWithClock(

--- a/pkg/scheduler/actions/common/solvers/search_budget_test.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget_test.go
@@ -363,7 +363,6 @@ func TestSearchResultNilReceiver(t *testing.T) {
 
 	require.Empty(t, result.Reason())
 	require.False(t, result.ReducedBudget())
-	require.False(t, result.EnteredSearch())
 }
 
 func sessionWithScenarioSearchBudgets(budgets *kaiv1.ScenarioSearchBudgets) *framework.Session {

--- a/pkg/scheduler/actions/common/solvers/search_result.go
+++ b/pkg/scheduler/actions/common/solvers/search_result.go
@@ -19,7 +19,6 @@ type SearchResult struct {
 	reason        SearchResultReason
 	solution      *solutionResult
 	reducedBudget bool
-	enteredSearch bool
 }
 
 func (r *SearchResult) Reason() SearchResultReason {
@@ -36,16 +35,9 @@ func (r *SearchResult) ReducedBudget() bool {
 	return r.reducedBudget
 }
 
-func (r *SearchResult) EnteredSearch() bool {
-	if r == nil {
-		return false
-	}
-	return r.enteredSearch
-}
-
 // NewNotAttemptedSearchResult returns a terminal result for callers that skip solver entry.
 func NewNotAttemptedSearchResult() *SearchResult {
-	return terminalSearchResult(SearchResultNotAttempted, false, false)
+	return terminalSearchResult(SearchResultNotAttempted, false)
 }
 
 func solvedSearchResult(solution *solutionResult, reducedBudget bool) *SearchResult {
@@ -53,14 +45,12 @@ func solvedSearchResult(solution *solutionResult, reducedBudget bool) *SearchRes
 		reason:        SearchResultSolved,
 		solution:      solution,
 		reducedBudget: reducedBudget,
-		enteredSearch: true,
 	}
 }
 
-func terminalSearchResult(reason SearchResultReason, reducedBudget bool, enteredSearch bool) *SearchResult {
+func terminalSearchResult(reason SearchResultReason, reducedBudget bool) *SearchResult {
 	return &SearchResult{
 		reason:        reason,
 		reducedBudget: reducedBudget,
-		enteredSearch: enteredSearch,
 	}
 }

--- a/pkg/scheduler/actions/common/solvers/search_result.go
+++ b/pkg/scheduler/actions/common/solvers/search_result.go
@@ -17,6 +17,7 @@ const (
 // SearchResult records the outcome and budget state of a scenario search attempt.
 type SearchResult struct {
 	reason        SearchResultReason
+	solution      *solutionResult
 	reducedBudget bool
 	enteredSearch bool
 }
@@ -40,4 +41,26 @@ func (r *SearchResult) EnteredSearch() bool {
 		return false
 	}
 	return r.enteredSearch
+}
+
+// NewNotAttemptedSearchResult returns a terminal result for callers that skip solver entry.
+func NewNotAttemptedSearchResult() *SearchResult {
+	return terminalSearchResult(SearchResultNotAttempted, false, false)
+}
+
+func solvedSearchResult(solution *solutionResult, reducedBudget bool) *SearchResult {
+	return &SearchResult{
+		reason:        SearchResultSolved,
+		solution:      solution,
+		reducedBudget: reducedBudget,
+		enteredSearch: true,
+	}
+}
+
+func terminalSearchResult(reason SearchResultReason, reducedBudget bool, enteredSearch bool) *SearchResult {
+	return &SearchResult{
+		reason:        reason,
+		reducedBudget: reducedBudget,
+		enteredSearch: enteredSearch,
+	}
 }

--- a/pkg/scheduler/actions/consolidation/consolidation.go
+++ b/pkg/scheduler/actions/consolidation/consolidation.go
@@ -33,6 +33,12 @@ func (alloc *consolidationAction) Execute(ssn *framework.Session) {
 	log.InfraLogger.V(2).Infof("Enter Consolidation ...")
 	defer log.InfraLogger.V(2).Infof("Leaving Consolidation ...")
 
+	actionBudget, err := solvers.NewActionSearchBudget(ssn, framework.Consolidation)
+	if err != nil {
+		log.InfraLogger.Errorf("Invalid scenario search budget for consolidation: %v", err)
+		return
+	}
+
 	if ssn.GetMaxNumberConsolidationPreemptees() == 0 {
 		log.InfraLogger.V(4).Infof("Consolidation is disabled, skipping")
 		return
@@ -70,12 +76,14 @@ func (alloc *consolidationAction) Execute(ssn *framework.Session) {
 		}
 
 		metrics.IncPodgroupsConsideredByAction()
-		if succeeded, stmt := attemptToConsolidateForPreemptor(ssn, job); succeeded {
+		if succeeded, stmt, searchResult := attemptToConsolidateForPreemptor(ssn, job, actionBudget); succeeded {
 			metrics.IncPodgroupScheduledByAction()
 			err := stmt.Commit()
 			if err != nil {
 				log.InfraLogger.Errorf("Failed to commit consolidation statement: %v", err)
 			}
+		} else if shouldStopActionForSearchResult(searchResult) {
+			return
 		} else {
 			smallestFailedJobs.UpdateRepresentative(job)
 		}
@@ -83,7 +91,8 @@ func (alloc *consolidationAction) Execute(ssn *framework.Session) {
 }
 
 func attemptToConsolidateForPreemptor(
-	ssn *framework.Session, job *podgroup_info.PodGroupInfo) (bool, *framework.Statement) {
+	ssn *framework.Session, job *podgroup_info.PodGroupInfo, actionBudget *solvers.ActionSearchBudget,
+) (bool, *framework.Statement, *solvers.SearchResult) {
 	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false, ssn.ClusterInfo.MinNodeGPUMemory)
 	log.InfraLogger.V(3).Infof(
 		"Attempting to consolidate running jobs in order to make room for job: <%s/%s>, resources: <%v>",
@@ -92,32 +101,47 @@ func attemptToConsolidateForPreemptor(
 		log.InfraLogger.V(3).Infof(
 			"Can't consolidate for job: <%v/%v>, not enough allocatable GPUs in the cluster",
 			job.Namespace, job.Name)
-		return false, nil
+		return false, nil, nil
 	}
-	success, stmt := attemptToConsolidatePreemptor(ssn, job)
-	return success, stmt
+	success, stmt, searchResult := attemptToConsolidatePreemptor(ssn, job, actionBudget)
+	return success, stmt, searchResult
 }
 
 func attemptToConsolidatePreemptor(
-	ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo) (bool, *framework.Statement) {
+	ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo, actionBudget *solvers.ActionSearchBudget,
+) (bool, *framework.Statement, *solvers.SearchResult) {
 	feasibleNodes := common.FeasibleNodesForJob(maps.Values(ssn.ClusterInfo.Nodes), preemptor)
 	solver := solvers.NewJobsSolver(
 		feasibleNodes,
 		allPodsReallocated,
 		func() *utils.JobsOrderByQueues { return buildConsolidationVictimsQueue(ssn, preemptor) },
-		framework.Consolidation)
+		framework.Consolidation,
+		actionBudget)
 
-	isScenarioFeasible, stmt, victimsTasksNames := solver.Solve(ssn, preemptor)
+	isScenarioFeasible, stmt, victimsTasksNames, searchResult := solver.SolveWithResult(ssn, preemptor)
 	if isScenarioFeasible {
 		log.InfraLogger.V(3).Infof(
 			"Sucesfully consolidated for job: <%s/%s>, and about to reallocate victims: <%v>",
 			preemptor.Namespace, preemptor.Name, victimsTasksNames)
-		return true, stmt
+		return true, stmt, searchResult
+	}
+
+	if shouldStopActionForSearchResult(searchResult) {
+		return false, nil, searchResult
 	}
 
 	log.InfraLogger.V(3).Infof("Didn't find a consolidation strategy for job: <%v/%v>",
 		preemptor.Namespace, preemptor.Name)
-	return false, nil
+	return false, nil, searchResult
+}
+
+func shouldStopActionForSearchResult(result *solvers.SearchResult) bool {
+	switch result.Reason() {
+	case solvers.SearchResultDeadlineExhausted, solvers.SearchResultNotAttempted:
+		return true
+	default:
+		return false
+	}
 }
 
 func allPodsReallocated(scenario api.ScenarioInfo) bool {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -47,6 +47,12 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 	log.InfraLogger.V(2).Infof("Enter Preempt ...")
 	defer log.InfraLogger.V(2).Infof("Leaving Preempt ...")
 
+	actionBudget, err := solvers.NewActionSearchBudget(ssn, framework.Preempt)
+	if err != nil {
+		log.InfraLogger.Errorf("Invalid scenario search budget for preempt: %v", err)
+		return
+	}
+
 	jobsOrderByQueues := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
 		FilterNonPending:  true,
 		FilterUnready:     true,
@@ -83,7 +89,7 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 		}
 
 		metrics.IncPodgroupsConsideredByAction()
-		succeeded, statement, preemptedTasksNames := attemptToPreemptForPreemptor(ssn, job)
+		succeeded, statement, preemptedTasksNames, searchResult := attemptToPreemptForPreemptor(ssn, job, actionBudget)
 		if succeeded {
 			metrics.RegisterPreemptionAttempts()
 			metrics.IncPodgroupScheduledByAction()
@@ -93,6 +99,8 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 			if err := statement.Commit(); err != nil {
 				log.InfraLogger.Errorf("Failed to commit preemption statement: %v", err)
 			}
+		} else if shouldStopActionForSearchResult(searchResult) {
+			return
 		} else {
 			log.InfraLogger.V(3).Infof("Didn't find a preemption strategy for job <%s/%s>",
 				job.Namespace, job.Name)
@@ -102,8 +110,8 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 }
 
 func attemptToPreemptForPreemptor(
-	ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo,
-) (bool, *framework.Statement, []string) {
+	ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo, actionBudget *solvers.ActionSearchBudget,
+) (bool, *framework.Statement, []string, *solvers.SearchResult) {
 	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(preemptor, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false, ssn.ClusterInfo.MinNodeGPUMemory)
 	log.InfraLogger.V(3).Infof(
 		"Attempting to preempt for job: <%v/%v>, priority: <%v>, queue: <%v>, resources: <%v>",
@@ -113,7 +121,7 @@ func attemptToPreemptForPreemptor(
 	if result := ssn.IsNonPreemptibleJobOverQueueQuotaFn(preemptor, preemptorTasks); !result.IsSchedulable {
 		log.InfraLogger.V(3).Infof("Job <%v/%v> would have placed the queue resources over quota",
 			preemptor.Namespace, preemptor.Name)
-		return false, nil, nil
+		return false, nil, nil, nil
 	}
 
 	feasibleNodes := common.FeasibleNodesForJob(maps.Values(ssn.ClusterInfo.Nodes), preemptor)
@@ -122,8 +130,18 @@ func attemptToPreemptForPreemptor(
 		ssn.PreemptScenarioValidator,
 		getOrderedVictimsQueue(ssn, preemptor),
 		framework.Preempt,
+		actionBudget,
 	)
-	return solver.Solve(ssn, preemptor)
+	return solver.SolveWithResult(ssn, preemptor)
+}
+
+func shouldStopActionForSearchResult(result *solvers.SearchResult) bool {
+	switch result.Reason() {
+	case solvers.SearchResultDeadlineExhausted, solvers.SearchResultNotAttempted:
+		return true
+	default:
+		return false
+	}
 }
 
 func buildFilterFuncForPreempt(ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo) func(*podgroup_info.PodGroupInfo) bool {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -120,10 +120,6 @@ func (ra *reclaimAction) attemptToReclaimForSpecificJob(
 	log.InfraLogger.V(3).Infof("Attempting to reclaim for job: <%v/%v> of queue <%v>, resources: <%v>",
 		reclaimer.Namespace, reclaimer.Name, queue.Name, resReq)
 
-	if actionBudget != nil && actionBudget.Exhausted() {
-		return false, nil, nil, solvers.NewNotAttemptedSearchResult()
-	}
-
 	ssn.OnJobSolutionStart()
 
 	feasibleNodes := common.FeasibleNodesForJob(maps.Values(ssn.ClusterInfo.Nodes), reclaimer)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -48,6 +48,12 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 	log.InfraLogger.V(2).Infof("Enter Reclaim ...")
 	defer log.InfraLogger.V(2).Infof("Leaving Reclaim ...")
 
+	actionBudget, err := solvers.NewActionSearchBudget(ssn, framework.Reclaim)
+	if err != nil {
+		log.InfraLogger.Errorf("Invalid scenario search budget for reclaim: %v", err)
+		return
+	}
+
 	jobsOrderByQueues := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
 		FilterNonPending:  true,
 		FilterUnready:     true,
@@ -86,7 +92,7 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 			continue
 		}
 		metrics.IncPodgroupsConsideredByAction()
-		succeeded, statement, reclaimeeTasksNames := ra.attemptToReclaimForSpecificJob(ssn, job)
+		succeeded, statement, reclaimeeTasksNames, searchResult := ra.attemptToReclaimForSpecificJob(ssn, job, actionBudget)
 		if succeeded {
 			metrics.IncPodgroupScheduledByAction()
 			log.InfraLogger.V(3).Infof(
@@ -96,6 +102,8 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 			if err := statement.Commit(); err != nil {
 				log.InfraLogger.Errorf("Failed to commit reclaim statement: %v", err)
 			}
+		} else if shouldStopActionForSearchResult(searchResult) {
+			return
 		} else {
 			log.InfraLogger.V(3).Infof("Didn't find a reclaim strategy for job <%s/%s>",
 				job.Namespace, job.Name)
@@ -105,12 +113,16 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 }
 
 func (ra *reclaimAction) attemptToReclaimForSpecificJob(
-	ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo,
-) (bool, *framework.Statement, []string) {
+	ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo, actionBudget *solvers.ActionSearchBudget,
+) (bool, *framework.Statement, []string, *solvers.SearchResult) {
 	queue := ssn.ClusterInfo.Queues[reclaimer.Queue]
 	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(reclaimer, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false, ssn.ClusterInfo.MinNodeGPUMemory)
 	log.InfraLogger.V(3).Infof("Attempting to reclaim for job: <%v/%v> of queue <%v>, resources: <%v>",
 		reclaimer.Namespace, reclaimer.Name, queue.Name, resReq)
+
+	if actionBudget != nil && actionBudget.Exhausted() {
+		return false, nil, nil, solvers.NewNotAttemptedSearchResult()
+	}
 
 	ssn.OnJobSolutionStart()
 
@@ -119,8 +131,18 @@ func (ra *reclaimAction) attemptToReclaimForSpecificJob(
 		feasibleNodes,
 		ssn.ReclaimScenarioValidatorFn,
 		getOrderedVictimsQueue(ssn, reclaimer),
-		framework.Reclaim)
-	return solver.Solve(ssn, reclaimer)
+		framework.Reclaim,
+		actionBudget)
+	return solver.SolveWithResult(ssn, reclaimer)
+}
+
+func shouldStopActionForSearchResult(result *solvers.SearchResult) bool {
+	switch result.Reason() {
+	case solvers.SearchResultDeadlineExhausted, solvers.SearchResultNotAttempted:
+		return true
+	default:
+		return false
+	}
 }
 
 func getOrderedVictimsQueue(ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo) solvers.GenerateVictimsQueue {

--- a/pkg/scheduler/actions/reclaim/reclaim_budget_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_budget_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
@@ -15,16 +16,20 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 )
 
-func TestAttemptToReclaimSkipsJobSolutionStartWhenActionBudgetAlreadyExhausted(t *testing.T) {
+func TestAttemptToReclaimLetsSolverApplyMinJobBudgetAfterActionBudgetExpires(t *testing.T) {
 	queueID := common_info.QueueID("reclaim-queue")
+	jobID := common_info.PodGroupID("reclaim-job")
 	ssn := &framework.Session{
 		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{},
 			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
 				queueID: {
 					UID:  queueID,
@@ -37,6 +42,8 @@ func TestAttemptToReclaimSkipsJobSolutionStartWhenActionBudgetAlreadyExhausted(t
 				MaxActionSearchDuration: map[string]metav1.Duration{
 					constants.ActionReclaim: {Duration: time.Nanosecond},
 				},
+				MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+				MinJobSearchDuration: scenarioSearchDurationPtrForTest("50ms"),
 			},
 		},
 	}
@@ -49,16 +56,30 @@ func TestAttemptToReclaimSkipsJobSolutionStartWhenActionBudgetAlreadyExhausted(t
 	require.NoError(t, err)
 	time.Sleep(time.Millisecond)
 
-	job := podgroup_info.NewPodGroupInfo("reclaim-job")
+	pod := common_info.BuildPod(
+		"runai-reclaim", "reclaim-job-0", "", v1.PodPending, common_info.BuildResourceList("1", "1Gi"),
+		nil, nil, map[string]string{constants.PodGroupAnnotationForPod: string(jobID)},
+	)
+	task := pod_info.NewTaskInfo(pod, resource_info.NewResourceVectorMap())
+	job := podgroup_info.NewPodGroupInfo(jobID, task)
 	job.Name = "reclaim-job"
 	job.Namespace = "runai-reclaim"
 	job.Queue = queueID
+	ssn.ClusterInfo.PodGroupInfos[job.UID] = job
 
 	succeeded, statement, victims, result := New().attemptToReclaimForSpecificJob(ssn, job, actionBudget)
 
 	require.False(t, succeeded)
 	require.Nil(t, statement)
 	require.Empty(t, victims)
-	require.Equal(t, solvers.SearchResultNotAttempted, result.Reason())
-	require.Zero(t, onJobSolutionStartCalls)
+	require.Equal(t, solvers.SearchResultGeneratorsExhausted, result.Reason())
+	require.Equal(t, 1, onJobSolutionStartCalls)
+}
+
+func scenarioSearchDurationPtrForTest(value string) *metav1.Duration {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		panic(err)
+	}
+	return &metav1.Duration{Duration: duration}
 }

--- a/pkg/scheduler/actions/reclaim/reclaim_budget_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_budget_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestAttemptToReclaimSkipsJobSolutionStartWhenActionBudgetAlreadyExhausted(t *testing.T) {
+	queueID := common_info.QueueID("reclaim-queue")
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				queueID: {
+					UID:  queueID,
+					Name: string(queueID),
+				},
+			},
+		},
+		Config: &conf.SchedulerConfiguration{
+			ScenarioSearchBudgets: &kaiv1.ScenarioSearchBudgets{
+				MaxActionSearchDuration: map[string]metav1.Duration{
+					constants.ActionReclaim: {Duration: time.Nanosecond},
+				},
+			},
+		},
+	}
+	onJobSolutionStartCalls := 0
+	ssn.AddOnJobSolutionStartFn(func() {
+		onJobSolutionStartCalls++
+	})
+
+	actionBudget, err := solvers.NewActionSearchBudget(ssn, framework.Reclaim)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+
+	job := podgroup_info.NewPodGroupInfo("reclaim-job")
+	job.Name = "reclaim-job"
+	job.Namespace = "runai-reclaim"
+	job.Queue = queueID
+
+	succeeded, statement, victims, result := New().attemptToReclaimForSpecificJob(ssn, job, actionBudget)
+
+	require.False(t, succeeded)
+	require.Nil(t, statement)
+	require.Empty(t, victims)
+	require.Equal(t, solvers.SearchResultNotAttempted, result.Reason())
+	require.Zero(t, onJobSolutionStartCalls)
+}


### PR DESCRIPTION
## Description

Stack slice 4 of 9 for the reclaim generator portfolio.

References:
- Full implementation PR: #1716
- Design: #1696 (`docs/developer/designs/reclaim-generator-portfolio-design.md`)
- Original issue: #1660

This PR wires search budgets into the solver:
- Updates `JobSolver`, reclaim, preempt, and consolidation to create/use action search budgets.
- Adds `SolveWithResult`.
- Adds deadline, not-attempted, and no-generator result outcomes.

This is the first production behavior change in the stack: bounded search can now stop based on the configured budgets.

## Related Issues

Related to #1660.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Stacking:
- Base: `erez/reclaim-generator-portfolio-03-budget-model`
- Next PR: `erez/reclaim-generator-portfolio-05-built-in-generators`

Verification for the rebuilt stack:
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache go test ./pkg/scheduler/plugins/scenariogenerators ./pkg/scheduler/conf_util ./pkg/operator/operands/scheduler ./pkg/scheduler/actions/common/solvers ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/preempt ./pkg/scheduler/actions/consolidation ./pkg/scheduler/actions/integration_tests/reclaim ./pkg/scheduler/cache ./pkg/scheduler/cache/status_updater ./pkg/scheduler/metrics ./pkg/apis/scheduling/v2alpha2 -count=1`
- `git diff --check`
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache make validate`
