### PR TITLE
feat(scheduler): drive solver from generator portfolio

### DIFF
--- a/docs/developer/designs/reclaim-generator-portfolio-design.md
+++ b/docs/developer/designs/reclaim-generator-portfolio-design.md
@@ -61,7 +61,7 @@ The current reclaim path can spend unbounded synchronous scheduler time trying t
 
 ## Proposal
 
-Move scenario generation behind a bounded generator portfolio owned by the shared `JobSolver` path used by reclaim, preempt, and consolidation. Each applicable generator yields `ByNodeScenario` candidates incrementally. The driver simulates candidates through the existing solver, validates accepted solutions with the existing post-simulation validator, and stops when a solution is found, all generators are exhausted, or the effective time budget expires.
+Move scenario generation behind a bounded generator portfolio owned by the shared `JobSolver` path used by reclaim, preempt, and consolidation. Each available generator yields `ByNodeScenario` candidates incrementally. The driver simulates candidates through the existing solver, validates accepted solutions with the existing post-simulation validator, and stops when a solution is found, all generators are exhausted, or the effective time budget expires.
 
 The initial portfolio is:
 
@@ -106,11 +106,11 @@ The negative result is intentionally approximate when produced by the bounded po
 
 ### Mechanism
 
-`solvePartialJob` keeps its simulation and validation skeleton. The scenario source changes from a single exhaustive emitter to an ordered portfolio of generators. The portfolio owns generator iteration, action filtering, budget checks, and stop reasons.
+`solvePartialJob` keeps its simulation and validation skeleton. The scenario source changes from a single exhaustive emitter to an ordered portfolio of generators. The portfolio owns generator iteration, budget checks, and stop reasons.
 
-Generator iteration happens at pending-job granularity, not at `probeSize` granularity. For one pending job, the driver selects the first applicable generator and lets that generator attempt own the complete `searchMaxSolvableK` progression: exponential probes, binary-search probes, and the full-job probe when the partial search succeeds. Only after that generator attempt exhausts candidates or reaches its generator deadline does the driver start over with the next applicable generator. The driver must not restart the whole generator portfolio for every partial gang size, because that discards the intended progression from smaller successful probes to larger probes and can let an earlier generator repeatedly consume the shared job/action budget before a later generator gets its own search.
+Generator iteration happens at pending-job granularity, not at `probeSize` granularity. For one pending job, the driver selects the first available generator and lets that generator attempt own the complete `searchMaxSolvableK` progression: exponential probes, binary-search probes, and the full-job probe when the partial search succeeds. Only after that generator attempt exhausts candidates or reaches its generator deadline does the driver start over with the next available generator. The driver must not restart the whole generator portfolio for every partial gang size, because that discards the intended progression from smaller successful probes to larger probes and can let an earlier generator repeatedly consume the shared job/action budget before a later generator gets its own search.
 
-When the driver reaches the effective deadline without a validated solution, the action reports "no solution" as an incomplete result. The result reason must distinguish at least deadline exhaustion, generator exhaustion, no applicable generator, and not-attempted jobs so metrics and reduced-budget messages are accurate.
+When the driver reaches the effective deadline without a validated solution, the action reports "no solution" as an incomplete result. The result reason must distinguish at least deadline exhaustion, generator exhaustion, no available generator, and not-attempted jobs so metrics and reduced-budget messages are accurate.
 
 ### Search Result Contract
 
@@ -120,11 +120,11 @@ The driver returns a structured result, not just `nil`. The result reason is the
 | --- | --- | --- |
 | `solved` | a fully simulated, validator-approved scenario was found | yes |
 | `deadline_exhausted` | the action or job deadline expired before a solution was found | yes, if at least one candidate was requested or the job received a search attempt |
-| `generators_exhausted` | all applicable generators were exhausted or reached their own generator deadline before a solution was found | yes |
-| `no_generator` | no registered generator applies to this action/job shape | no |
+| `generators_exhausted` | all available generators were exhausted or reached their own generator deadline before a solution was found | yes |
+| `no_generator` | no scenario generator is available | no |
 | `not_attempted` | the job was skipped before any generator attempt, usually because no search budget remained | no |
 
-Generator deadlines bound one generator attempt, not the whole job search. A generator's `maxGeneratorSearchDuration` covers all partial gang probes it owns for that pending job. When that generator attempt reaches its deadline, the portfolio moves to the next applicable generator and restarts the pending-job partial-gang search with that generator. The whole-job result is `generators_exhausted` only after all applicable generators have either exhausted their candidates or reached their generator deadline. User-facing messages may still say "no valid reclaim scenario was found," but metrics should use the concrete result reason rather than a vague `no_solution_found` value.
+Generator deadlines bound one generator attempt, not the whole job search. A generator's `maxGeneratorSearchDuration` covers all partial gang probes it owns for that pending job. When that generator attempt reaches its deadline, the portfolio moves to the next available generator and restarts the pending-job partial-gang search with that generator. The whole-job result is `generators_exhausted` only after all available generators have either exhausted their candidates or reached their generator deadline. User-facing messages may still say "no valid reclaim scenario was found," but metrics should use the concrete result reason rather than a vague `no_solution_found` value.
 
 ### Generator Abstraction
 
@@ -148,18 +148,18 @@ Accumulated scenario filters are the Phase 1 mechanism for these cheap validity 
 
 ### Plugin Registration and Ordering
 
-`NewJobsSolver`, `solvePartialJob`, and scenario generation are shared by reclaim, preempt, and consolidation. The proposal adds a session extension point that lets plugins register generators for one or more action types:
+`NewJobsSolver`, `solvePartialJob`, and scenario generation are shared by reclaim, preempt, and consolidation. The proposal adds a session extension point that lets plugins register generators:
 
 ```go
 type ScenarioGeneratorFactory func(ctx *solvers.SolveContext) solvers.ScenarioGenerator
 
 func (ssn *Session) AddScenarioGenerator(
+    name string,
     f ScenarioGeneratorFactory,
-    applies ...framework.ActionType,
 )
 ```
 
-Generator order is derived from scheduler plugin execution order. `OpenSession` calls plugin `OnSessionOpen` hooks in configured plugin order, and each hook appends its generators by calling `AddScenarioGenerator`. If a plugin registers multiple generators, their relative order is the order of its `AddScenarioGenerator` calls. `JobSolver` filters registered generators by the current action and tries them in registration order at generator-attempt granularity: each generator gets the complete partial-gang search for the pending job before the next generator starts.
+Generator order is derived from scheduler plugin execution order. `OpenSession` calls plugin `OnSessionOpen` hooks in configured plugin order, and each hook appends its generators by calling `AddScenarioGenerator`. If a plugin registers multiple generators, their relative order is the order of its `AddScenarioGenerator` calls. `JobSolver` tries available generators in registration order at generator-attempt granularity: each generator gets the complete partial-gang search for the pending job before the next generator starts.
 
 Generator selection is controlled by normal scheduler plugin enablement and plugin order; this is not an alpha mechanism. The new time-budget knobs are alpha/experimental controls for KAI development, support, and experiments while defaults are tuned.
 
@@ -207,9 +207,9 @@ All values are strings parsed with Go's standard `time.ParseDuration`, which sup
 
 ```go
 budget := newSearchBudget(actionDeadline, jobDeadline, generatorDeadlines)
-generators := applicableGenerators(ssn, action, pendingJob)
+availableGenerators := ssn.ScenarioGeneratorRegistrations
 
-for _, generatorFactory := range generators {
+for _, generatorFactory := range availableGenerators {
     generatorBudget := budget.beginGenerator(generatorFactory.Name())
     result := searchMaxSolvableKWithGenerator(
         ssn, pendingJob, state, feasibleNodeMap, generatorFactory, generatorBudget,
@@ -261,7 +261,7 @@ The exact deduplication design should be specified and implemented separately. T
 
 #### Smart Generator Selection
 
-Phase 1 drains applicable generators in normal scheduler plugin order. A later generator-selection policy may choose, skip, or reorder registered generators per job based on job shape and, if useful, cluster state. It must preserve the generator-attempt boundary unless a separate design explains how per-probe switching preserves search continuity and budget fairness. That future policy should be designed from replay and production evidence showing which generator families solve which workload shapes; it should not be implicit in the Phase 1 plugin-registration mechanism.
+Phase 1 drains available generators in normal scheduler plugin order. A later generator-selection policy may choose, skip, or reorder registered generators per job based on job shape and, if useful, cluster state. It must preserve the generator-attempt boundary unless a separate design explains how per-probe switching preserves search continuity and budget fairness. That future policy should be designed from replay and production evidence showing which generator families solve which workload shapes; it should not be implicit in the Phase 1 plugin-registration mechanism.
 
 #### Generator Checkpointing Across Scheduling Sessions
 
@@ -290,7 +290,7 @@ For reduced-budget jobs, the `ScenarioSearchUnresolved` detail should say that t
 
 Bounded scenario search outcomes must be visible to job submitters without changing the meaning of Kubernetes `Unschedulable`. The allocate action can continue to set the existing `Unschedulable` condition and events for ordinary allocation failures. An unresolved scenario-search attempt is a separate scheduler outcome and must not overload that signal, because other Kubernetes components, including autoscaling integrations, already use `Unschedulable` semantics.
 
-When reclaim, preempt, or consolidation reaches a bounded-search terminal result for a pending job, the scheduler should set a dedicated `ScenarioSearchUnresolved` condition on both the `PodGroup` and its pending Pods. The `PodGroup` condition is the authoritative job-level explanation. Pod conditions provide a direct answer for users who inspect only the submitted Pods. The condition should be emitted once for the job scheduling outcome, not once per generator, probe, or scenario. `Unresolved` is intentionally broader than `exhausted`: it covers jobs where all configured generator attempts were drained, jobs where the time budget expired before a complete answer, jobs skipped because no budget remained, and jobs with no applicable generator.
+When reclaim, preempt, or consolidation reaches a bounded-search terminal result for a pending job, the scheduler should set a dedicated `ScenarioSearchUnresolved` condition on both the `PodGroup` and its pending Pods. The `PodGroup` condition is the authoritative job-level explanation. Pod conditions provide a direct answer for users who inspect only the submitted Pods. The condition should be emitted once for the job scheduling outcome, not once per generator, probe, or scenario. `Unresolved` is intentionally broader than `exhausted`: it covers jobs where all configured generator attempts were drained, jobs where the time budget expired before a complete answer, jobs skipped because no budget remained, and jobs with no available generator.
 
 User-facing condition messages should describe the scheduling outcome, not the internal generator mechanics:
 
@@ -299,7 +299,7 @@ User-facing condition messages should describe the scheduling outcome, not the i
 | `deadline_exhausted` | `KAI could not find a valid reclaim scenario within the configured search budget for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle.` |
 | `generators_exhausted` | `KAI tried the configured scenario-search policy and found no valid reclaim scenario for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle.` |
 | `not_attempted` | `KAI did not attempt scenario search for this job in this scheduling cycle because the configured search budget was already exhausted.` |
-| `no_generator` | `KAI did not attempt scenario search for this job because no configured scenario generator applies to this action.` |
+| `no_generator` | `KAI did not attempt scenario search for this job because no scenario generator is available.` |
 
 If `reduced_budget=true`, the message should say that the scheduler could not find a valid scenario within the remaining configured search time because the action search budget was partly consumed by earlier jobs. This wording must only be used for jobs that actually received a reduced budget.
 
@@ -342,7 +342,7 @@ The Phase 1 production metrics do not export per-job generator attribution such 
 
 ## Test Plan
 
-- Unit-test portfolio ordering, applicable-action filtering, stop reasons, and deadline handling.
+- Unit-test portfolio ordering, stop reasons, and deadline handling.
 - Unit-test that one generator owns the complete partial-gang search for a pending job before the next generator is tried.
 - Unit-test `NodeLocalGreedy` candidate construction, pre-#1537 node-local scenario shape, and whole victim-job handling.
 - Unit-test `MultiNodeGang` as a wrapper over the existing builder/emitter.

--- a/pkg/scheduler/actions/common/solvers/generator_test_helpers_test.go
+++ b/pkg/scheduler/actions/common/solvers/generator_test_helpers_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_affinity"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
+)
+
+func newGeneratorTestSession(t *testing.T, nodeGPUs map[string]int) *framework.Session {
+	t.Helper()
+
+	defaultQueue := createQueue("default")
+	defaultQueue.ParentQueue = ""
+
+	return &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				defaultQueue.UID: defaultQueue,
+			},
+			Nodes: newGeneratorTestNodes(t, nodeGPUs),
+		},
+	}
+}
+
+func newGeneratorTestNodes(t *testing.T, nodeGPUs map[string]int) map[string]*node_info.NodeInfo {
+	t.Helper()
+
+	resourceLists := make([]v1.ResourceList, 0, len(nodeGPUs))
+	for _, gpus := range nodeGPUs {
+		resourceLists = append(resourceLists, generatorTestNodeResources(gpus))
+	}
+	vectorMap := resource_info.BuildResourceVectorMap(resourceLists)
+
+	nodes := map[string]*node_info.NodeInfo{}
+	for name, gpus := range nodeGPUs {
+		controller := gomock.NewController(t)
+		nodePodAffinityInfo := pod_affinity.NewMockNodePodAffinityInfo(controller)
+		nodePodAffinityInfo.EXPECT().AddPod(gomock.Any()).AnyTimes()
+		nodePodAffinityInfo.EXPECT().RemovePod(gomock.Any()).AnyTimes()
+
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: v1.NodeStatus{
+				Allocatable: generatorTestNodeResources(gpus),
+				Capacity:    generatorTestNodeResources(gpus),
+			},
+		}
+		nodes[name] = node_info.NewNodeInfo(node, nodePodAffinityInfo, vectorMap)
+	}
+	return nodes
+}
+
+func generatorTestNodeResources(gpus int) v1.ResourceList {
+	return v1.ResourceList{
+		resource_info.GPUResourceName: resource.MustParse(strconv.Itoa(gpus)),
+		v1.ResourcePods:               resource.MustParse("100"),
+	}
+}
+
+func addGeneratorTestPendingJob(
+	t *testing.T, ssn *framework.Session, tasksPerJob int, jobID int, queueName string,
+) *podgroup_info.PodGroupInfo {
+	t.Helper()
+
+	job, _ := createJobWithTasks(tasksPerJob, jobID, queueName, v1.PodPending, []v1.ResourceRequirements{requireOneGPU()})
+	addGeneratorTestQueue(ssn, queueName)
+	ssn.ClusterInfo.PodGroupInfos[job.UID] = job
+	return job
+}
+
+func addGeneratorTestJob(
+	t *testing.T, ssn *framework.Session, tasksPerJob int, jobID int, queueName string, nodeNames ...string,
+) (*podgroup_info.PodGroupInfo, []*pod_info.PodInfo) {
+	t.Helper()
+
+	job, tasks := createJobWithTasks(tasksPerJob, jobID, queueName, v1.PodRunning, []v1.ResourceRequirements{requireOneGPU()})
+	addGeneratorTestQueue(ssn, queueName)
+	ssn.ClusterInfo.PodGroupInfos[job.UID] = job
+
+	for index, task := range tasks {
+		nodeName := nodeNames[index%len(nodeNames)]
+		task.NodeName = nodeName
+		task.Pod.Spec.NodeName = nodeName
+		require.NoError(t, ssn.ClusterInfo.Nodes[nodeName].AddTask(task))
+	}
+	return job, tasks
+}
+
+func addGeneratorTestQueue(ssn *framework.Session, queueName string) {
+	queue := createQueue(queueName)
+	ssn.ClusterInfo.Queues[queue.UID] = queue
+}
+
+func setGeneratorTestMinAvailable(job *podgroup_info.PodGroupInfo, minAvailable int) {
+	for _, podSet := range job.GetAllPodSets() {
+		podSet.SetMinAvailable(int32(minAvailable))
+	}
+	job.PodGroup.Spec.MinMember = ptr.To(int32(minAvailable))
+}
+
+func generatorTestVictimsQueue(
+	ssn *framework.Session, jobs ...*podgroup_info.PodGroupInfo,
+) *utils.JobsOrderByQueues {
+	victimsQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
+		VictimQueue:       true,
+		MaxJobsQueueDepth: scheduler_util.QueueCapacityInfinite,
+	})
+	for _, job := range jobs {
+		victimsQueue.PushJob(job)
+	}
+	return &victimsQueue
+}
+
+func generatorTestVictimsQueueFactory(
+	ssn *framework.Session, jobs ...*podgroup_info.PodGroupInfo,
+) GenerateVictimsQueue {
+	return func() *utils.JobsOrderByQueues {
+		return generatorTestVictimsQueue(ssn, jobs...)
+	}
+}

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -103,18 +103,18 @@ func (s *JobSolver) SolveWithResult(
 	if s.generateVictimsQueue == nil {
 		return false, nil, nil, terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
 	}
-	registrations := applicableScenarioGeneratorRegistrations(ssn, s.actionType)
-	if len(registrations) == 0 {
+	availableGenerators := ssn.ScenarioGeneratorRegistrations
+	if len(availableGenerators) == 0 {
 		return false, nil, nil, terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
 	}
 
 	var lastVictimTasks []*pod_info.PodInfo
 	var lastResult *SearchResult
-	for _, registration := range registrations {
+	for _, availableGenerator := range availableGenerators {
 		state := solvingState{}
-		generatorBudget := jobBudget.BeginGenerator(registration.Name)
+		generatorBudget := jobBudget.BeginGenerator(availableGenerator.Name)
 		result := s.solvePendingJobWithGenerator(
-			ssn, &state, pendingJob, tasksToAllocate, jobBudget, registration, generatorBudget,
+			ssn, &state, pendingJob, tasksToAllocate, jobBudget, availableGenerator, generatorBudget,
 		)
 		lastVictimTasks = state.recordedVictimsTasks
 		lastResult = result
@@ -150,12 +150,12 @@ func (s *JobSolver) solvePendingJobWithGenerator(
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	jobBudget *jobSearchBudget,
-	registration framework.ScenarioGeneratorRegistration,
+	availableGenerator framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget,
 ) *SearchResult {
 	n := len(tasksToAllocate)
 	maxSolvedK, searchResult := s.searchMaxSolvableK(
-		ssn, state, pendingJob, tasksToAllocate, jobBudget, registration, generatorBudget,
+		ssn, state, pendingJob, tasksToAllocate, jobBudget, availableGenerator, generatorBudget,
 	)
 	if maxSolvedK == 0 {
 		if searchResult == nil {
@@ -164,7 +164,7 @@ func (s *JobSolver) solvePendingJobWithGenerator(
 		return searchResult
 	}
 
-	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, n, jobBudget, registration, generatorBudget)
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, n, jobBudget, availableGenerator, generatorBudget)
 	return result
 }
 
@@ -179,7 +179,7 @@ func (s *JobSolver) searchMaxSolvableK(
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	jobBudget *jobSearchBudget,
-	registration framework.ScenarioGeneratorRegistration,
+	availableGenerator framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget,
 ) (int, *SearchResult) {
 	n := len(tasksToAllocate)
@@ -189,7 +189,7 @@ func (s *JobSolver) searchMaxSolvableK(
 
 	return searchMaxSolvableK(n, func(k int) *SearchResult {
 		return s.tryProbeAndDiscard(
-			ssn, state, pendingJob, tasksToAllocate, k, jobBudget, registration, generatorBudget,
+			ssn, state, pendingJob, tasksToAllocate, k, jobBudget, availableGenerator, generatorBudget,
 		)
 	})
 }
@@ -248,10 +248,10 @@ func (s *JobSolver) tryProbeAndDiscard(
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
 	jobBudget *jobSearchBudget,
-	registration framework.ScenarioGeneratorRegistration,
+	availableGenerator framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget,
 ) *SearchResult {
-	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k, jobBudget, registration, generatorBudget)
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k, jobBudget, availableGenerator, generatorBudget)
 	if !resultSolved(result) {
 		log.InfraLogger.V(5).Infof("No solution found for %d tasks out of %d tasks to allocate for %s",
 			k, len(tasksToAllocate), pendingJob.Name)
@@ -276,17 +276,17 @@ func (s *JobSolver) probeAtK(
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
 	jobBudget *jobSearchBudget,
-	registration framework.ScenarioGeneratorRegistration,
+	availableGenerator framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget,
 ) *SearchResult {
 	pendingTasks := tasksToAllocate[:k]
 	partialPendingJob := getPartialJobRepresentative(pendingJob, pendingTasks)
-	return s.solvePartialJob(ssn, state, partialPendingJob, jobBudget, registration, generatorBudget, k)
+	return s.solvePartialJob(ssn, state, partialPendingJob, jobBudget, availableGenerator, generatorBudget, k)
 }
 
 func (s *JobSolver) solvePartialJob(
 	ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo,
-	jobBudget *jobSearchBudget, registration framework.ScenarioGeneratorRegistration,
+	jobBudget *jobSearchBudget, availableGenerator framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget, probeK int,
 ) *SearchResult {
 	if jobBudget == nil {
@@ -312,7 +312,7 @@ func (s *JobSolver) solvePartialJob(
 		FeasibleNodes:        feasibleNodeMap,
 		ProbeK:               probeK,
 	}
-	portfolio := newSingleGeneratorScenarioPortfolio(solveCtx, jobBudget, registration, generatorBudget)
+	portfolio := newSingleGeneratorScenarioPortfolio(solveCtx, jobBudget, availableGenerator, generatorBudget)
 
 	for {
 		if jobBudget.Exhausted() {

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	solverscenario "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -87,47 +86,86 @@ func (s *JobSolver) Solve(
 // describing why the scenario search stopped.
 func (s *JobSolver) SolveWithResult(
 	ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo,
-) (bool, *framework.Statement, []string, *SearchResult) {
-	state := solvingState{}
+) (solved bool, statement *framework.Statement, victimTaskNames []string, searchResult *SearchResult) {
 	originalNumActiveTasks := pendingJob.GetNumActiveUsedTasks()
 
 	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
 	n := len(tasksToAllocate)
 	if n == 0 {
-		return false, nil, calcVictimNames(state.recordedVictimsTasks),
-			terminalSearchResult(SearchResultGeneratorsExhausted, false)
+		return false, nil, nil, terminalSearchResult(SearchResultGeneratorsExhausted, false)
 	}
 
 	jobBudget := s.actionBudget.BeginJob()
 	if jobBudget.Exhausted() {
-		return false, nil, calcVictimNames(state.recordedVictimsTasks),
-			terminalSearchResult(SearchResultNotAttempted, false)
+		return false, nil, nil, terminalSearchResult(SearchResultNotAttempted, false)
 	}
 
-	maxSolvedK, searchResult := s.searchMaxSolvableK(ssn, &state, pendingJob, tasksToAllocate, jobBudget)
+	if s.generateVictimsQueue == nil {
+		return false, nil, nil, terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
+	}
+	registrations := applicableScenarioGeneratorRegistrations(ssn, s.actionType)
+	if len(registrations) == 0 {
+		return false, nil, nil, terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
+	}
+
+	var lastVictimTasks []*pod_info.PodInfo
+	var lastResult *SearchResult
+	for _, registration := range registrations {
+		state := solvingState{}
+		generatorBudget := jobBudget.BeginGenerator(registration.Name)
+		result := s.solvePendingJobWithGenerator(
+			ssn, &state, pendingJob, tasksToAllocate, jobBudget, registration, generatorBudget,
+		)
+		lastVictimTasks = state.recordedVictimsTasks
+		lastResult = result
+
+		if resultSolved(result) {
+			solution := result.solution
+			numActiveTasks := pendingJob.GetNumActiveUsedTasks()
+			jobSolved := pendingJob.IsGangSatisfied()
+			if originalNumActiveTasks >= numActiveTasks {
+				jobSolved = false
+			}
+
+			log.InfraLogger.V(4).Infof(
+				"Scenario solved for %d tasks to allocate for %s. Victims: %s",
+				n, pendingJob.Name, victimPrintingStruct{solution.victimsTasks})
+			return jobSolved, solution.statement, calcVictimNames(solution.victimsTasks), result
+		}
+
+		if shouldStopSearch(result) {
+			return false, nil, calcVictimNames(lastVictimTasks), result
+		}
+	}
+
+	if lastResult == nil {
+		lastResult = terminalSearchResult(SearchResultGeneratorsExhausted, jobBudget.ReducedBudget())
+	}
+	return false, nil, calcVictimNames(lastVictimTasks), lastResult
+}
+
+func (s *JobSolver) solvePendingJobWithGenerator(
+	ssn *framework.Session,
+	state *solvingState,
+	pendingJob *podgroup_info.PodGroupInfo,
+	tasksToAllocate []*pod_info.PodInfo,
+	jobBudget *jobSearchBudget,
+	registration framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget,
+) *SearchResult {
+	n := len(tasksToAllocate)
+	maxSolvedK, searchResult := s.searchMaxSolvableK(
+		ssn, state, pendingJob, tasksToAllocate, jobBudget, registration, generatorBudget,
+	)
 	if maxSolvedK == 0 {
 		if searchResult == nil {
-			searchResult = terminalSearchResult(SearchResultGeneratorsExhausted, false)
+			searchResult = terminalSearchResult(SearchResultGeneratorsExhausted, jobBudget.ReducedBudget())
 		}
-		return false, nil, calcVictimNames(state.recordedVictimsTasks), searchResult
+		return searchResult
 	}
 
-	result := s.probeAtK(ssn, &state, pendingJob, tasksToAllocate, n, jobBudget)
-	if !resultSolved(result) {
-		return false, nil, calcVictimNames(state.recordedVictimsTasks), result
-	}
-
-	solution := result.solution
-	numActiveTasks := pendingJob.GetNumActiveUsedTasks()
-	jobSolved := pendingJob.IsGangSatisfied()
-	if originalNumActiveTasks >= numActiveTasks {
-		jobSolved = false
-	}
-
-	log.InfraLogger.V(4).Infof(
-		"Scenario solved for %d tasks to allocate for %s. Victims: %s",
-		n, pendingJob.Name, victimPrintingStruct{solution.victimsTasks})
-	return jobSolved, solution.statement, calcVictimNames(solution.victimsTasks), result
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, n, jobBudget, registration, generatorBudget)
+	return result
 }
 
 // searchMaxSolvableK returns the largest k in [0, n] for which a probe at k succeeds.
@@ -141,6 +179,8 @@ func (s *JobSolver) searchMaxSolvableK(
 	pendingJob *podgroup_info.PodGroupInfo,
 	tasksToAllocate []*pod_info.PodInfo,
 	jobBudget *jobSearchBudget,
+	registration framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget,
 ) (int, *SearchResult) {
 	n := len(tasksToAllocate)
 	if n == 0 {
@@ -148,7 +188,9 @@ func (s *JobSolver) searchMaxSolvableK(
 	}
 
 	return searchMaxSolvableK(n, func(k int) *SearchResult {
-		return s.tryProbeAndDiscard(ssn, state, pendingJob, tasksToAllocate, k, jobBudget)
+		return s.tryProbeAndDiscard(
+			ssn, state, pendingJob, tasksToAllocate, k, jobBudget, registration, generatorBudget,
+		)
 	})
 }
 
@@ -206,8 +248,10 @@ func (s *JobSolver) tryProbeAndDiscard(
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
 	jobBudget *jobSearchBudget,
+	registration framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget,
 ) *SearchResult {
-	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k, jobBudget)
+	result := s.probeAtK(ssn, state, pendingJob, tasksToAllocate, k, jobBudget, registration, generatorBudget)
 	if !resultSolved(result) {
 		log.InfraLogger.V(5).Infof("No solution found for %d tasks out of %d tasks to allocate for %s",
 			k, len(tasksToAllocate), pendingJob.Name)
@@ -232,15 +276,18 @@ func (s *JobSolver) probeAtK(
 	tasksToAllocate []*pod_info.PodInfo,
 	k int,
 	jobBudget *jobSearchBudget,
+	registration framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget,
 ) *SearchResult {
 	pendingTasks := tasksToAllocate[:k]
 	partialPendingJob := getPartialJobRepresentative(pendingJob, pendingTasks)
-	return s.solvePartialJob(ssn, state, partialPendingJob, jobBudget)
+	return s.solvePartialJob(ssn, state, partialPendingJob, jobBudget, registration, generatorBudget, k)
 }
 
 func (s *JobSolver) solvePartialJob(
 	ssn *framework.Session, state *solvingState, partialPendingJob *podgroup_info.PodGroupInfo,
-	jobBudget *jobSearchBudget,
+	jobBudget *jobSearchBudget, registration framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget, probeK int,
 ) *SearchResult {
 	if jobBudget == nil {
 		jobBudget = newUnlimitedActionSearchBudget(s.actionType).BeginJob()
@@ -255,29 +302,23 @@ func (s *JobSolver) solvePartialJob(
 		feasibleNodeMap[task.NodeName] = node
 	}
 
-	if s.generateVictimsQueue == nil {
-		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
+	solveCtx := &SolveContext{
+		Session:              ssn,
+		ActionType:           s.actionType,
+		PartialPendingJob:    partialPendingJob,
+		RecordedVictimsJobs:  state.recordedVictimsJobs,
+		RecordedVictimsTasks: state.recordedVictimsTasks,
+		GenerateVictimsQueue: s.generateVictimsQueue,
+		FeasibleNodes:        feasibleNodeMap,
+		ProbeK:               probeK,
 	}
-	victimsQueue := s.generateVictimsQueue()
-	if victimsQueue == nil {
-		return terminalSearchResult(SearchResultNoGenerator, jobBudget.ReducedBudget())
-	}
+	portfolio := newSingleGeneratorScenarioPortfolio(solveCtx, jobBudget, registration, generatorBudget)
 
-	scenarioBuilder := NewPodAccumulatedScenarioBuilder(
-		ssn, partialPendingJob, state.recordedVictimsJobs, victimsQueue, feasibleNodeMap)
-
-	firstScenario := true
 	for {
 		if jobBudget.Exhausted() {
 			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget())
 		}
-		var scenarioToSolve *solverscenario.ByNodeScenario
-		if firstScenario {
-			scenarioToSolve = scenarioBuilder.GetValidScenario()
-			firstScenario = false
-		} else {
-			scenarioToSolve = scenarioBuilder.GetNextScenario()
-		}
+		scenarioToSolve := portfolio.Next()
 		if scenarioToSolve == nil {
 			break
 		}
@@ -293,7 +334,7 @@ func (s *JobSolver) solvePartialJob(
 		}
 	}
 
-	return terminalSearchResult(SearchResultGeneratorsExhausted, jobBudget.ReducedBudget())
+	return terminalSearchResult(portfolio.StopReason(), jobBudget.ReducedBudget())
 }
 
 func shouldStopSearch(result *SearchResult) bool {

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -38,12 +38,9 @@ func NewJobsSolver(
 	solutionValidator SolutionValidator,
 	generateVictimsQueue GenerateVictimsQueue,
 	action framework.ActionType,
-	actionBudget ...*ActionSearchBudget,
+	actionBudget *ActionSearchBudget,
 ) *JobSolver {
-	var budget *ActionSearchBudget
-	if len(actionBudget) > 0 {
-		budget = actionBudget[0]
-	}
+	budget := actionBudget
 	if budget == nil {
 		budget = newUnlimitedActionSearchBudget(action)
 	}

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -135,7 +135,11 @@ func TestSolveWithResultReportsDeadlineWhenBudgetExhaustsDuringScenarioSearch(t 
 		nil, resource_info.NewResourceVectorMap(),
 	)
 	ssn.ClusterInfo.Nodes[node.Name] = node
-	ssn.AddScenarioGenerator("deadline-test", NewMultiNodeGangGenerator, framework.Reclaim)
+	ssn.AddScenarioGenerator("deadline-test", func(ctx framework.ScenarioGeneratorContext) framework.ScenarioGenerator {
+		solveCtx := ctx.(*SolveContext)
+		solveCtx.GenerateVictimsQueue()
+		return &portfolioTestGenerator{name: "deadline-test"}
+	}, framework.Reclaim)
 	solver := NewJobsSolver(
 		[]*node_info.NodeInfo{node},
 		nil,

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -139,7 +139,7 @@ func TestSolveWithResultReportsDeadlineWhenBudgetExhaustsDuringScenarioSearch(t 
 		solveCtx := ctx.(*SolveContext)
 		solveCtx.GenerateVictimsQueue()
 		return &portfolioTestGenerator{name: "deadline-test"}
-	}, framework.Reclaim)
+	})
 	solver := NewJobsSolver(
 		[]*node_info.NodeInfo{node},
 		nil,
@@ -175,7 +175,7 @@ func TestSolveWithResultRunsCompletePartialSearchForOneGeneratorBeforeNext(t *te
 		solveCtx := ctx.(*SolveContext)
 		factoryCalls = append(factoryCalls, fmt.Sprintf("first:%d", solveCtx.ProbeK))
 		return &portfolioTestGenerator{name: "first"}
-	}, framework.Reclaim)
+	})
 	ssn.AddScenarioGenerator("second", func(ctx framework.ScenarioGeneratorContext) framework.ScenarioGenerator {
 		solveCtx := ctx.(*SolveContext)
 		factoryCalls = append(factoryCalls, fmt.Sprintf("second:%d", solveCtx.ProbeK))
@@ -188,7 +188,7 @@ func TestSolveWithResultRunsCompletePartialSearchForOneGeneratorBeforeNext(t *te
 			solveCtx.RecordedVictimsJobs,
 		)
 		return &portfolioTestGenerator{name: "second", scenarios: []api.ScenarioInfo{sn}}
-	}, framework.Reclaim)
+	})
 	solver := NewJobsSolver(
 		jobSolverResultTestFeasibleNodes(ssn),
 		nil,

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -34,14 +34,6 @@ func TestNewJobsSolverDefaultsNilBudgetToUnlimited(t *testing.T) {
 	require.Greater(t, solver.actionBudget.BeginJob().Remaining(), time.Hour)
 }
 
-func TestNewJobsSolverDefaultsOmittedBudgetToUnlimited(t *testing.T) {
-	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim)
-
-	require.NotNil(t, solver.actionBudget)
-	require.False(t, solver.actionBudget.Exhausted())
-	require.Greater(t, solver.actionBudget.BeginJob().Remaining(), time.Hour)
-}
-
 func TestSolveWithResultReturnsTerminalResultWhenNoTasksToAllocate(t *testing.T) {
 	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim, nil)
 	pendingJob := podgroup_info.NewPodGroupInfo("pending-job")

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -4,6 +4,7 @@
 package solvers
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,10 +14,12 @@ import (
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
@@ -132,6 +135,7 @@ func TestSolveWithResultReportsDeadlineWhenBudgetExhaustsDuringScenarioSearch(t 
 		nil, resource_info.NewResourceVectorMap(),
 	)
 	ssn.ClusterInfo.Nodes[node.Name] = node
+	ssn.AddScenarioGenerator("deadline-test", NewMultiNodeGangGenerator, framework.Reclaim)
 	solver := NewJobsSolver(
 		[]*node_info.NodeInfo{node},
 		nil,
@@ -151,6 +155,54 @@ func TestSolveWithResultReportsDeadlineWhenBudgetExhaustsDuringScenarioSearch(t 
 	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
 }
 
+func TestSolveWithResultRunsCompletePartialSearchForOneGeneratorBeforeNext(t *testing.T) {
+	ssn := newGeneratorTestSession(t, map[string]int{
+		"node-1": 1,
+		"node-2": 1,
+		"node-3": 1,
+	})
+	require.NoError(t, ssn.InitNodeScoringPool())
+	pendingJob := addGeneratorTestPendingJob(t, ssn, 3, 10, "team-pending")
+	setGeneratorTestMinAvailable(pendingJob, 3)
+	victimJob, victimTasks := addGeneratorTestJob(t, ssn, 3, 20, "team-victim", "node-1", "node-2", "node-3")
+	factoryCalls := []string{}
+
+	ssn.AddScenarioGenerator("first", func(ctx framework.ScenarioGeneratorContext) framework.ScenarioGenerator {
+		solveCtx := ctx.(*SolveContext)
+		factoryCalls = append(factoryCalls, fmt.Sprintf("first:%d", solveCtx.ProbeK))
+		return &portfolioTestGenerator{name: "first"}
+	}, framework.Reclaim)
+	ssn.AddScenarioGenerator("second", func(ctx framework.ScenarioGeneratorContext) framework.ScenarioGenerator {
+		solveCtx := ctx.(*SolveContext)
+		factoryCalls = append(factoryCalls, fmt.Sprintf("second:%d", solveCtx.ProbeK))
+		pendingTasks := podgroup_info.GetTasksToAllocate(
+			solveCtx.PartialPendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false,
+		)
+		sn := scenario.NewByNodeScenario(
+			ssn, solveCtx.PartialPendingJob, pendingTasks,
+			unrecordedVictimsForProbe(victimTasks, solveCtx.RecordedVictimsTasks, solveCtx.ProbeK),
+			solveCtx.RecordedVictimsJobs,
+		)
+		return &portfolioTestGenerator{name: "second", scenarios: []api.ScenarioInfo{sn}}
+	}, framework.Reclaim)
+	solver := NewJobsSolver(
+		jobSolverResultTestFeasibleNodes(ssn),
+		nil,
+		generatorTestVictimsQueueFactory(ssn, victimJob),
+		framework.Reclaim,
+		nil,
+	)
+
+	solved, statement, _, result := solver.SolveWithResult(ssn, pendingJob)
+	if statement != nil {
+		defer statement.Discard()
+	}
+
+	require.True(t, solved)
+	require.Equal(t, SearchResultSolved, result.Reason())
+	require.Equal(t, []string{"first:1", "second:1", "second:2", "second:3", "second:3"}, factoryCalls)
+}
+
 func TestSearchMaxSolvableKStopsAfterTerminalPartialProbe(t *testing.T) {
 	probes := map[int]*SearchResult{
 		1: solvedSearchResult(&solutionResult{solved: true}, false),
@@ -163,6 +215,40 @@ func TestSearchMaxSolvableKStopsAfterTerminalPartialProbe(t *testing.T) {
 
 	require.Equal(t, 0, maxSolvedK)
 	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
+}
+
+func jobSolverResultTestFeasibleNodes(ssn *framework.Session) []*node_info.NodeInfo {
+	nodes := make([]*node_info.NodeInfo, 0, len(ssn.ClusterInfo.Nodes))
+	for _, node := range ssn.ClusterInfo.Nodes {
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+func unrecordedVictimsForProbe(
+	victimTasks []*pod_info.PodInfo, recordedVictims []*pod_info.PodInfo, probeK int,
+) []*pod_info.PodInfo {
+	recordedByUID := map[common_info.PodID]struct{}{}
+	for _, task := range recordedVictims {
+		recordedByUID[task.UID] = struct{}{}
+	}
+
+	neededVictims := probeK - len(recordedVictims)
+	if neededVictims <= 0 {
+		return nil
+	}
+
+	selectedVictims := make([]*pod_info.PodInfo, 0, neededVictims)
+	for _, task := range victimTasks {
+		if _, alreadyRecorded := recordedByUID[task.UID]; alreadyRecorded {
+			continue
+		}
+		selectedVictims = append(selectedVictims, task)
+		if len(selectedVictims) == neededVictims {
+			return selectedVictims
+		}
+	}
+	return selectedVictims
 }
 
 func newJobSolverResultTestSession(t *testing.T, tasksCount int) (*framework.Session, *podgroup_info.PodGroupInfo) {

--- a/pkg/scheduler/actions/common/solvers/scenario_generator.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_generator.go
@@ -46,9 +46,9 @@ func newScenarioPortfolio(ctx *SolveContext, jobBudget *jobSearchBudget) *scenar
 			stopReason: SearchResultNoGenerator,
 		}
 	}
-	return newScenarioPortfolioForRegistrations(
+	return newScenarioPortfolioForAvailableGenerators(
 		ctx, jobBudget,
-		applicableScenarioGeneratorRegistrations(ctx.Session, ctx.ActionType),
+		ctx.Session.ScenarioGeneratorRegistrations,
 		nil,
 	)
 }
@@ -56,18 +56,18 @@ func newScenarioPortfolio(ctx *SolveContext, jobBudget *jobSearchBudget) *scenar
 func newSingleGeneratorScenarioPortfolio(
 	ctx *SolveContext,
 	jobBudget *jobSearchBudget,
-	registration framework.ScenarioGeneratorRegistration,
+	availableGenerator framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget,
 ) *scenarioPortfolio {
-	return newScenarioPortfolioForRegistrations(
-		ctx, jobBudget, []framework.ScenarioGeneratorRegistration{registration}, generatorBudget,
+	return newScenarioPortfolioForAvailableGenerators(
+		ctx, jobBudget, []framework.ScenarioGeneratorRegistration{availableGenerator}, generatorBudget,
 	)
 }
 
-func newScenarioPortfolioForRegistrations(
+func newScenarioPortfolioForAvailableGenerators(
 	ctx *SolveContext,
 	jobBudget *jobSearchBudget,
-	registrations []framework.ScenarioGeneratorRegistration,
+	availableGenerators []framework.ScenarioGeneratorRegistration,
 	generatorBudget *generatorSearchBudget,
 ) *scenarioPortfolio {
 	portfolio := &scenarioPortfolio{
@@ -81,18 +81,18 @@ func newScenarioPortfolioForRegistrations(
 		return portfolio
 	}
 
-	for _, registration := range registrations {
-		if registration.Factory == nil {
+	for _, availableGenerator := range availableGenerators {
+		if availableGenerator.Factory == nil {
 			continue
 		}
-		generator := registration.Factory(ctx)
+		generator := availableGenerator.Factory(ctx)
 		if generator == nil {
 			continue
 		}
 		portfolio.generators = append(portfolio.generators, generator)
 	}
 	if len(portfolio.generators) == 0 {
-		if len(registrations) == 0 {
+		if len(availableGenerators) == 0 {
 			portfolio.stopReason = SearchResultNoGenerator
 		}
 	}
@@ -148,32 +148,6 @@ func (p *scenarioPortfolio) currentGenerator() framework.ScenarioGenerator {
 func (p *scenarioPortfolio) moveToNextGenerator() {
 	p.currentIndex++
 	p.currentBudget = nil
-}
-
-func scenarioGeneratorAppliesToAction(
-	registration framework.ScenarioGeneratorRegistration, action framework.ActionType,
-) bool {
-	if len(registration.Actions) == 0 {
-		return true
-	}
-	_, applies := registration.Actions[action]
-	return applies
-}
-
-func applicableScenarioGeneratorRegistrations(
-	ssn *framework.Session, action framework.ActionType,
-) []framework.ScenarioGeneratorRegistration {
-	if ssn == nil {
-		return nil
-	}
-	registrations := []framework.ScenarioGeneratorRegistration{}
-	for _, registration := range ssn.ScenarioGeneratorRegistrations {
-		if registration.Factory == nil || !scenarioGeneratorAppliesToAction(registration, action) {
-			continue
-		}
-		registrations = append(registrations, registration)
-	}
-	return registrations
 }
 
 // ValidateScenarioGeneratorContext extracts the solver context required by scenario generator plugins.

--- a/pkg/scheduler/actions/common/solvers/scenario_generator.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_generator.go
@@ -4,11 +4,13 @@
 package solvers
 
 import (
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
 type SolveContext struct {
@@ -25,6 +27,153 @@ type SolveContext struct {
 
 func (ctx *SolveContext) Action() framework.ActionType {
 	return ctx.ActionType
+}
+
+type scenarioPortfolio struct {
+	ctx           *SolveContext
+	generators    []framework.ScenarioGenerator
+	jobBudget     *jobSearchBudget
+	currentIndex  int
+	currentBudget *generatorSearchBudget
+	stopReason    SearchResultReason
+}
+
+func newScenarioPortfolio(ctx *SolveContext, jobBudget *jobSearchBudget) *scenarioPortfolio {
+	if ctx == nil || ctx.Session == nil {
+		return &scenarioPortfolio{
+			ctx:        ctx,
+			jobBudget:  jobBudget,
+			stopReason: SearchResultNoGenerator,
+		}
+	}
+	return newScenarioPortfolioForRegistrations(
+		ctx, jobBudget,
+		applicableScenarioGeneratorRegistrations(ctx.Session, ctx.ActionType),
+		nil,
+	)
+}
+
+func newSingleGeneratorScenarioPortfolio(
+	ctx *SolveContext,
+	jobBudget *jobSearchBudget,
+	registration framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget,
+) *scenarioPortfolio {
+	return newScenarioPortfolioForRegistrations(
+		ctx, jobBudget, []framework.ScenarioGeneratorRegistration{registration}, generatorBudget,
+	)
+}
+
+func newScenarioPortfolioForRegistrations(
+	ctx *SolveContext,
+	jobBudget *jobSearchBudget,
+	registrations []framework.ScenarioGeneratorRegistration,
+	generatorBudget *generatorSearchBudget,
+) *scenarioPortfolio {
+	portfolio := &scenarioPortfolio{
+		ctx:           ctx,
+		jobBudget:     jobBudget,
+		currentBudget: generatorBudget,
+		stopReason:    SearchResultGeneratorsExhausted,
+	}
+	if ctx == nil || ctx.Session == nil {
+		portfolio.stopReason = SearchResultNoGenerator
+		return portfolio
+	}
+
+	for _, registration := range registrations {
+		if registration.Factory == nil {
+			continue
+		}
+		generator := registration.Factory(ctx)
+		if generator == nil {
+			continue
+		}
+		portfolio.generators = append(portfolio.generators, generator)
+	}
+	if len(portfolio.generators) == 0 {
+		if len(registrations) == 0 {
+			portfolio.stopReason = SearchResultNoGenerator
+		}
+	}
+	return portfolio
+}
+
+func (p *scenarioPortfolio) Next() *scenario.ByNodeScenario {
+	for {
+		generator := p.currentGenerator()
+		if generator == nil {
+			return nil
+		}
+		if p.currentBudget == nil {
+			p.currentBudget = p.jobBudget.BeginGenerator(generator.Name())
+		}
+		if p.currentBudget.Exhausted() {
+			p.moveToNextGenerator()
+			continue
+		}
+
+		sn := generator.Next()
+		if sn == nil {
+			p.moveToNextGenerator()
+			continue
+		}
+		byNodeScenario, ok := sn.(*scenario.ByNodeScenario)
+		if !ok {
+			log.InfraLogger.V(4).Infof(
+				"Scenario generator <%s> returned unsupported scenario type %T",
+				generator.Name(), sn,
+			)
+			p.moveToNextGenerator()
+			continue
+		}
+		return byNodeScenario
+	}
+}
+
+func (p *scenarioPortfolio) StopReason() SearchResultReason {
+	if p == nil {
+		return SearchResultNoGenerator
+	}
+	return p.stopReason
+}
+
+func (p *scenarioPortfolio) currentGenerator() framework.ScenarioGenerator {
+	if p == nil || p.currentIndex >= len(p.generators) {
+		return nil
+	}
+	return p.generators[p.currentIndex]
+}
+
+func (p *scenarioPortfolio) moveToNextGenerator() {
+	p.currentIndex++
+	p.currentBudget = nil
+}
+
+func scenarioGeneratorAppliesToAction(
+	registration framework.ScenarioGeneratorRegistration, action framework.ActionType,
+) bool {
+	if len(registration.Actions) == 0 {
+		return true
+	}
+	_, applies := registration.Actions[action]
+	return applies
+}
+
+func applicableScenarioGeneratorRegistrations(
+	ssn *framework.Session, action framework.ActionType,
+) []framework.ScenarioGeneratorRegistration {
+	if ssn == nil {
+		return nil
+	}
+	registrations := []framework.ScenarioGeneratorRegistration{}
+	for _, registration := range ssn.ScenarioGeneratorRegistrations {
+		if registration.Factory == nil || !scenarioGeneratorAppliesToAction(registration, action) {
+			continue
+		}
+		registrations = append(registrations, registration)
+	}
+	return registrations
 }
 
 // ValidateScenarioGeneratorContext extracts the solver context required by scenario generator plugins.

--- a/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
@@ -35,27 +35,6 @@ func TestScenarioPortfolioUsesRegistrationOrder(t *testing.T) {
 	require.Equal(t, SearchResultGeneratorsExhausted, portfolio.StopReason())
 }
 
-func TestScenarioPortfolioFiltersByAction(t *testing.T) {
-	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
-	preemptOnly := &portfolioTestGenerator{name: "preempt", scenarios: []api.ScenarioInfo{
-		newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob),
-	}}
-	reclaimOnly := &portfolioTestGenerator{name: "reclaim", scenarios: []api.ScenarioInfo{firstScenario}}
-	allActionsScenario := newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob)
-	allActions := &portfolioTestGenerator{name: "all", scenarios: []api.ScenarioInfo{allActionsScenario}}
-	ctx.Session.AddScenarioGenerator("preempt", portfolioTestFactory(preemptOnly), framework.Preempt)
-	ctx.Session.AddScenarioGenerator("reclaim", portfolioTestFactory(reclaimOnly), framework.Reclaim)
-	ctx.Session.AddScenarioGenerator("all", portfolioTestFactory(allActions))
-
-	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
-
-	require.Same(t, firstScenario, portfolio.Next())
-	require.Same(t, allActionsScenario, portfolio.Next())
-	require.Nil(t, portfolio.Next())
-	require.Zero(t, preemptOnly.nextCalls)
-	require.Equal(t, SearchResultGeneratorsExhausted, portfolio.StopReason())
-}
-
 func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToGeneratorDeadline(t *testing.T) {
 	clock := &fakeClock{now: time.Unix(0, 0)}
 	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
@@ -128,16 +107,12 @@ func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToJobDeadline(t *testin
 	require.Same(t, firstScenario, portfolio.Next())
 }
 
-func TestScenarioPortfolioReturnsNoGeneratorWhenNoRegistrationApplies(t *testing.T) {
-	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
-	preemptOnly := &portfolioTestGenerator{name: "preempt", scenarios: []api.ScenarioInfo{firstScenario}}
-	ctx.Session.AddScenarioGenerator("preempt", portfolioTestFactory(preemptOnly), framework.Preempt)
-
+func TestScenarioPortfolioReturnsNoGeneratorWhenNoAvailableGenerators(t *testing.T) {
+	ctx, _, _ := newScenarioPortfolioTestContext(t, framework.Reclaim)
 	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
 
 	require.Nil(t, portfolio.Next())
 	require.Equal(t, SearchResultNoGenerator, portfolio.StopReason())
-	require.Zero(t, preemptOnly.nextCalls)
 }
 
 func TestScenarioPortfolioReturnsGeneratorsExhaustedAfterAllGeneratorsEnd(t *testing.T) {

--- a/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
@@ -1,0 +1,239 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestScenarioPortfolioUsesRegistrationOrder(t *testing.T) {
+	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	secondScenario := newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob)
+	firstGenerator := &portfolioTestGenerator{name: "first", scenarios: []api.ScenarioInfo{firstScenario}}
+	secondGenerator := &portfolioTestGenerator{name: "second", scenarios: []api.ScenarioInfo{secondScenario}}
+	ctx.Session.AddScenarioGenerator("first", portfolioTestFactory(firstGenerator))
+	ctx.Session.AddScenarioGenerator("second", portfolioTestFactory(secondGenerator))
+
+	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
+
+	require.Same(t, firstScenario, portfolio.Next())
+	require.Same(t, secondScenario, portfolio.Next())
+	require.Nil(t, portfolio.Next())
+	require.Equal(t, SearchResultGeneratorsExhausted, portfolio.StopReason())
+}
+
+func TestScenarioPortfolioFiltersByAction(t *testing.T) {
+	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	preemptOnly := &portfolioTestGenerator{name: "preempt", scenarios: []api.ScenarioInfo{
+		newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob),
+	}}
+	reclaimOnly := &portfolioTestGenerator{name: "reclaim", scenarios: []api.ScenarioInfo{firstScenario}}
+	allActionsScenario := newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob)
+	allActions := &portfolioTestGenerator{name: "all", scenarios: []api.ScenarioInfo{allActionsScenario}}
+	ctx.Session.AddScenarioGenerator("preempt", portfolioTestFactory(preemptOnly), framework.Preempt)
+	ctx.Session.AddScenarioGenerator("reclaim", portfolioTestFactory(reclaimOnly), framework.Reclaim)
+	ctx.Session.AddScenarioGenerator("all", portfolioTestFactory(allActions))
+
+	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
+
+	require.Same(t, firstScenario, portfolio.Next())
+	require.Same(t, allActionsScenario, portfolio.Next())
+	require.Nil(t, portfolio.Next())
+	require.Zero(t, preemptOnly.nextCalls)
+	require.Equal(t, SearchResultGeneratorsExhausted, portfolio.StopReason())
+}
+
+func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToGeneratorDeadline(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	firstGenerator := &portfolioTestGenerator{
+		name:      constants.GeneratorNodeLocalGreedy,
+		scenarios: []api.ScenarioInfo{firstScenario},
+		onNext: func() {
+			clock.Advance(2 * time.Millisecond)
+		},
+	}
+	secondGenerator := &portfolioTestGenerator{
+		name:      constants.GeneratorMultiNodeGang,
+		scenarios: []api.ScenarioInfo{newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob)},
+	}
+	ctx.Session.AddScenarioGenerator("first", portfolioTestFactory(firstGenerator))
+	ctx.Session.AddScenarioGenerator("second", portfolioTestFactory(secondGenerator))
+	actionBudget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("1s"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1s"),
+			MaxGeneratorSearchDuration: map[string]metav1.Duration{
+				constants.GeneratorNodeLocalGreedy: scenarioSearchDurationForTest("1ms"),
+				constants.GeneratorMultiNodeGang:   scenarioSearchDurationForTest("1s"),
+			},
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	portfolio := newScenarioPortfolio(ctx, actionBudget.BeginJob())
+
+	require.Same(t, firstScenario, portfolio.Next())
+	require.Same(t, secondGenerator.scenarios[0], portfolio.Next())
+	require.Equal(t, 1, firstGenerator.nextCalls)
+	require.Equal(t, 1, secondGenerator.nextCalls)
+}
+
+func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToJobDeadline(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	generator := &portfolioTestGenerator{
+		name:      constants.GeneratorNodeLocalGreedy,
+		scenarios: []api.ScenarioInfo{firstScenario},
+		onNext: func() {
+			clock.Advance(2 * time.Millisecond)
+		},
+	}
+	ctx.Session.AddScenarioGenerator("first", portfolioTestFactory(generator))
+	actionBudget, err := newActionSearchBudgetWithClock(
+		sessionWithScenarioSearchBudgets(&kaiv1.ScenarioSearchBudgets{
+			MaxActionSearchDuration: map[string]metav1.Duration{
+				constants.ActionReclaim: scenarioSearchDurationForTest("1s"),
+			},
+			MaxJobSearchDuration: scenarioSearchDurationPtrForTest("1ms"),
+			MaxGeneratorSearchDuration: map[string]metav1.Duration{
+				constants.GeneratorNodeLocalGreedy: scenarioSearchDurationForTest("1s"),
+			},
+		}),
+		framework.Reclaim,
+		clock.Now,
+	)
+	require.NoError(t, err)
+
+	portfolio := newScenarioPortfolio(ctx, actionBudget.BeginJob())
+
+	require.Same(t, firstScenario, portfolio.Next())
+}
+
+func TestScenarioPortfolioReturnsNoGeneratorWhenNoRegistrationApplies(t *testing.T) {
+	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	preemptOnly := &portfolioTestGenerator{name: "preempt", scenarios: []api.ScenarioInfo{firstScenario}}
+	ctx.Session.AddScenarioGenerator("preempt", portfolioTestFactory(preemptOnly), framework.Preempt)
+
+	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
+
+	require.Nil(t, portfolio.Next())
+	require.Equal(t, SearchResultNoGenerator, portfolio.StopReason())
+	require.Zero(t, preemptOnly.nextCalls)
+}
+
+func TestScenarioPortfolioReturnsGeneratorsExhaustedAfterAllGeneratorsEnd(t *testing.T) {
+	ctx, _, _ := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	firstGenerator := &portfolioTestGenerator{name: "first"}
+	secondGenerator := &portfolioTestGenerator{name: "second"}
+	ctx.Session.AddScenarioGenerator("first", portfolioTestFactory(firstGenerator))
+	ctx.Session.AddScenarioGenerator("second", portfolioTestFactory(secondGenerator))
+
+	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
+
+	require.Nil(t, portfolio.Next())
+	require.Equal(t, SearchResultGeneratorsExhausted, portfolio.StopReason())
+	require.Equal(t, 1, firstGenerator.nextCalls)
+	require.Equal(t, 1, secondGenerator.nextCalls)
+}
+
+func TestScenarioPortfolioSkipsNonByNodeScenarios(t *testing.T) {
+	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	firstGenerator := &portfolioTestGenerator{
+		name:      "first",
+		scenarios: []api.ScenarioInfo{portfolioTestScenarioInfo{}},
+	}
+	secondGenerator := &portfolioTestGenerator{name: "second", scenarios: []api.ScenarioInfo{firstScenario}}
+	ctx.Session.AddScenarioGenerator("first", portfolioTestFactory(firstGenerator))
+	ctx.Session.AddScenarioGenerator("second", portfolioTestFactory(secondGenerator))
+
+	portfolio := newScenarioPortfolio(ctx, newUnlimitedActionSearchBudget(framework.Reclaim).BeginJob())
+
+	require.Same(t, firstScenario, portfolio.Next())
+	require.Equal(t, 1, firstGenerator.nextCalls)
+	require.Equal(t, 1, secondGenerator.nextCalls)
+}
+
+func newScenarioPortfolioTestContext(
+	t *testing.T, action framework.ActionType,
+) (*SolveContext, *podgroup_info.PodGroupInfo, *scenario.ByNodeScenario) {
+	t.Helper()
+
+	ssn := newGeneratorTestSession(t, map[string]int{"node-1": 1})
+	pendingJob := addGeneratorTestPendingJob(t, ssn, 1, 10, "team-pending")
+	sn := newPortfolioTestByNodeScenario(t, ssn, pendingJob)
+	ctx := &SolveContext{
+		Session:              ssn,
+		ActionType:           action,
+		PartialPendingJob:    pendingJob,
+		GenerateVictimsQueue: generatorTestVictimsQueueFactory(ssn),
+		FeasibleNodes:        ssn.ClusterInfo.Nodes,
+	}
+	return ctx, pendingJob, sn
+}
+
+func newPortfolioTestByNodeScenario(
+	t *testing.T, ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo,
+) *scenario.ByNodeScenario {
+	t.Helper()
+
+	pendingTasks := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	return scenario.NewByNodeScenario(ssn, pendingJob, pendingTasks, nil, nil)
+}
+
+func portfolioTestFactory(generator framework.ScenarioGenerator) framework.ScenarioGeneratorFactory {
+	return func(framework.ScenarioGeneratorContext) framework.ScenarioGenerator {
+		return generator
+	}
+}
+
+type portfolioTestGenerator struct {
+	name      string
+	scenarios []api.ScenarioInfo
+	onNext    func()
+	nextCalls int
+}
+
+func (g *portfolioTestGenerator) Name() string {
+	return g.name
+}
+
+func (g *portfolioTestGenerator) Next() api.ScenarioInfo {
+	g.nextCalls++
+	if g.onNext != nil {
+		g.onNext()
+	}
+	if len(g.scenarios) == 0 {
+		return nil
+	}
+	sn := g.scenarios[0]
+	g.scenarios = g.scenarios[1:]
+	return sn
+}
+
+type portfolioTestScenarioInfo struct{}
+
+func (portfolioTestScenarioInfo) GetPreemptor() *podgroup_info.PodGroupInfo {
+	return nil
+}
+
+func (portfolioTestScenarioInfo) GetVictims() map[common_info.PodGroupID]*api.VictimInfo {
+	return nil
+}

--- a/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
@@ -59,6 +59,7 @@ func TestScenarioPortfolioFiltersByAction(t *testing.T) {
 func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToGeneratorDeadline(t *testing.T) {
 	clock := &fakeClock{now: time.Unix(0, 0)}
 	ctx, _, firstScenario := newScenarioPortfolioTestContext(t, framework.Reclaim)
+	secondScenario := newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob)
 	firstGenerator := &portfolioTestGenerator{
 		name:      constants.GeneratorNodeLocalGreedy,
 		scenarios: []api.ScenarioInfo{firstScenario},
@@ -68,7 +69,7 @@ func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToGeneratorDeadline(t *
 	}
 	secondGenerator := &portfolioTestGenerator{
 		name:      constants.GeneratorMultiNodeGang,
-		scenarios: []api.ScenarioInfo{newPortfolioTestByNodeScenario(t, ctx.Session, ctx.PartialPendingJob)},
+		scenarios: []api.ScenarioInfo{secondScenario},
 	}
 	ctx.Session.AddScenarioGenerator("first", portfolioTestFactory(firstGenerator))
 	ctx.Session.AddScenarioGenerator("second", portfolioTestFactory(secondGenerator))
@@ -91,7 +92,7 @@ func TestScenarioPortfolioDoesNotChargeGeneratorBuildTimeToGeneratorDeadline(t *
 	portfolio := newScenarioPortfolio(ctx, actionBudget.BeginJob())
 
 	require.Same(t, firstScenario, portfolio.Next())
-	require.Same(t, secondGenerator.scenarios[0], portfolio.Next())
+	require.Same(t, secondScenario, portfolio.Next())
 	require.Equal(t, 1, firstGenerator.nextCalls)
 	require.Equal(t, 1, secondGenerator.nextCalls)
 }

--- a/pkg/scheduler/actions/consolidation/consolidation_test.go
+++ b/pkg/scheduler/actions/consolidation/consolidation_test.go
@@ -1568,13 +1568,13 @@ func getTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
 						Status:       pod_status.Pipelined,
 					},
 					"running_job3": {
-						NodeName:     "node2",
+						NodeName:     "node3",
 						GPUsRequired: 4,
-						Status:       pod_status.Pipelined,
+						Status:       pod_status.Running,
 					},
 					"pending_job0": {
 						GPUsRequired: 3,
-						NodeName:     "node3",
+						NodeName:     "node2",
 						Status:       pod_status.Pipelined,
 					},
 				},

--- a/pkg/scheduler/actions/reclaim/reclaim_budget_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_budget_test.go
@@ -72,7 +72,7 @@ func TestAttemptToReclaimLetsSolverApplyMinJobBudgetAfterActionBudgetExpires(t *
 	require.False(t, succeeded)
 	require.Nil(t, statement)
 	require.Empty(t, victims)
-	require.Equal(t, solvers.SearchResultGeneratorsExhausted, result.Reason())
+	require.Equal(t, solvers.SearchResultNoGenerator, result.Reason())
 	require.Equal(t, 1, onJobSolutionStartCalls)
 }
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -64,7 +64,6 @@ type ScenarioGeneratorFactory func(ctx ScenarioGeneratorContext) ScenarioGenerat
 type ScenarioGeneratorRegistration struct {
 	Name    string
 	Factory ScenarioGeneratorFactory
-	Actions map[ActionType]struct{}
 }
 
 type Session struct {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -131,15 +131,10 @@ func (ssn *Session) AddPreJobAllocationFn(fn api.PreJobAllocationFn) {
 	ssn.PreJobAllocationFns = append(ssn.PreJobAllocationFns, fn)
 }
 
-func (ssn *Session) AddScenarioGenerator(name string, factory ScenarioGeneratorFactory, applies ...ActionType) {
-	actions := map[ActionType]struct{}{}
-	for _, action := range applies {
-		actions[action] = struct{}{}
-	}
+func (ssn *Session) AddScenarioGenerator(name string, factory ScenarioGeneratorFactory) {
 	ssn.ScenarioGeneratorRegistrations = append(ssn.ScenarioGeneratorRegistrations, ScenarioGeneratorRegistration{
 		Name:    name,
 		Factory: factory,
-		Actions: actions,
 	})
 }
 

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -232,23 +232,17 @@ func TestVictimInvariantPrePredicateFailure(t *testing.T) {
 	})
 }
 
-func TestAddScenarioGeneratorPreservesOrderAndActions(t *testing.T) {
+func TestAddScenarioGeneratorPreservesOrder(t *testing.T) {
 	ssn := &Session{}
 
-	ssn.AddScenarioGenerator("first", newTestScenarioGenerator("first"), Reclaim, Preempt)
-	ssn.AddScenarioGenerator("second", newTestScenarioGenerator("second"), Consolidation)
+	ssn.AddScenarioGenerator("first", newTestScenarioGenerator("first"))
+	ssn.AddScenarioGenerator("second", newTestScenarioGenerator("second"))
 	ssn.AddScenarioGenerator("third", newTestScenarioGenerator("third"))
 
 	require.Len(t, ssn.ScenarioGeneratorRegistrations, 3)
 	require.Equal(t, "first", ssn.ScenarioGeneratorRegistrations[0].Name)
 	require.Equal(t, "second", ssn.ScenarioGeneratorRegistrations[1].Name)
 	require.Equal(t, "third", ssn.ScenarioGeneratorRegistrations[2].Name)
-
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, Reclaim)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, Preempt)
-	require.NotContains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, Consolidation)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[1].Actions, Consolidation)
-	require.Empty(t, ssn.ScenarioGeneratorRegistrations[2].Actions)
 
 	generator := ssn.ScenarioGeneratorRegistrations[0].Factory(testScenarioGeneratorContext{action: Reclaim})
 	require.Equal(t, "first", generator.Name())

--- a/pkg/scheduler/plugins/multinodegang/multinodegang.go
+++ b/pkg/scheduler/plugins/multinodegang/multinodegang.go
@@ -34,5 +34,5 @@ func addScenarioGenerator(
 			return
 		}
 	}
-	ssn.AddScenarioGenerator(name, factory, framework.Reclaim, framework.Preempt, framework.Consolidation)
+	ssn.AddScenarioGenerator(name, factory)
 }

--- a/pkg/scheduler/plugins/multinodegang/multinodegang_test.go
+++ b/pkg/scheduler/plugins/multinodegang/multinodegang_test.go
@@ -21,9 +21,6 @@ func TestMultiNodeGangPluginRegistersMultiNodeGangGenerator(t *testing.T) {
 	require.Equal(t, Name, plugin.Name())
 	require.Len(t, ssn.ScenarioGeneratorRegistrations, 1)
 	require.Equal(t, constants.GeneratorMultiNodeGang, ssn.ScenarioGeneratorRegistrations[0].Name)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, framework.Reclaim)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, framework.Preempt)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, framework.Consolidation)
 }
 
 func TestMultiNodeGangGeneratorConstructorLivesInPluginPackage(t *testing.T) {

--- a/pkg/scheduler/plugins/nodelocalgreedy/nodelocalgreedy.go
+++ b/pkg/scheduler/plugins/nodelocalgreedy/nodelocalgreedy.go
@@ -34,5 +34,5 @@ func addScenarioGenerator(
 			return
 		}
 	}
-	ssn.AddScenarioGenerator(name, factory, framework.Reclaim, framework.Preempt, framework.Consolidation)
+	ssn.AddScenarioGenerator(name, factory)
 }

--- a/pkg/scheduler/plugins/nodelocalgreedy/nodelocalgreedy_test.go
+++ b/pkg/scheduler/plugins/nodelocalgreedy/nodelocalgreedy_test.go
@@ -21,9 +21,6 @@ func TestNodeLocalGreedyPluginRegistersNodeLocalGenerator(t *testing.T) {
 	require.Equal(t, Name, plugin.Name())
 	require.Len(t, ssn.ScenarioGeneratorRegistrations, 1)
 	require.Equal(t, constants.GeneratorNodeLocalGreedy, ssn.ScenarioGeneratorRegistrations[0].Name)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, framework.Reclaim)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, framework.Preempt)
-	require.Contains(t, ssn.ScenarioGeneratorRegistrations[0].Actions, framework.Consolidation)
 }
 
 func TestNodeLocalGreedyGeneratorConstructorLivesInPluginPackage(t *testing.T) {


### PR DESCRIPTION
## Description

Stack slice 6 of 9 for the reclaim generator portfolio.

References:
- Full implementation PR: #1716
- Design: #1696 (`docs/developer/designs/reclaim-generator-portfolio-design.md`)
- Original issue: #1660

This PR adds the portfolio driver:
- Drives the solver from the registered scenario generator portfolio.
- Preserves the per-generator lifecycle: one generator owns a full partial-gang search before fallback to the next generator.
- Keeps benchmark-scale assertions out of this PR.

This slice turns the registered built-in generators into the active search portfolio.

## Related Issues

Related to #1660.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Stacking:
- Base: `erez/reclaim-generator-portfolio-05-built-in-generators`
- Next PR: `erez/reclaim-generator-portfolio-07-metrics`

Verification for the rebuilt stack:
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache go test ./pkg/scheduler/plugins/scenariogenerators ./pkg/scheduler/conf_util ./pkg/operator/operands/scheduler ./pkg/scheduler/actions/common/solvers ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/preempt ./pkg/scheduler/actions/consolidation ./pkg/scheduler/actions/integration_tests/reclaim ./pkg/scheduler/cache ./pkg/scheduler/cache/status_updater ./pkg/scheduler/metrics ./pkg/apis/scheduling/v2alpha2 -count=1`
- `git diff --check`
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache make validate`
