### PR TITLE
feat(scheduler): add scenario search metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Added built-in `NodeLocalGreedy` and `MultiNodeGang` scenario generator implementations for bounded reclaim, preempt, and consolidation search.
+- Added a bounded scenario generator portfolio for reclaim, preempt, and consolidation search, with `SchedulingShard.spec.scenarioSearchBudgets` time-budget configuration and production scenario-search metrics.
 - Added an opt-in `deviceaccess` admission plugin (`--block-nvidia-visible-devices`, config field `admission.blockNvidiaVisibleDevices`, default disabled) that (1) rejects pods overriding the `NVIDIA_VISIBLE_DEVICES` environment variable with values other than `void`/`none` (or via a `valueFrom` reference), and (2) injects `NVIDIA_VISIBLE_DEVICES=void` into containers that do not request a GPU, blocking their access to GPUs on the node.
 - Added support for configuring admission Pod Disruption Budget via Helm values (`admission.podDisruptionBudget`) [#1490](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490) [dttung2905](https://github.com/dttung2905)
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.

--- a/docs/metrics/METRICS.md
+++ b/docs/metrics/METRICS.md
@@ -59,6 +59,13 @@ Metrics related to the core scheduling algorithm performance, task lifecycle, an
 | `scenarios_filtered_by_action` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action` | Cumulative count of simulation scenarios filtered/rejected by each action. |
 | `total_preemption_attempts` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service` | Cumulative total of preemption attempts across the entire cluster lifetime. |
 | `pod_group_evicted_pods_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `podgroup`, `uid`, `nodepool`, `action` | Cumulative count of pods evicted per pod group, tracked by nodepool and action. |
+| `scenario_search_jobs_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action`, `result`, `reduced_budget` | Cumulative count of jobs considered by bounded scenario search, grouped by scheduling action, terminal search result, and whether the job ran after the action budget was reduced. |
+| `scenario_search_action_budget_configured_seconds` | Gauge | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action` | Configured scenario-search budget for each scheduling action in seconds. A value of 0 means unlimited. |
+| `scenario_search_job_budget_configured_seconds` | Gauge | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service` | Configured per-job scenario-search budget in seconds. A value of 0 means unlimited. |
+| `scenario_search_generator_budget_configured_seconds` | Gauge | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `generator` | Configured per-generator scenario-search budget in seconds. A value of 0 means unlimited. |
+| `scenario_search_action_budget_exhausted_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action` | Cumulative count of action-level scenario-search budget exhaustion events. |
+| `scenario_search_duration_seconds` | Histogram | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action`, `generator`, `result` | Duration in seconds of generator scenario-search attempts. Buckets: [1ms, 2ms, 4ms, ..., 32.768s] (exponential). |
+| `scenario_search_scenarios_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action`, `generator`, `state` | Cumulative count of bounded-search scenarios emitted by generators, simulated by the solver, or rejected by validation. |
 
 ### Queue Fair-Share & Usage Metrics
 
@@ -88,6 +95,10 @@ Business/Resource Labels:
 - **`queue_metadata_name`**: The Queue resource's `metadata.name`. Always populated.
 - **`queue_display_name`**: The Queue's `spec.displayName`. Empty string when unset.
 - **`action`**: Scheduling action name
+- **`generator`**: Scenario generator name
+- **`result`**: Scenario search result (`solved`, `deadline_exhausted`, `generators_exhausted`, `no_generator`, `not_attempted`, `unsolved`, or `validator_rejected`, depending on the metric)
+- **`reduced_budget`**: Whether the scenario search ran after the action budget was reduced (`true` or `false`)
+- **`state`**: Scenario lifecycle state (`emitted`, `simulated`, or `validator_rejected`)
 - **`plugin`**: Plugin name
 - **`OnSession`**: Session lifecycle phase (`OnSessionOpen` or `OnSessionClose`)
 - **`podgroup`**: PodGroup resource identifier

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.88.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/ray-project/kuberay/ray-operator v1.5.1
 	github.com/run-ai/kwok-operator v0.0.0-20240926063032-05b6364bc7c7
@@ -149,7 +150,6 @@ require (
 	github.com/opencontainers/selinux v1.13.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -84,12 +85,22 @@ func (s *JobSolver) Solve(
 func (s *JobSolver) SolveWithResult(
 	ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo,
 ) (solved bool, statement *framework.Statement, victimTaskNames []string, searchResult *SearchResult) {
+	defer func() {
+		if searchResult != nil {
+			metrics.IncScenarioSearchJobs(
+				s.actionType, searchResult.scenarioSearchMetricResult(), searchResult.ReducedBudget(),
+			)
+		}
+	}()
+
 	originalNumActiveTasks := pendingJob.GetNumActiveUsedTasks()
 
 	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
 	n := len(tasksToAllocate)
 	if n == 0 {
-		return false, nil, nil, terminalSearchResult(SearchResultGeneratorsExhausted, false)
+		searchResult := terminalSearchResult(SearchResultGeneratorsExhausted, false)
+		searchResult.metricResult = string(SearchResultNotAttempted)
+		return false, nil, nil, searchResult
 	}
 
 	jobBudget := s.actionBudget.BeginJob()
@@ -313,25 +324,58 @@ func (s *JobSolver) solvePartialJob(
 
 	for {
 		if jobBudget.Exhausted() {
+			s.observeActionBudgetExhausted()
 			return terminalSearchResult(SearchResultDeadlineExhausted, jobBudget.ReducedBudget())
 		}
 		scenarioToSolve := portfolio.Next()
 		if scenarioToSolve == nil {
 			break
 		}
-		scenarioSolver := newByPodSolver(feasibleNodeMap, s.solutionValidator, ssn.AllowConsolidatingReclaim(),
+		generatorName := portfolio.CurrentGeneratorName()
+		validatorRejected := false
+		scenarioSolver := newByPodSolver(feasibleNodeMap, s.solutionValidatorWithMetrics(generatorName, &validatorRejected),
+			ssn.AllowConsolidatingReclaim(),
 			s.actionType)
 
 		log.InfraLogger.V(5).Infof("Trying to solve scenario: %s", scenarioToSolve)
 		metrics.IncScenarioSimulatedByAction()
+		metrics.IncScenarioSearchScenario(s.actionType, generatorName, "simulated")
 
 		result := scenarioSolver.solve(ssn, scenarioToSolve)
+		attemptResult := scenarioSearchResultUnsolved
+		if validatorRejected {
+			attemptResult = scenarioSearchResultValidatorRejected
+		}
 		if result.solved {
+			portfolio.ObserveCurrentAttempt(string(SearchResultSolved))
 			return solvedSearchResult(result, jobBudget.ReducedBudget())
 		}
+		portfolio.ObserveCurrentAttempt(attemptResult)
 	}
 
 	return terminalSearchResult(portfolio.StopReason(), jobBudget.ReducedBudget())
+}
+
+func (s *JobSolver) observeActionBudgetExhausted() {
+	if s.actionBudget != nil && s.actionBudget.Exhausted() {
+		metrics.IncScenarioSearchActionBudgetExhausted(s.actionType)
+	}
+}
+
+func (s *JobSolver) solutionValidatorWithMetrics(generator string, rejected *bool) SolutionValidator {
+	if s.solutionValidator == nil {
+		return nil
+	}
+	return func(scenario api.ScenarioInfo) bool {
+		valid := s.solutionValidator(scenario)
+		if !valid {
+			if rejected != nil {
+				*rejected = true
+			}
+			metrics.IncScenarioSearchScenario(s.actionType, generator, "validator_rejected")
+		}
+		return valid
+	}
 }
 
 func shouldStopSearch(result *SearchResult) bool {

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -177,7 +177,7 @@ func TestSolveWithResultRecordsGeneratorExhaustedMetricAfterGeneratorAttempt(t *
 	}
 	before := scenarioSearchCounterValue(t, "scenario_search_jobs_total", labels)
 	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
-	ssn.AddScenarioGenerator("empty", portfolioTestFactory(&portfolioTestGenerator{name: "empty"}), framework.Reclaim)
+	ssn.AddScenarioGenerator("empty", portfolioTestFactory(&portfolioTestGenerator{name: "empty"}))
 	solver := NewJobsSolver(
 		nil,
 		nil,
@@ -212,7 +212,7 @@ func TestSolveWithResultRecordsUnsolvedScenarioDurationAfterSimulation(t *testin
 	ssn.AddScenarioGenerator(generatorName, portfolioTestFactory(&portfolioTestGenerator{
 		name:      generatorName,
 		scenarios: []api.ScenarioInfo{scenarioToSolve},
-	}), framework.Reclaim)
+	}))
 	solver := NewJobsSolver(
 		nil,
 		nil,

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +47,22 @@ func TestSolveWithResultReturnsTerminalResultWhenNoTasksToAllocate(t *testing.T)
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultGeneratorsExhausted, result.Reason())
 	require.False(t, result.ReducedBudget())
+}
+
+func TestSolveWithResultRecordsNoSearchMetricAsNotAttempted(t *testing.T) {
+	labels := map[string]string{
+		"action":         "reclaim",
+		"result":         string(SearchResultNotAttempted),
+		"reduced_budget": "false",
+	}
+	before := scenarioSearchCounterValue(t, "scenario_search_jobs_total", labels)
+	solver := NewJobsSolver(nil, nil, nil, framework.Reclaim, nil)
+	pendingJob := podgroup_info.NewPodGroupInfo("pending-job")
+
+	_, _, _, result := solver.SolveWithResult(&framework.Session{}, pendingJob)
+
+	require.Equal(t, SearchResultGeneratorsExhausted, result.Reason())
+	require.Equal(t, before+1, scenarioSearchCounterValue(t, "scenario_search_jobs_total", labels))
 }
 
 func TestSolveWithResultReturnsNoGeneratorWhenGeneratorFuncIsNil(t *testing.T) {
@@ -149,6 +167,65 @@ func TestSolveWithResultReportsDeadlineWhenBudgetExhaustsDuringScenarioSearch(t 
 	require.Nil(t, statement)
 	require.Empty(t, victims)
 	require.Equal(t, SearchResultDeadlineExhausted, result.Reason())
+}
+
+func TestSolveWithResultRecordsGeneratorExhaustedMetricAfterGeneratorAttempt(t *testing.T) {
+	labels := map[string]string{
+		"action":         "reclaim",
+		"result":         string(SearchResultGeneratorsExhausted),
+		"reduced_budget": "false",
+	}
+	before := scenarioSearchCounterValue(t, "scenario_search_jobs_total", labels)
+	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	ssn.AddScenarioGenerator("empty", portfolioTestFactory(&portfolioTestGenerator{name: "empty"}), framework.Reclaim)
+	solver := NewJobsSolver(
+		nil,
+		nil,
+		func() *utils.JobsOrderByQueues {
+			return utils.GetVictimsQueue(ssn, nil)
+		},
+		framework.Reclaim,
+		nil,
+	)
+
+	_, _, _, result := solver.SolveWithResult(ssn, pendingJob)
+
+	require.Equal(t, SearchResultGeneratorsExhausted, result.Reason())
+	require.Equal(t, before+1, scenarioSearchCounterValue(t, "scenario_search_jobs_total", labels))
+}
+
+func TestSolveWithResultRecordsUnsolvedScenarioDurationAfterSimulation(t *testing.T) {
+	generatorName := "test-unsolved-duration"
+	labels := map[string]string{
+		"action":    "reclaim",
+		"generator": generatorName,
+		"result":    scenarioSearchResultUnsolved,
+	}
+	before := scenarioSearchHistogramCount(t, "scenario_search_duration_seconds", labels)
+	ssn, pendingJob := newJobSolverResultTestSession(t, 1)
+	ssn.ClusterInfo.Nodes = map[string]*node_info.NodeInfo{"node-1": {}}
+	scenarioToSolve := scenario.NewByNodeScenario(
+		ssn, pendingJob,
+		podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false),
+		nil, nil,
+	)
+	ssn.AddScenarioGenerator(generatorName, portfolioTestFactory(&portfolioTestGenerator{
+		name:      generatorName,
+		scenarios: []api.ScenarioInfo{scenarioToSolve},
+	}), framework.Reclaim)
+	solver := NewJobsSolver(
+		nil,
+		nil,
+		func() *utils.JobsOrderByQueues {
+			return utils.GetVictimsQueue(ssn, nil)
+		},
+		framework.Reclaim,
+		nil,
+	)
+
+	solver.SolveWithResult(ssn, pendingJob)
+
+	require.Equal(t, before+1, scenarioSearchHistogramCount(t, "scenario_search_duration_seconds", labels))
 }
 
 func TestSolveWithResultRunsCompletePartialSearchForOneGeneratorBeforeNext(t *testing.T) {
@@ -267,4 +344,55 @@ func newJobSolverResultTestSession(t *testing.T, tasksCount int) (*framework.Ses
 			Nodes: map[string]*node_info.NodeInfo{},
 		},
 	}, pendingJob
+}
+
+func scenarioSearchCounterValue(t *testing.T, metricName string, labels map[string]string) float64 {
+	t.Helper()
+
+	metric := scenarioSearchMetric(t, metricName, labels)
+	if metric == nil || metric.GetCounter() == nil {
+		return 0
+	}
+	return metric.GetCounter().GetValue()
+}
+
+func scenarioSearchHistogramCount(t *testing.T, metricName string, labels map[string]string) uint64 {
+	t.Helper()
+
+	metric := scenarioSearchMetric(t, metricName, labels)
+	if metric == nil || metric.GetHistogram() == nil {
+		return 0
+	}
+	return metric.GetHistogram().GetSampleCount()
+}
+
+func scenarioSearchMetric(t *testing.T, metricName string, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if scenarioSearchMetricHasLabels(metric, labels) {
+				return metric
+			}
+		}
+	}
+	return nil
+}
+
+func scenarioSearchMetricHasLabels(metric *dto.Metric, labels map[string]string) bool {
+	if len(metric.GetLabel()) != len(labels) {
+		return false
+	}
+	for _, label := range metric.GetLabel() {
+		expectedValue, found := labels[label.GetName()]
+		if !found || expectedValue != label.GetValue() {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/scheduler/actions/common/solvers/scenario_generator.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_generator.go
@@ -4,6 +4,8 @@
 package solvers
 
 import (
+	"time"
+
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
@@ -11,7 +13,11 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
 )
+
+const scenarioSearchResultUnsolved = "unsolved"
+const scenarioSearchResultValidatorRejected = "validator_rejected"
 
 type SolveContext struct {
 	Session              *framework.Session
@@ -30,12 +36,14 @@ func (ctx *SolveContext) Action() framework.ActionType {
 }
 
 type scenarioPortfolio struct {
-	ctx           *SolveContext
-	generators    []framework.ScenarioGenerator
-	jobBudget     *jobSearchBudget
-	currentIndex  int
-	currentBudget *generatorSearchBudget
-	stopReason    SearchResultReason
+	ctx              *SolveContext
+	generators       []framework.ScenarioGenerator
+	jobBudget        *jobSearchBudget
+	currentIndex     int
+	currentBudget    *generatorSearchBudget
+	currentName      string
+	currentStartedAt time.Time
+	stopReason       SearchResultReason
 }
 
 func newScenarioPortfolio(ctx *SolveContext, jobBudget *jobSearchBudget) *scenarioPortfolio {
@@ -113,22 +121,44 @@ func (p *scenarioPortfolio) Next() *scenario.ByNodeScenario {
 			continue
 		}
 
+		generatorName := generator.Name()
+		attemptStartedAt := time.Now()
 		sn := generator.Next()
 		if sn == nil {
+			p.observeGeneratorAttempt(generatorName, string(SearchResultGeneratorsExhausted), attemptStartedAt)
 			p.moveToNextGenerator()
 			continue
 		}
 		byNodeScenario, ok := sn.(*scenario.ByNodeScenario)
 		if !ok {
+			p.observeGeneratorAttempt(generatorName, "unsupported", attemptStartedAt)
 			log.InfraLogger.V(4).Infof(
 				"Scenario generator <%s> returned unsupported scenario type %T",
-				generator.Name(), sn,
+				generatorName, sn,
 			)
 			p.moveToNextGenerator()
 			continue
 		}
+		p.currentName = generatorName
+		p.currentStartedAt = attemptStartedAt
+		metrics.IncScenarioSearchScenario(p.ctx.ActionType, generatorName, "emitted")
 		return byNodeScenario
 	}
+}
+
+func (p *scenarioPortfolio) CurrentGeneratorName() string {
+	if p == nil {
+		return ""
+	}
+	return p.currentName
+}
+
+func (p *scenarioPortfolio) ObserveCurrentAttempt(result string) {
+	if p == nil || p.currentStartedAt.IsZero() {
+		return
+	}
+	p.observeGeneratorAttempt(p.currentName, result, p.currentStartedAt)
+	p.currentStartedAt = time.Time{}
 }
 
 func (p *scenarioPortfolio) StopReason() SearchResultReason {
@@ -148,6 +178,15 @@ func (p *scenarioPortfolio) currentGenerator() framework.ScenarioGenerator {
 func (p *scenarioPortfolio) moveToNextGenerator() {
 	p.currentIndex++
 	p.currentBudget = nil
+	p.currentName = ""
+	p.currentStartedAt = time.Time{}
+}
+
+func (p *scenarioPortfolio) observeGeneratorAttempt(generator string, result string, startedAt time.Time) {
+	if p == nil || p.ctx == nil {
+		return
+	}
+	metrics.ObserveScenarioSearchDuration(p.ctx.ActionType, generator, result, time.Since(startedAt))
 }
 
 // ValidateScenarioGeneratorContext extracts the solver context required by scenario generator plugins.

--- a/pkg/scheduler/actions/common/solvers/search_budget.go
+++ b/pkg/scheduler/actions/common/solvers/search_budget.go
@@ -12,6 +12,7 @@ import (
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
 )
 
 const unlimitedRemaining = time.Duration(1<<63 - 1)
@@ -79,6 +80,11 @@ func newActionSearchBudgetWithClock(
 	generatorLimits, err := parseGeneratorLimits(budgets)
 	if err != nil {
 		return nil, err
+	}
+	metrics.SetScenarioSearchActionBudget(action, actionLimit)
+	metrics.SetScenarioSearchJobBudget(jobLimit)
+	for generator, limit := range generatorLimits {
+		metrics.SetScenarioSearchGeneratorBudget(generator, limit)
 	}
 
 	return &ActionSearchBudget{

--- a/pkg/scheduler/actions/common/solvers/search_result.go
+++ b/pkg/scheduler/actions/common/solvers/search_result.go
@@ -19,6 +19,7 @@ type SearchResult struct {
 	reason        SearchResultReason
 	solution      *solutionResult
 	reducedBudget bool
+	metricResult  string
 }
 
 func (r *SearchResult) Reason() SearchResultReason {
@@ -33,6 +34,16 @@ func (r *SearchResult) ReducedBudget() bool {
 		return false
 	}
 	return r.reducedBudget
+}
+
+func (r *SearchResult) scenarioSearchMetricResult() string {
+	if r == nil {
+		return ""
+	}
+	if r.metricResult != "" {
+		return r.metricResult
+	}
+	return string(r.reason)
 }
 
 // NewNotAttemptedSearchResult returns a terminal result for callers that skip solver entry.

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -20,6 +20,7 @@ limitations under the License.
 package metrics
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,27 +36,34 @@ const (
 )
 
 var (
-	currentAction               string
-	e2eSchedulingLatency        prometheus.Gauge
-	openSessionLatency          prometheus.Gauge
-	closeSessionLatency         prometheus.Gauge
-	pluginSchedulingLatency     *prometheus.GaugeVec
-	actionSchedulingLatency     *prometheus.GaugeVec
-	taskSchedulingLatency       prometheus.Histogram
-	taskBindLatency             prometheus.Histogram
-	podgroupsScheduledByAction  *prometheus.CounterVec
-	podgroupsConsideredByAction *prometheus.CounterVec
-	scenariosSimulatedByAction  *prometheus.CounterVec
-	scenariosFilteredByAction   *prometheus.CounterVec
-	preemptionAttempts          prometheus.Counter
-	queueFairShareCPU           *prometheus.GaugeVec
-	queueFairShareMemory        *prometheus.GaugeVec
-	queueFairShareGPU           *prometheus.GaugeVec
-	queueCPUUsage               *prometheus.GaugeVec
-	queueMemoryUsage            *prometheus.GaugeVec
-	queueGPUUsage               *prometheus.GaugeVec
-	usageQueryLatency           *prometheus.HistogramVec
-	podGroupEvictedPodsTotal    *prometheus.CounterVec
+	currentAction                                  string
+	e2eSchedulingLatency                           prometheus.Gauge
+	openSessionLatency                             prometheus.Gauge
+	closeSessionLatency                            prometheus.Gauge
+	pluginSchedulingLatency                        *prometheus.GaugeVec
+	actionSchedulingLatency                        *prometheus.GaugeVec
+	taskSchedulingLatency                          prometheus.Histogram
+	taskBindLatency                                prometheus.Histogram
+	podgroupsScheduledByAction                     *prometheus.CounterVec
+	podgroupsConsideredByAction                    *prometheus.CounterVec
+	scenariosSimulatedByAction                     *prometheus.CounterVec
+	scenariosFilteredByAction                      *prometheus.CounterVec
+	preemptionAttempts                             prometheus.Counter
+	queueFairShareCPU                              *prometheus.GaugeVec
+	queueFairShareMemory                           *prometheus.GaugeVec
+	queueFairShareGPU                              *prometheus.GaugeVec
+	queueCPUUsage                                  *prometheus.GaugeVec
+	queueMemoryUsage                               *prometheus.GaugeVec
+	queueGPUUsage                                  *prometheus.GaugeVec
+	usageQueryLatency                              *prometheus.HistogramVec
+	podGroupEvictedPodsTotal                       *prometheus.CounterVec
+	scenarioSearchJobsTotal                        *prometheus.CounterVec
+	scenarioSearchActionBudgetConfiguredSeconds    *prometheus.GaugeVec
+	scenarioSearchJobBudgetConfiguredSeconds       prometheus.Gauge
+	scenarioSearchGeneratorBudgetConfiguredSeconds *prometheus.GaugeVec
+	scenarioSearchActionBudgetExhaustedTotal       *prometheus.CounterVec
+	scenarioSearchDurationSeconds                  *prometheus.HistogramVec
+	scenarioSearchScenariosTotal                   *prometheus.CounterVec
 )
 
 func init() {
@@ -207,6 +215,56 @@ func InitMetrics(namespace string) {
 			Name:      "pod_group_evicted_pods_total",
 			Help:      "Total number of pods evicted per pod group",
 		}, []string{"podgroup", "namespace", "uid", "nodepool", "action"})
+
+	scenarioSearchJobsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_jobs_total",
+			Help:      "Count of jobs considered by bounded scenario search.",
+		}, []string{"action", "result", "reduced_budget"})
+
+	scenarioSearchActionBudgetConfiguredSeconds = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_action_budget_configured_seconds",
+			Help:      "Configured action scenario search budget in seconds.",
+		}, []string{"action"})
+
+	scenarioSearchJobBudgetConfiguredSeconds = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_job_budget_configured_seconds",
+			Help:      "Configured per-job scenario search budget in seconds.",
+		})
+
+	scenarioSearchGeneratorBudgetConfiguredSeconds = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_generator_budget_configured_seconds",
+			Help:      "Configured generator scenario search budget in seconds.",
+		}, []string{"generator"})
+
+	scenarioSearchActionBudgetExhaustedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_action_budget_exhausted_total",
+			Help:      "Count of action-level scenario search budget exhaustion events.",
+		}, []string{"action"})
+
+	scenarioSearchDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_duration_seconds",
+			Help:      "Elapsed generator-search duration in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 16),
+		}, []string{"action", "generator", "result"})
+
+	scenarioSearchScenariosTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "scenario_search_scenarios_total",
+			Help:      "Count of bounded-search scenarios by state.",
+		}, []string{"action", "generator", "state"})
 }
 
 // UpdateOpenSessionDuration updates latency for open session, including all plugins
@@ -310,6 +368,34 @@ func RegisterPreemptionAttempts() {
 // RecordPodGroupEvictedPods records the number of pods evicted for a pod group
 func RecordPodGroupEvictedPods(name, namespace, uid, nodepool, action string, count int) {
 	podGroupEvictedPodsTotal.WithLabelValues(name, namespace, uid, nodepool, action).Add(float64(count))
+}
+
+func IncScenarioSearchJobs[A ~string](action A, result string, reducedBudget bool) {
+	scenarioSearchJobsTotal.WithLabelValues(string(action), result, strconv.FormatBool(reducedBudget)).Inc()
+}
+
+func SetScenarioSearchActionBudget[A ~string](action A, budget time.Duration) {
+	scenarioSearchActionBudgetConfiguredSeconds.WithLabelValues(string(action)).Set(budget.Seconds())
+}
+
+func SetScenarioSearchJobBudget(budget time.Duration) {
+	scenarioSearchJobBudgetConfiguredSeconds.Set(budget.Seconds())
+}
+
+func SetScenarioSearchGeneratorBudget(generator string, budget time.Duration) {
+	scenarioSearchGeneratorBudgetConfiguredSeconds.WithLabelValues(generator).Set(budget.Seconds())
+}
+
+func IncScenarioSearchActionBudgetExhausted[A ~string](action A) {
+	scenarioSearchActionBudgetExhaustedTotal.WithLabelValues(string(action)).Inc()
+}
+
+func ObserveScenarioSearchDuration[A ~string](action A, generator string, result string, duration time.Duration) {
+	scenarioSearchDurationSeconds.WithLabelValues(string(action), generator, result).Observe(duration.Seconds())
+}
+
+func IncScenarioSearchScenario[A ~string](action A, generator string, state string) {
+	scenarioSearchScenariosTotal.WithLabelValues(string(action), generator, state).Inc()
 }
 
 // Duration get the time since specified start

--- a/pkg/scheduler/metrics/metrics_test.go
+++ b/pkg/scheduler/metrics/metrics_test.go
@@ -5,9 +5,12 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
 )
 
 // TestQueueLabels exercises the three queue identification labels emitted on
@@ -17,9 +20,9 @@ import (
 func TestQueueLabels(t *testing.T) {
 	cases := []struct {
 		name              string
-		queueName         string // value passed as queue_name (display-name fallback)
-		queueMetadataName string // value passed as queue_metadata_name
-		queueDisplayName  string // value passed as queue_display_name
+		queueName         string
+		queueMetadataName string
+		queueDisplayName  string
 	}{
 		{
 			name:              "displayName set and different from metadata.name",
@@ -59,6 +62,69 @@ func TestQueueLabels(t *testing.T) {
 	}
 }
 
+func TestScenarioSearchMetricWrappersUseExpectedLabels(t *testing.T) {
+	jobsLabels := map[string]string{
+		"action":         "test-action-jobs",
+		"result":         "solved",
+		"reduced_budget": "true",
+	}
+	actionExhaustedLabels := map[string]string{
+		"action": "test-action-exhausted",
+	}
+	scenariosLabels := map[string]string{
+		"action":    "test-action-scenarios",
+		"generator": "test-generator-labels",
+		"state":     "emitted",
+	}
+	jobsBefore := counterValueOrZero(t, "scenario_search_jobs_total", jobsLabels)
+	actionExhaustedBefore := counterValueOrZero(
+		t, "scenario_search_action_budget_exhausted_total", actionExhaustedLabels,
+	)
+	scenariosBefore := counterValueOrZero(t, "scenario_search_scenarios_total", scenariosLabels)
+
+	IncScenarioSearchJobs("test-action-jobs", "solved", true)
+	IncScenarioSearchActionBudgetExhausted("test-action-exhausted")
+	IncScenarioSearchScenario("test-action-scenarios", "test-generator-labels", "emitted")
+
+	require.Equal(t, jobsBefore+1, counterValue(t, "scenario_search_jobs_total", jobsLabels))
+	require.Equal(t, actionExhaustedBefore+1, counterValue(
+		t, "scenario_search_action_budget_exhausted_total", actionExhaustedLabels,
+	))
+	require.Equal(t, scenariosBefore+1, counterValue(t, "scenario_search_scenarios_total", scenariosLabels))
+}
+
+func TestScenarioSearchDurationMetricObservesSeconds(t *testing.T) {
+	labels := map[string]string{
+		"action":    "test-action-duration",
+		"generator": "test-generator-duration",
+		"result":    "generators_exhausted",
+	}
+	countBefore, sumBefore := histogramSnapshot(t, "scenario_search_duration_seconds", labels)
+
+	ObserveScenarioSearchDuration(
+		"test-action-duration", "test-generator-duration", "generators_exhausted", 2500*time.Millisecond,
+	)
+
+	countAfter, sumAfter := histogramSnapshot(t, "scenario_search_duration_seconds", labels)
+
+	require.Equal(t, countBefore+1, countAfter)
+	require.InEpsilon(t, sumBefore+2.5, sumAfter, 0.000001)
+}
+
+func TestScenarioSearchConfiguredBudgetMetricsAcceptUnlimitedZero(t *testing.T) {
+	SetScenarioSearchActionBudget("test-action-zero-budget", 0)
+	SetScenarioSearchJobBudget(0)
+	SetScenarioSearchGeneratorBudget("test-generator-zero-budget", 0)
+
+	require.Equal(t, 0.0, gaugeValue(t, "scenario_search_action_budget_configured_seconds", map[string]string{
+		"action": "test-action-zero-budget",
+	}))
+	require.Equal(t, 0.0, gaugeValue(t, "scenario_search_job_budget_configured_seconds", nil))
+	require.Equal(t, 0.0, gaugeValue(t, "scenario_search_generator_budget_configured_seconds", map[string]string{
+		"generator": "test-generator-zero-budget",
+	}))
+}
+
 func assertGauge(t *testing.T, gauge *prometheus.GaugeVec, labels prometheus.Labels, expected float64) {
 	t.Helper()
 	g, err := gauge.GetMetricWith(labels)
@@ -68,4 +134,105 @@ func assertGauge(t *testing.T, gauge *prometheus.GaugeVec, labels prometheus.Lab
 	if got := testutil.ToFloat64(g); got != expected {
 		t.Errorf("metric value for labels %v: got %v, want %v", labels, got, expected)
 	}
+}
+
+func counterValue(t *testing.T, metricName string, labels map[string]string) float64 {
+	t.Helper()
+
+	metric := findMetric(t, metricName, labels)
+	require.NotNil(t, metric.GetCounter())
+	return metric.GetCounter().GetValue()
+}
+
+func counterValueOrZero(t *testing.T, metricName string, labels map[string]string) float64 {
+	t.Helper()
+
+	metric := findMetricOrNil(t, metricName, labels)
+	if metric == nil || metric.GetCounter() == nil {
+		return 0
+	}
+	return metric.GetCounter().GetValue()
+}
+
+func gaugeValue(t *testing.T, metricName string, labels map[string]string) float64 {
+	t.Helper()
+
+	metric := findMetric(t, metricName, labels)
+	require.NotNil(t, metric.GetGauge())
+	return metric.GetGauge().GetValue()
+}
+
+func histogramSnapshot(t *testing.T, metricName string, labels map[string]string) (uint64, float64) {
+	t.Helper()
+
+	metric := findMetricOrNil(t, metricName, labels)
+	if metric == nil || metric.GetHistogram() == nil {
+		return 0, 0
+	}
+	histogram := metric.GetHistogram()
+	return histogram.GetSampleCount(), histogram.GetSampleSum()
+}
+
+func findMetric(t *testing.T, metricName string, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	family := findMetricFamily(t, metricName)
+	for _, metric := range family.GetMetric() {
+		if metricHasLabels(metric, labels) {
+			return metric
+		}
+	}
+	t.Fatalf("metric %q with labels %v not found", metricName, labels)
+	return nil
+}
+
+func findMetricOrNil(t *testing.T, metricName string, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	family := findMetricFamilyOrNil(t, metricName)
+	if family == nil {
+		return nil
+	}
+	for _, metric := range family.GetMetric() {
+		if metricHasLabels(metric, labels) {
+			return metric
+		}
+	}
+	return nil
+}
+
+func findMetricFamily(t *testing.T, metricName string) *dto.MetricFamily {
+	t.Helper()
+
+	if family := findMetricFamilyOrNil(t, metricName); family != nil {
+		return family
+	}
+	t.Fatalf("metric family %q not found", metricName)
+	return nil
+}
+
+func findMetricFamilyOrNil(t *testing.T, metricName string) *dto.MetricFamily {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() == metricName {
+			return family
+		}
+	}
+	return nil
+}
+
+func metricHasLabels(metric *dto.Metric, labels map[string]string) bool {
+	if len(metric.GetLabel()) != len(labels) {
+		return false
+	}
+	for _, label := range metric.GetLabel() {
+		expectedValue, found := labels[label.GetName()]
+		if !found || expectedValue != label.GetValue() {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Description

Stack slice 7 of 9 for the reclaim generator portfolio.

References:
- Full implementation PR: #1716
- Design: #1696 (`docs/developer/designs/reclaim-generator-portfolio-design.md`)
- Original issue: #1660

This PR adds scenario search observability:
- Adds scenario-search counters, gauges, histograms, and metric wrapper tests.
- Wires metrics into budget parsing, portfolio attempts, solver outcomes, and deadline exhaustion.
- Includes the `go.mod` direct dependency adjustment needed by the metrics wrapper tests.

Runtime behavior is the same search behavior introduced earlier in the stack, with metrics emitted for visibility.

## Related Issues

Related to #1660.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Stacking:
- Base: `erez/reclaim-generator-portfolio-06-portfolio-driver`
- Next PR: `erez/reclaim-generator-portfolio-08-explainability`

Verification for the rebuilt stack:
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache go test ./pkg/scheduler/plugins/scenariogenerators ./pkg/scheduler/conf_util ./pkg/operator/operands/scheduler ./pkg/scheduler/actions/common/solvers ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/preempt ./pkg/scheduler/actions/consolidation ./pkg/scheduler/actions/integration_tests/reclaim ./pkg/scheduler/cache ./pkg/scheduler/cache/status_updater ./pkg/scheduler/metrics ./pkg/apis/scheduling/v2alpha2 -count=1`
- `git diff --check`
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache make validate`
