### PR TITLE
feat(scheduler): explain unresolved scenario searches

### DIFF
--- a/docs/developer/designs/reclaim-generator-portfolio-design.md
+++ b/docs/developer/designs/reclaim-generator-portfolio-design.md
@@ -303,7 +303,7 @@ User-facing condition messages should describe the scheduling outcome, not the i
 
 If `reduced_budget=true`, the message should say that the scheduler could not find a valid scenario within the remaining configured search time because the action search budget was partly consumed by earlier jobs. This wording must only be used for jobs that actually received a reduced budget.
 
-Kubernetes Events may repeat the same human-readable message on the `PodGroup` and Pods, but they should use `ScenarioSearchUnresolved` as the event reason rather than `Unschedulable`. Events should not include generator names, probe sizes, scenario counts, or elapsed durations. Those details belong in metrics, logs, replay output, or future debug tooling.
+Kubernetes Events should continue to report the existing fundamental scheduling outcome, such as `Unschedulable`, rather than `ScenarioSearchUnresolved`. Scenario-search unresolved details are durable status conditions on the `PodGroup` and pending Pods, not additional scenario-search events. Events should not include generator names, probe sizes, scenario counts, or elapsed durations. Those details belong in metrics, logs, replay output, or future debug tooling.
 
 ### Integration Posture
 
@@ -366,7 +366,7 @@ Initial implementation criteria:
 Default tuning criteria:
 
 - Defaults are tuned against the 1000-node large-job benchmark and representative production-like snapshots.
-- `ScenarioSearchUnresolved` conditions and events are accurate, and reduced-budget wording is only emitted for reduced-budget jobs.
+- `ScenarioSearchUnresolved` conditions are accurate, and reduced-budget wording is only emitted for reduced-budget jobs.
 - Metrics show `deadline_exhausted`, `generators_exhausted`, `no_generator`, and `not_attempted` outcomes clearly by action and, where applicable, generator.
 - Legacy-equivalent configuration is documented as current emitter plus unlimited budgets; bounded-search misses are terminal for the current scheduling attempt.
 

--- a/pkg/apis/scheduling/v2alpha2/podgroup_types.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_types.go
@@ -283,6 +283,9 @@ type SchedulingConditionType string
 const (
 	// UnschedulableOnNodePool means the pod group is Unschedulable on the current node pool
 	UnschedulableOnNodePool SchedulingConditionType = "UnschedulableOnNodePool"
+
+	// ScenarioSearchUnresolved means bounded scenario search did not resolve a pending job in the current scheduling attempt
+	ScenarioSearchUnresolved SchedulingConditionType = "ScenarioSearchUnresolved"
 )
 
 // These are reasons for a pod group's transition to a condition.

--- a/pkg/scheduler/actions/common/solvers/search_result.go
+++ b/pkg/scheduler/actions/common/solvers/search_result.go
@@ -3,6 +3,8 @@
 
 package solvers
 
+import "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+
 // SearchResultReason describes why a scenario search stopped.
 type SearchResultReason string
 
@@ -44,6 +46,39 @@ func (r *SearchResult) scenarioSearchMetricResult() string {
 		return r.metricResult
 	}
 	return string(r.reason)
+}
+
+func (r *SearchResult) ScenarioSearchUnresolved() *podgroup_info.ScenarioSearchUnresolved {
+	if r == nil {
+		return nil
+	}
+
+	var reason podgroup_info.ScenarioSearchResultReason
+	switch r.reason {
+	case SearchResultDeadlineExhausted:
+		reason = podgroup_info.ScenarioSearchResultDeadlineExhausted
+	case SearchResultGeneratorsExhausted:
+		reason = podgroup_info.ScenarioSearchResultGeneratorsExhausted
+	case SearchResultNoGenerator:
+		reason = podgroup_info.ScenarioSearchResultNoGenerator
+	case SearchResultNotAttempted:
+		reason = podgroup_info.ScenarioSearchResultNotAttempted
+	default:
+		return nil
+	}
+
+	return &podgroup_info.ScenarioSearchUnresolved{
+		Reason:        reason,
+		ReducedBudget: r.reducedBudget,
+	}
+}
+
+func RecordScenarioSearchUnresolved(job *podgroup_info.PodGroupInfo, result *SearchResult) {
+	unresolved := result.ScenarioSearchUnresolved()
+	if unresolved == nil {
+		return
+	}
+	job.SetScenarioSearchUnresolved(unresolved.Reason, unresolved.ReducedBudget)
 }
 
 // NewNotAttemptedSearchResult returns a terminal result for callers that skip solver entry.

--- a/pkg/scheduler/actions/common/solvers/search_result_explainability_test.go
+++ b/pkg/scheduler/actions/common/solvers/search_result_explainability_test.go
@@ -20,27 +20,27 @@ func TestSearchResultScenarioSearchUnresolved(t *testing.T) {
 	}{
 		{
 			name:           "deadline exhausted",
-			result:         terminalSearchResult(SearchResultDeadlineExhausted, false, true),
+			result:         terminalSearchResult(SearchResultDeadlineExhausted, false),
 			expectedReason: podgroup_info.ScenarioSearchResultDeadlineExhausted,
 		},
 		{
 			name:           "generators exhausted",
-			result:         terminalSearchResult(SearchResultGeneratorsExhausted, false, true),
+			result:         terminalSearchResult(SearchResultGeneratorsExhausted, false),
 			expectedReason: podgroup_info.ScenarioSearchResultGeneratorsExhausted,
 		},
 		{
 			name:           "no generator",
-			result:         terminalSearchResult(SearchResultNoGenerator, false, false),
+			result:         terminalSearchResult(SearchResultNoGenerator, false),
 			expectedReason: podgroup_info.ScenarioSearchResultNoGenerator,
 		},
 		{
 			name:           "not attempted",
-			result:         terminalSearchResult(SearchResultNotAttempted, false, false),
+			result:         terminalSearchResult(SearchResultNotAttempted, false),
 			expectedReason: podgroup_info.ScenarioSearchResultNotAttempted,
 		},
 		{
 			name:           "reduced budget",
-			result:         terminalSearchResult(SearchResultDeadlineExhausted, true, true),
+			result:         terminalSearchResult(SearchResultDeadlineExhausted, true),
 			expectedReason: podgroup_info.ScenarioSearchResultDeadlineExhausted,
 			reducedBudget:  true,
 		},

--- a/pkg/scheduler/actions/common/solvers/search_result_explainability_test.go
+++ b/pkg/scheduler/actions/common/solvers/search_result_explainability_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+)
+
+func TestSearchResultScenarioSearchUnresolved(t *testing.T) {
+	tests := []struct {
+		name           string
+		result         *SearchResult
+		expectedReason podgroup_info.ScenarioSearchResultReason
+		reducedBudget  bool
+	}{
+		{
+			name:           "deadline exhausted",
+			result:         terminalSearchResult(SearchResultDeadlineExhausted, false, true),
+			expectedReason: podgroup_info.ScenarioSearchResultDeadlineExhausted,
+		},
+		{
+			name:           "generators exhausted",
+			result:         terminalSearchResult(SearchResultGeneratorsExhausted, false, true),
+			expectedReason: podgroup_info.ScenarioSearchResultGeneratorsExhausted,
+		},
+		{
+			name:           "no generator",
+			result:         terminalSearchResult(SearchResultNoGenerator, false, false),
+			expectedReason: podgroup_info.ScenarioSearchResultNoGenerator,
+		},
+		{
+			name:           "not attempted",
+			result:         terminalSearchResult(SearchResultNotAttempted, false, false),
+			expectedReason: podgroup_info.ScenarioSearchResultNotAttempted,
+		},
+		{
+			name:           "reduced budget",
+			result:         terminalSearchResult(SearchResultDeadlineExhausted, true, true),
+			expectedReason: podgroup_info.ScenarioSearchResultDeadlineExhausted,
+			reducedBudget:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unresolved := tt.result.ScenarioSearchUnresolved()
+
+			require.NotNil(t, unresolved)
+			require.Equal(t, tt.expectedReason, unresolved.Reason)
+			require.Equal(t, tt.reducedBudget, unresolved.ReducedBudget)
+		})
+	}
+}
+
+func TestSearchResultScenarioSearchUnresolvedIgnoresSolvedAndNilResults(t *testing.T) {
+	require.Nil(t, solvedSearchResult(&solutionResult{solved: true}, false).ScenarioSearchUnresolved())
+
+	var result *SearchResult
+	require.Nil(t, result.ScenarioSearchUnresolved())
+}

--- a/pkg/scheduler/actions/consolidation/consolidation.go
+++ b/pkg/scheduler/actions/consolidation/consolidation.go
@@ -82,9 +82,11 @@ func (alloc *consolidationAction) Execute(ssn *framework.Session) {
 			if err != nil {
 				log.InfraLogger.Errorf("Failed to commit consolidation statement: %v", err)
 			}
-		} else if shouldStopActionForSearchResult(searchResult) {
-			return
 		} else {
+			solvers.RecordScenarioSearchUnresolved(job, searchResult)
+			if shouldStopActionForSearchResult(searchResult) {
+				return
+			}
 			smallestFailedJobs.UpdateRepresentative(job)
 		}
 	}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -99,9 +99,11 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 			if err := statement.Commit(); err != nil {
 				log.InfraLogger.Errorf("Failed to commit preemption statement: %v", err)
 			}
-		} else if shouldStopActionForSearchResult(searchResult) {
-			return
 		} else {
+			solvers.RecordScenarioSearchUnresolved(job, searchResult)
+			if shouldStopActionForSearchResult(searchResult) {
+				return
+			}
 			log.InfraLogger.V(3).Infof("Didn't find a preemption strategy for job <%s/%s>",
 				job.Namespace, job.Name)
 			smallestFailedJobs.UpdateRepresentative(job)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -102,9 +102,11 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 			if err := statement.Commit(); err != nil {
 				log.InfraLogger.Errorf("Failed to commit reclaim statement: %v", err)
 			}
-		} else if shouldStopActionForSearchResult(searchResult) {
-			return
 		} else {
+			solvers.RecordScenarioSearchUnresolved(job, searchResult)
+			if shouldStopActionForSearchResult(searchResult) {
+				return
+			}
 			log.InfraLogger.V(3).Infof("Didn't find a reclaim strategy for job <%s/%s>",
 				job.Namespace, job.Name)
 			smallestFailedJobs.UpdateRepresentative(job)

--- a/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
@@ -6,20 +6,14 @@ package reclaim_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
 	. "go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	kaiv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
-	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/topology_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
@@ -51,35 +45,6 @@ const (
 	unschedulableDistributedJobName = "unschedulable-distributed-job"
 	unschedulableDistributedRackKey = "benchmark.kai.scheduler/rack"
 )
-
-func TestReducedBudgetFailedReclaimRecordsScenarioSearchUnresolved(t *testing.T) {
-	defer gock.Off()
-
-	test_utils.InitTestingInfrastructure()
-	controller := NewController(t)
-	defer controller.Finish()
-
-	topology := buildUnschedulableDistributedReclaimBenchmarkTopology(
-		defaultUnschedulableDistributedReclaimBenchmarkParams(10),
-	)
-	ssn := test_utils.BuildSession(topology, controller)
-	ssn.Config.ScenarioSearchBudgets = &kaiv1.ScenarioSearchBudgets{
-		MaxActionSearchDuration: map[string]metav1.Duration{
-			commonconstants.ActionReclaim: {Duration: 250 * time.Millisecond},
-		},
-		MaxJobSearchDuration: &metav1.Duration{Duration: time.Second},
-		MinJobSearchDuration: &metav1.Duration{Duration: 500 * time.Millisecond},
-	}
-
-	reclaim.New().Execute(ssn)
-
-	job := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID("unschedulable-distributed-job")]
-	require.NotNil(t, job)
-	require.Empty(t, job.JobFitErrors)
-	require.NotNil(t, job.ScenarioSearchUnresolved)
-	require.Equal(t, podgroup_info.ScenarioSearchResultGeneratorsExhausted, job.ScenarioSearchUnresolved.Reason)
-	require.True(t, job.ScenarioSearchUnresolved.ReducedBudget)
-}
 
 func BenchmarkReclaimUnschedulableDistributedJob_10Node(b *testing.B) {
 	benchmarkReclaimUnschedulableDistributedJob(b, 10)

--- a/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_benchmark_test.go
@@ -6,14 +6,20 @@ package reclaim_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	. "go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	kaiv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/topology_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
@@ -45,6 +51,35 @@ const (
 	unschedulableDistributedJobName = "unschedulable-distributed-job"
 	unschedulableDistributedRackKey = "benchmark.kai.scheduler/rack"
 )
+
+func TestReducedBudgetFailedReclaimRecordsScenarioSearchUnresolved(t *testing.T) {
+	defer gock.Off()
+
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+
+	topology := buildUnschedulableDistributedReclaimBenchmarkTopology(
+		defaultUnschedulableDistributedReclaimBenchmarkParams(10),
+	)
+	ssn := test_utils.BuildSession(topology, controller)
+	ssn.Config.ScenarioSearchBudgets = &kaiv1.ScenarioSearchBudgets{
+		MaxActionSearchDuration: map[string]metav1.Duration{
+			commonconstants.ActionReclaim: {Duration: 250 * time.Millisecond},
+		},
+		MaxJobSearchDuration: &metav1.Duration{Duration: time.Second},
+		MinJobSearchDuration: &metav1.Duration{Duration: 500 * time.Millisecond},
+	}
+
+	reclaim.New().Execute(ssn)
+
+	job := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID("unschedulable-distributed-job")]
+	require.NotNil(t, job)
+	require.Empty(t, job.JobFitErrors)
+	require.NotNil(t, job.ScenarioSearchUnresolved)
+	require.Equal(t, podgroup_info.ScenarioSearchResultGeneratorsExhausted, job.ScenarioSearchUnresolved.Reason)
+	require.True(t, job.ScenarioSearchUnresolved.ReducedBudget)
+}
 
 func BenchmarkReclaimUnschedulableDistributedJob_10Node(b *testing.B) {
 	benchmarkReclaimUnschedulableDistributedJob(b, 10)

--- a/pkg/scheduler/actions/reclaim/reclaim_reduced_budget_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_reduced_budget_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	. "go.uber.org/mock/gomock"
+	"gopkg.in/h2non/gock.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+)
+
+func TestReducedBudgetFailedReclaimRecordsScenarioSearchUnresolved(t *testing.T) {
+	defer gock.Off()
+
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+
+	topology := buildUnschedulableDistributedReclaimBenchmarkTopology(
+		defaultUnschedulableDistributedReclaimBenchmarkParams(10),
+	)
+	ssn := test_utils.BuildSession(topology, controller)
+	ssn.Config.ScenarioSearchBudgets = &kaiv1.ScenarioSearchBudgets{
+		MaxActionSearchDuration: map[string]metav1.Duration{
+			commonconstants.ActionReclaim: {Duration: 250 * time.Millisecond},
+		},
+		MaxJobSearchDuration: &metav1.Duration{Duration: time.Second},
+		MinJobSearchDuration: &metav1.Duration{Duration: 500 * time.Millisecond},
+	}
+
+	reclaim.New().Execute(ssn)
+
+	job := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID(unschedulableDistributedJobName)]
+	require.NotNil(t, job)
+	require.Empty(t, job.JobFitErrors)
+	require.NotNil(t, job.ScenarioSearchUnresolved)
+	require.Equal(t, podgroup_info.ScenarioSearchResultGeneratorsExhausted, job.ScenarioSearchUnresolved.Reason)
+	require.True(t, job.ScenarioSearchUnresolved.ReducedBudget)
+}

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -51,6 +51,20 @@ type StalenessInfo struct {
 	Stale     bool
 }
 
+type ScenarioSearchResultReason string
+
+const (
+	ScenarioSearchResultDeadlineExhausted   ScenarioSearchResultReason = "deadline_exhausted"
+	ScenarioSearchResultGeneratorsExhausted ScenarioSearchResultReason = "generators_exhausted"
+	ScenarioSearchResultNoGenerator         ScenarioSearchResultReason = "no_generator"
+	ScenarioSearchResultNotAttempted        ScenarioSearchResultReason = "not_attempted"
+)
+
+type ScenarioSearchUnresolved struct {
+	Reason        ScenarioSearchResultReason
+	ReducedBudget bool
+}
+
 type PodGroupInfos struct {
 	PodGroupInfos []*PodGroupInfo
 }
@@ -69,6 +83,8 @@ type PodGroupInfo struct {
 
 	JobFitErrors   []common_info.JobFitError
 	TasksFitErrors map[common_info.PodID]*common_info.TasksFitErrors
+
+	ScenarioSearchUnresolved *ScenarioSearchUnresolved
 
 	AllocatedVector resource_info.ResourceVector
 	VectorMap       *resource_info.ResourceVectorMap
@@ -572,6 +588,13 @@ func (pgi *PodGroupInfo) AddSimpleJobFitError(reason enginev2alpha2.Unschedulabl
 
 func (pgi *PodGroupInfo) AddJobFitError(err common_info.JobFitError) {
 	pgi.JobFitErrors = append(pgi.JobFitErrors, err)
+}
+
+func (pgi *PodGroupInfo) SetScenarioSearchUnresolved(reason ScenarioSearchResultReason, reducedBudget bool) {
+	pgi.ScenarioSearchUnresolved = &ScenarioSearchUnresolved{
+		Reason:        reason,
+		ReducedBudget: reducedBudget,
+	}
 }
 
 func (pgi *PodGroupInfo) GetSchedulingConstraintsSignature() common_info.SchedulingConstraintsSignature {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -508,6 +508,7 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 
 	podGroupInfo := podgroup_info.NewPodGroupInfo("group-1", maps.Values(podInfos)...)
 	podGroupInfo.SetPodGroup(podGroup)
+	podGroupInfo.AddSimpleJobFitError(podgroup_info.OverCapacity, "job is over capacity")
 	podGroupInfo.SetScenarioSearchUnresolved(
 		podgroup_info.ScenarioSearchResultDeadlineExhausted,
 		false,
@@ -531,10 +532,13 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 
 	newPodGroup := newPodGroupObj.(*enginev2alpha2.PodGroup)
 	condition := newPodGroup.Status.SchedulingConditions[0]
-	assert.Equal(t, enginev2alpha2.ScenarioSearchUnresolved, condition.Type)
-	assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), condition.Reason)
-	assert.Equal(t, exhaustedMessage, condition.Message)
-	assert.Empty(t, condition.Reasons)
+	assert.Equal(t, enginev2alpha2.UnschedulableOnNodePool, condition.Type)
+	assert.Equal(t, enginev2alpha2.PodGroupReasonUnschedulable, condition.Reason)
+	assert.Contains(t, condition.Message, "job is over capacity")
+	if assert.Len(t, condition.Reasons, 1) {
+		assert.Equal(t, enginev2alpha2.UnschedulableReason(podgroup_info.OverCapacity), condition.Reasons[0].Reason)
+		assert.Equal(t, "job is over capacity", condition.Reasons[0].Message)
+	}
 
 	for _, podID := range []common_info.PodID{"pod-1", "pod-2"} {
 		podObj, err := waitForCondition(func() (runtime.Object, error) {
@@ -556,7 +560,7 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 		unschedulableCondition := podConditionByType(pod, v1.PodScheduled)
 		assert.Equal(t, v1.ConditionFalse, unschedulableCondition.Status)
 		assert.Equal(t, v1.PodReasonUnschedulable, unschedulableCondition.Reason)
-		assert.Equal(t, "Node-Pool 'default': "+common_info.DefaultPodError, unschedulableCondition.Message)
+		assert.Equal(t, "Node-Pool 'default': OverCapacity: job is over capacity.", unschedulableCondition.Message)
 
 		scenarioSearchCondition := podConditionByType(pod, v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved))
 		assert.Equal(t, v1.ConditionTrue, scenarioSearchCondition.Status)
@@ -572,8 +576,8 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 
 	podGroupEvent := getPodGroupEvent(t, kubeClient)
 	assert.NotNil(t, podGroupEvent)
-	assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), podGroupEvent.Reason)
-	assert.Equal(t, exhaustedMessage, podGroupEvent.Message)
+	assert.Equal(t, enginev2alpha2.PodGroupReasonUnschedulable, podGroupEvent.Reason)
+	assert.Contains(t, podGroupEvent.Message, "job is over capacity")
 }
 
 func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
 )
 
+const reducedBudgetReclaimMessage = "Scheduler could not find a valid reclaim scenario for this job within the remaining configured search time."
+
 type test struct {
 	name                             string
 	podGroupMinMember                int   // if not set, uses len(pods)
@@ -97,6 +99,23 @@ func TestRecordJobStatusEvent(t *testing.T) {
 			},
 			expectedPodEventPatterns: map[common_info.PodID][]string{
 				"pod-1": {"generic error"},
+			},
+		},
+		{
+			name: "reduced-budget reclaim job error",
+			pods: map[v1.PodPhase][]common_info.PodID{
+				v1.PodPending: {"pod-1"},
+			},
+			nodeErrors:                    map[common_info.PodID]map[string]string{},
+			podErrors:                     map[common_info.PodID]error{},
+			jobErrors:                     newUnschedulabeReasons(map[string]string{podgroup_info.PodSchedulingErrors: reducedBudgetReclaimMessage}),
+			expectedPodgroupErrorPatterns: []string{reducedBudgetReclaimMessage},
+			expectedPodgroupEventPatterns: []string{reducedBudgetReclaimMessage},
+			expectedPodErrorPatterns: map[common_info.PodID][]string{
+				"pod-1": {reducedBudgetReclaimMessage},
+			},
+			expectedPodEventPatterns: map[common_info.PodID][]string{
+				"pod-1": {reducedBudgetReclaimMessage},
 			},
 		},
 		{
@@ -450,6 +469,104 @@ func TestRecordJobStatusEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
+	podInfos, podsAsObjects := getPods(map[v1.PodPhase][]common_info.PodID{
+		v1.PodPending: {"pod-1", "pod-2"},
+	})
+	podGroup := &enginev2alpha2.PodGroup{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodGroup",
+			APIVersion: "scheduling.run.ai/v2alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "group-1",
+			Namespace: "namespace-1",
+		},
+		Spec: enginev2alpha2.PodGroupSpec{
+			SchedulingBackoff: ptr.To(int32(1)),
+			MinMember:         ptr.To(int32(2)),
+		},
+	}
+
+	kubeClient := fake.NewSimpleClientset(podsAsObjects...)
+	kubeAiSchedulerClient := kubeaischedulerfake.NewSimpleClientset(podGroup)
+	cache := New(&SchedulerCacheParams{
+		KubeClient:                  kubeClient,
+		KAISchedulerClient:          kubeAiSchedulerClient,
+		NodePoolParams:              &conf.SchedulingNodePoolParams{},
+		FullHierarchyFairness:       true,
+		NumOfStatusRecordingWorkers: 4,
+		DiscoveryClient:             kubeClient.Discovery(),
+	})
+
+	stopCh := make(chan struct{})
+	cache.Run(stopCh)
+	cache.WaitForCacheSync(stopCh)
+	defer close(stopCh)
+
+	podGroupInfo := podgroup_info.NewPodGroupInfo("group-1", maps.Values(podInfos)...)
+	podGroupInfo.SetPodGroup(podGroup)
+	podGroupInfo.SetScenarioSearchUnresolved(
+		podgroup_info.ScenarioSearchResultDeadlineExhausted,
+		false,
+	)
+
+	err := cache.RecordJobStatusEvent(podGroupInfo)
+	assert.Nil(t, err)
+
+	exhaustedMessage := "KAI could not find a valid reclaim scenario within the configured search budget for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle."
+	newPodGroupObj, err := waitForCondition(func() (runtime.Object, error) {
+		updatedPodGroup, err := kubeAiSchedulerClient.SchedulingV2alpha2().PodGroups("namespace-1").Get(context.TODO(), "group-1", metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if len(updatedPodGroup.Status.SchedulingConditions) > 0 {
+			return updatedPodGroup, nil
+		}
+		return nil, fmt.Errorf("no scheduling conditions found")
+	})
+	assert.Nil(t, err)
+
+	newPodGroup := newPodGroupObj.(*enginev2alpha2.PodGroup)
+	condition := newPodGroup.Status.SchedulingConditions[0]
+	assert.Equal(t, enginev2alpha2.ScenarioSearchUnresolved, condition.Type)
+	assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), condition.Reason)
+	assert.Equal(t, exhaustedMessage, condition.Message)
+	assert.Empty(t, condition.Reasons)
+
+	for _, podID := range []common_info.PodID{"pod-1", "pod-2"} {
+		podObj, err := waitForCondition(func() (runtime.Object, error) {
+			pod, err := kubeClient.CoreV1().Pods("namespace-1").Get(context.TODO(), string(podID), metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			if len(pod.Status.Conditions) > 0 {
+				return pod, nil
+			}
+			return nil, fmt.Errorf("no conditions found for pod %s", pod.Name)
+		})
+		assert.Nil(t, err)
+
+		pod := podObj.(*v1.Pod)
+		podCondition := pod.Status.Conditions[0]
+		assert.Equal(t, v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved), podCondition.Type)
+		assert.Equal(t, v1.ConditionTrue, podCondition.Status)
+		assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), podCondition.Reason)
+		assert.Equal(t, exhaustedMessage, podCondition.Message)
+	}
+
+	for podID, event := range getPodEvents(t, kubeClient) {
+		assert.Contains(t, []common_info.PodID{"pod-1", "pod-2"}, podID)
+		assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), event.Reason)
+		assert.Equal(t, exhaustedMessage, event.Message)
+	}
+
+	podGroupEvent := getPodGroupEvent(t, kubeClient)
+	assert.NotNil(t, podGroupEvent)
+	assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), podGroupEvent.Reason)
+	assert.Equal(t, exhaustedMessage, podGroupEvent.Message)
 }
 
 func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -574,10 +574,10 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 		assert.Equal(t, exhaustedMessage, scenarioSearchCondition.Message)
 	}
 
-	for podID, event := range getPodEvents(t, kubeClient) {
-		assert.Contains(t, []common_info.PodID{"pod-1", "pod-2"}, podID)
-		assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), event.Reason)
-		assert.Equal(t, exhaustedMessage, event.Message)
+	podEvents := getPodEventsByPod(t, kubeClient)
+	for _, podID := range []common_info.PodID{"pod-1", "pod-2"} {
+		assertPodEvent(t, podEvents[podID], v1.PodReasonUnschedulable, "job is over capacity")
+		assertPodEvent(t, podEvents[podID], string(enginev2alpha2.ScenarioSearchUnresolved), exhaustedMessage)
 	}
 
 	podGroupEvents := getPodGroupEvents(t, kubeClient)
@@ -757,6 +757,34 @@ func getPodEvents(t *testing.T, kubeClient clientset.Interface) (eventsPerPod ma
 	}
 
 	return eventsPerPod
+}
+
+func getPodEventsByPod(t *testing.T, kubeClient clientset.Interface) map[common_info.PodID][]*v1.Event {
+	events, err := kubeClient.CoreV1().Events("namespace-1").List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(t, err)
+
+	eventsPerPod := make(map[common_info.PodID][]*v1.Event)
+	for _, event := range events.Items {
+		if event.InvolvedObject.Kind != "Pod" {
+			continue
+		}
+		podID := common_info.PodID(event.InvolvedObject.UID)
+		eventsPerPod[podID] = append(eventsPerPod[podID], &event)
+	}
+
+	return eventsPerPod
+}
+
+func assertPodEvent(t *testing.T, events []*v1.Event, reason, messageSubstring string) {
+	for _, event := range events {
+		if event.Reason == reason && regexp.MustCompile(regexp.QuoteMeta(messageSubstring)).MatchString(event.Message) {
+			return
+		}
+	}
+
+	assert.Failf(t, "expected Pod event",
+		"expected Pod event with reason %q and message containing %q; events: %v",
+		reason, messageSubstring, events)
 }
 
 func getPodGroupEvent(t *testing.T, kubeClient clientset.Interface) *v1.Event {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -577,12 +577,12 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 	podEvents := getPodEventsByPod(t, kubeClient)
 	for _, podID := range []common_info.PodID{"pod-1", "pod-2"} {
 		assertPodEvent(t, podEvents[podID], v1.PodReasonUnschedulable, "job is over capacity")
-		assertPodEvent(t, podEvents[podID], string(enginev2alpha2.ScenarioSearchUnresolved), exhaustedMessage)
+		assertNoPodEvent(t, podEvents[podID], string(enginev2alpha2.ScenarioSearchUnresolved))
 	}
 
 	podGroupEvents := getPodGroupEvents(t, kubeClient)
 	assertPodGroupEvent(t, podGroupEvents, enginev2alpha2.PodGroupReasonUnschedulable, "job is over capacity")
-	assertPodGroupEvent(t, podGroupEvents, string(enginev2alpha2.ScenarioSearchUnresolved), exhaustedMessage)
+	assertNoPodGroupEvent(t, podGroupEvents, string(enginev2alpha2.ScenarioSearchUnresolved))
 }
 
 func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
@@ -787,6 +787,12 @@ func assertPodEvent(t *testing.T, events []*v1.Event, reason, messageSubstring s
 		reason, messageSubstring, events)
 }
 
+func assertNoPodEvent(t *testing.T, events []*v1.Event, reason string) {
+	for _, event := range events {
+		assert.NotEqual(t, reason, event.Reason, "expected no Pod event with reason %q; events: %v", reason, events)
+	}
+}
+
 func getPodGroupEvent(t *testing.T, kubeClient clientset.Interface) *v1.Event {
 	events := getPodGroupEvents(t, kubeClient)
 	if len(events) == 0 {
@@ -820,6 +826,12 @@ func assertPodGroupEvent(t *testing.T, events []*v1.Event, reason, messageSubstr
 	assert.Failf(t, "expected PodGroup event",
 		"expected PodGroup event with reason %q and message containing %q; events: %v",
 		reason, messageSubstring, events)
+}
+
+func assertNoPodGroupEvent(t *testing.T, events []*v1.Event, reason string) {
+	for _, event := range events {
+		assert.NotEqual(t, reason, event.Reason, "expected no PodGroup event with reason %q; events: %v", reason, events)
+	}
 }
 
 func getPods(pods map[v1.PodPhase][]common_info.PodID) (podsInfos map[common_info.PodID]*pod_info.PodInfo, podsAsObjects []runtime.Object) {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -523,22 +523,28 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		if len(updatedPodGroup.Status.SchedulingConditions) > 0 {
+		if podGroupSchedulingConditionByType(updatedPodGroup, enginev2alpha2.UnschedulableOnNodePool) != nil &&
+			podGroupSchedulingConditionByType(updatedPodGroup, enginev2alpha2.ScenarioSearchUnresolved) != nil {
 			return updatedPodGroup, nil
 		}
-		return nil, fmt.Errorf("no scheduling conditions found")
+		return nil, fmt.Errorf("missing expected scheduling conditions")
 	})
 	assert.Nil(t, err)
 
 	newPodGroup := newPodGroupObj.(*enginev2alpha2.PodGroup)
-	condition := newPodGroup.Status.SchedulingConditions[0]
-	assert.Equal(t, enginev2alpha2.UnschedulableOnNodePool, condition.Type)
-	assert.Equal(t, enginev2alpha2.PodGroupReasonUnschedulable, condition.Reason)
-	assert.Contains(t, condition.Message, "job is over capacity")
-	if assert.Len(t, condition.Reasons, 1) {
-		assert.Equal(t, enginev2alpha2.UnschedulableReason(podgroup_info.OverCapacity), condition.Reasons[0].Reason)
-		assert.Equal(t, "job is over capacity", condition.Reasons[0].Message)
+	unschedulablePodGroupCondition := podGroupSchedulingConditionByType(newPodGroup, enginev2alpha2.UnschedulableOnNodePool)
+	assert.Equal(t, enginev2alpha2.PodGroupReasonUnschedulable, unschedulablePodGroupCondition.Reason)
+	assert.Contains(t, unschedulablePodGroupCondition.Message, "job is over capacity")
+	if assert.Len(t, unschedulablePodGroupCondition.Reasons, 1) {
+		assert.Equal(t, enginev2alpha2.UnschedulableReason(podgroup_info.OverCapacity),
+			unschedulablePodGroupCondition.Reasons[0].Reason)
+		assert.Equal(t, "job is over capacity", unschedulablePodGroupCondition.Reasons[0].Message)
 	}
+
+	scenarioSearchPodGroupCondition := podGroupSchedulingConditionByType(newPodGroup, enginev2alpha2.ScenarioSearchUnresolved)
+	assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), scenarioSearchPodGroupCondition.Reason)
+	assert.Equal(t, exhaustedMessage, scenarioSearchPodGroupCondition.Message)
+	assert.Empty(t, scenarioSearchPodGroupCondition.Reasons)
 
 	for _, podID := range []common_info.PodID{"pod-1", "pod-2"} {
 		podObj, err := waitForCondition(func() (runtime.Object, error) {
@@ -574,10 +580,9 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 		assert.Equal(t, exhaustedMessage, event.Message)
 	}
 
-	podGroupEvent := getPodGroupEvent(t, kubeClient)
-	assert.NotNil(t, podGroupEvent)
-	assert.Equal(t, enginev2alpha2.PodGroupReasonUnschedulable, podGroupEvent.Reason)
-	assert.Contains(t, podGroupEvent.Message, "job is over capacity")
+	podGroupEvents := getPodGroupEvents(t, kubeClient)
+	assertPodGroupEvent(t, podGroupEvents, enginev2alpha2.PodGroupReasonUnschedulable, "job is over capacity")
+	assertPodGroupEvent(t, podGroupEvents, string(enginev2alpha2.ScenarioSearchUnresolved), exhaustedMessage)
 }
 
 func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
@@ -707,6 +712,17 @@ func podConditionByType(pod *v1.Pod, conditionType v1.PodConditionType) *v1.PodC
 	return nil
 }
 
+func podGroupSchedulingConditionByType(
+	podGroup *enginev2alpha2.PodGroup, conditionType enginev2alpha2.SchedulingConditionType,
+) *enginev2alpha2.SchedulingCondition {
+	for index := range podGroup.Status.SchedulingConditions {
+		if podGroup.Status.SchedulingConditions[index].Type == conditionType {
+			return &podGroup.Status.SchedulingConditions[index]
+		}
+	}
+	return nil
+}
+
 func validatePodEvents(t *testing.T, eventsPerPod map[common_info.PodID]*v1.Event, expectedPatterns map[common_info.PodID][]string) {
 	for podID, expectedMessagePatterns := range expectedPatterns {
 		event, found := eventsPerPod[podID]
@@ -744,17 +760,38 @@ func getPodEvents(t *testing.T, kubeClient clientset.Interface) (eventsPerPod ma
 }
 
 func getPodGroupEvent(t *testing.T, kubeClient clientset.Interface) *v1.Event {
+	events := getPodGroupEvents(t, kubeClient)
+	if len(events) == 0 {
+		return nil
+	}
+
+	return events[0]
+}
+
+func getPodGroupEvents(t *testing.T, kubeClient clientset.Interface) []*v1.Event {
 	events, err := kubeClient.CoreV1().Events("namespace-1").List(context.TODO(), metav1.ListOptions{})
 	assert.Nil(t, err)
 
+	var podGroupEvents []*v1.Event
 	for _, event := range events.Items {
 		if event.InvolvedObject.Kind == "PodGroup" {
-			return &event
+			podGroupEvents = append(podGroupEvents, &event)
 		}
-
 	}
 
-	return nil
+	return podGroupEvents
+}
+
+func assertPodGroupEvent(t *testing.T, events []*v1.Event, reason, messageSubstring string) {
+	for _, event := range events {
+		if event.Reason == reason && regexp.MustCompile(regexp.QuoteMeta(messageSubstring)).MatchString(event.Message) {
+			return
+		}
+	}
+
+	assert.Failf(t, "expected PodGroup event",
+		"expected PodGroup event with reason %q and message containing %q; events: %v",
+		reason, messageSubstring, events)
 }
 
 func getPods(pods map[v1.PodPhase][]common_info.PodID) (podsInfos map[common_info.PodID]*pod_info.PodInfo, podsAsObjects []runtime.Object) {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -542,19 +542,26 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
-			if len(pod.Status.Conditions) > 0 {
+			if hasPodCondition(pod, v1.PodScheduled) &&
+				hasPodCondition(pod, v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved)) {
 				return pod, nil
 			}
-			return nil, fmt.Errorf("no conditions found for pod %s", pod.Name)
+			return nil, fmt.Errorf("missing expected conditions for pod %s", pod.Name)
 		})
-		assert.Nil(t, err)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		pod := podObj.(*v1.Pod)
-		podCondition := pod.Status.Conditions[0]
-		assert.Equal(t, v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved), podCondition.Type)
-		assert.Equal(t, v1.ConditionTrue, podCondition.Status)
-		assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), podCondition.Reason)
-		assert.Equal(t, exhaustedMessage, podCondition.Message)
+		unschedulableCondition := podConditionByType(pod, v1.PodScheduled)
+		assert.Equal(t, v1.ConditionFalse, unschedulableCondition.Status)
+		assert.Equal(t, v1.PodReasonUnschedulable, unschedulableCondition.Reason)
+		assert.Equal(t, "Node-Pool 'default': "+common_info.DefaultPodError, unschedulableCondition.Message)
+
+		scenarioSearchCondition := podConditionByType(pod, v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved))
+		assert.Equal(t, v1.ConditionTrue, scenarioSearchCondition.Status)
+		assert.Equal(t, string(enginev2alpha2.ScenarioSearchUnresolved), scenarioSearchCondition.Reason)
+		assert.Equal(t, exhaustedMessage, scenarioSearchCondition.Message)
 	}
 
 	for podID, event := range getPodEvents(t, kubeClient) {
@@ -681,6 +688,19 @@ func waitForCondition(condition func() (runtime.Object, error)) (runtime.Object,
 			}
 		}
 	}
+}
+
+func hasPodCondition(pod *v1.Pod, conditionType v1.PodConditionType) bool {
+	return podConditionByType(pod, conditionType) != nil
+}
+
+func podConditionByType(pod *v1.Pod, conditionType v1.PodConditionType) *v1.PodCondition {
+	for index := range pod.Status.Conditions {
+		if pod.Status.Conditions[index].Type == conditionType {
+			return &pod.Status.Conditions[index]
+		}
+	}
+	return nil
 }
 
 func validatePodEvents(t *testing.T, eventsPerPod map[common_info.PodID]*v1.Event, expectedPatterns map[common_info.PodID][]string) {

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -585,6 +585,75 @@ func TestRecordJobStatusEventScenarioSearchUnresolved(t *testing.T) {
 	assertNoPodGroupEvent(t, podGroupEvents, string(enginev2alpha2.ScenarioSearchUnresolved))
 }
 
+func TestRecordJobStatusEventClearsPodGroupSchedulingConditionsForScheduledJob(t *testing.T) {
+	podInfos, podsAsObjects := getPods(map[v1.PodPhase][]common_info.PodID{
+		v1.PodRunning: {"pod-1"},
+	})
+	podGroup := &enginev2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "group-1",
+			Namespace: "namespace-1",
+			UID:       "group-1",
+		},
+		Status: enginev2alpha2.PodGroupStatus{
+			SchedulingConditions: []enginev2alpha2.SchedulingCondition{
+				{
+					Type:    enginev2alpha2.UnschedulableOnNodePool,
+					Reason:  enginev2alpha2.PodGroupReasonUnschedulable,
+					Message: "previous unschedulable reason",
+					Status:  v1.ConditionTrue,
+				},
+				{
+					Type:    enginev2alpha2.ScenarioSearchUnresolved,
+					Reason:  string(enginev2alpha2.ScenarioSearchUnresolved),
+					Message: "previous search limit",
+					Status:  v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	kubeClient := fake.NewSimpleClientset(podsAsObjects...)
+	kubeAiSchedulerClient := kubeaischedulerfake.NewSimpleClientset(podGroup)
+	cache := New(&SchedulerCacheParams{
+		KubeClient:                  kubeClient,
+		KAISchedulerClient:          kubeAiSchedulerClient,
+		NodePoolParams:              &conf.SchedulingNodePoolParams{},
+		DetailedFitErrors:           false,
+		FullHierarchyFairness:       true,
+		NumOfStatusRecordingWorkers: 4,
+		DiscoveryClient:             kubeClient.Discovery(),
+	})
+
+	stopCh := make(chan struct{})
+	cache.Run(stopCh)
+	cache.WaitForCacheSync(stopCh)
+	defer close(stopCh)
+
+	podGroupInfo := podgroup_info.NewPodGroupInfo("group-1", maps.Values(podInfos)...)
+	podGroupInfo.SetPodGroup(podGroup)
+
+	err := cache.RecordJobStatusEvent(podGroupInfo)
+	assert.NoError(t, err)
+
+	updatedPodGroupObj, err := waitForCondition(func() (runtime.Object, error) {
+		updatedPodGroup, err := kubeAiSchedulerClient.SchedulingV2alpha2().PodGroups("namespace-1").Get(
+			context.TODO(), "group-1", metav1.GetOptions{},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(updatedPodGroup.Status.SchedulingConditions) == 0 {
+			return updatedPodGroup, nil
+		}
+		return nil, fmt.Errorf("scheduling conditions were not cleared")
+	})
+	assert.NoError(t, err)
+
+	updatedPodGroup := updatedPodGroupObj.(*enginev2alpha2.PodGroup)
+	assert.Empty(t, updatedPodGroup.Status.SchedulingConditions)
+}
+
 func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
 	validPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -23,6 +23,7 @@ import (
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/k8s_internal"
@@ -216,6 +217,9 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			return nil
 		}
 		if job.ScenarioSearchUnresolved != nil {
+			if err := su.recordUnschedulablePodsConditions(job); err != nil {
+				return err
+			}
 			if err := su.recordScenarioSearchUnresolvedPodsEvents(job); err != nil {
 				return err
 			}
@@ -355,7 +359,7 @@ func (su *defaultStatusUpdater) updatePodCondition(pod *v1.Pod, condition *v1.Po
 		pod.Namespace, pod.Name, condition.Type, condition.Status)
 	if k8s_internal.UpdatePodCondition(&pod.Status, condition) {
 		statusPatchBaseObject := v1.PodStatus{}
-		statusPatchBaseObject.Conditions = []v1.PodCondition{*condition}
+		statusPatchBaseObject.Conditions = pod.Status.Conditions
 		podStatusPatchBytes, err := json.Marshal(statusPatchBaseObject)
 		if err != nil {
 			return err
@@ -386,21 +390,7 @@ func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info
 			continue
 		}
 
-		msg := common_info.DefaultPodError
-		fitError := job.TasksFitErrors[taskInfo.UID]
-		if fitError != nil {
-			msg = fitError.Error()
-
-			if su.detailedFitErrors {
-				msg = fitError.DetailedError()
-			} else {
-				log.InfraLogger.V(6).Infof("Full fit error: %s", fitError.DetailedError())
-			}
-		} else if len(job.JobFitErrors) > 0 {
-			msg = fmt.Sprintf("%s", common_info.JobFitErrorsToMessage(job.JobFitErrors))
-		}
-
-		msg = su.addNodePoolPrefixIfNeeded(job, msg)
+		msg := su.unschedulableTaskMessage(job, taskInfo)
 		log.InfraLogger.V(6).Infof("setting message for task: %v, %v", taskInfo.Name, msg)
 		updatePodCondition := utils.GetMarkUnschedulableValue(job.PodGroup.Spec.MarkUnschedulable)
 		if err := su.markTaskUnschedulable(taskInfo.Pod, msg, updatePodCondition); err != nil {
@@ -410,6 +400,52 @@ func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info
 	}
 
 	return errors.Join(errs...)
+}
+
+func (su *defaultStatusUpdater) recordUnschedulablePodsConditions(job *podgroup_info.PodGroupInfo) error {
+	if !utils.GetMarkUnschedulableValue(job.PodGroup.Spec.MarkUnschedulable) {
+		return nil
+	}
+
+	var errs []error
+	for _, taskInfo := range job.PodStatusIndex[pod_status.Pending] {
+		if job.IsInvalidSubGroupTask(taskInfo.UID) {
+			continue
+		}
+
+		msg := su.unschedulableTaskMessage(job, taskInfo)
+		if err := su.updatePodCondition(taskInfo.Pod, &v1.PodCondition{
+			Type:    v1.PodScheduled,
+			Status:  v1.ConditionFalse,
+			Reason:  v1.PodReasonUnschedulable,
+			Message: msg,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to update unschedulable task status <%s/%s>: %v",
+				taskInfo.Namespace, taskInfo.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (su *defaultStatusUpdater) unschedulableTaskMessage(
+	job *podgroup_info.PodGroupInfo, taskInfo *pod_info.PodInfo,
+) string {
+	msg := common_info.DefaultPodError
+	fitError := job.TasksFitErrors[taskInfo.UID]
+	if fitError != nil {
+		msg = fitError.Error()
+
+		if su.detailedFitErrors {
+			msg = fitError.DetailedError()
+		} else {
+			log.InfraLogger.V(6).Infof("Full fit error: %s", fitError.DetailedError())
+		}
+	} else if len(job.JobFitErrors) > 0 {
+		msg = fmt.Sprintf("%s", common_info.JobFitErrorsToMessage(job.JobFitErrors))
+	}
+
+	return su.addNodePoolPrefixIfNeeded(job, msg)
 }
 
 func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodsEvents(job *podgroup_info.PodGroupInfo) error {

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -223,13 +223,12 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			if err := su.recordScenarioSearchUnresolvedPodsEvents(job); err != nil {
 				return err
 			}
-			updatePodgroupStatus = su.recordScenarioSearchUnresolvedPodGroup(job)
 		} else {
 			if err := su.recordUnschedulablePodsEvents(job); err != nil {
 				return err
 			}
-			updatePodgroupStatus = su.recordUnschedulablePodGroup(job)
 		}
+		updatePodgroupStatus = su.recordUnschedulablePodGroup(job)
 	}
 
 	if len(patchData) > 0 || updatePodgroupStatus {
@@ -338,18 +337,6 @@ func (su *defaultStatusUpdater) markPodGroupUnschedulable(job *podgroup_info.Pod
 		Message:  message,
 		Status:   v1.ConditionTrue,
 		Reasons:  unschedulableExplanations,
-	})
-}
-
-func (su *defaultStatusUpdater) markPodGroupScenarioSearchUnresolved(job *podgroup_info.PodGroupInfo, message string) bool {
-	su.recorder.Event(job.PodGroup, v1.EventTypeNormal, string(enginev2alpha2.ScenarioSearchUnresolved), message)
-
-	return su.updatePodGroupSchedulingCondition(job.PodGroup, &enginev2alpha2.SchedulingCondition{
-		Type:     enginev2alpha2.ScenarioSearchUnresolved,
-		NodePool: utils.GetNodePoolNameFromLabels(job.PodGroup.Labels, su.nodePoolLabelKey),
-		Reason:   string(enginev2alpha2.ScenarioSearchUnresolved),
-		Message:  message,
-		Status:   v1.ConditionTrue,
 	})
 }
 
@@ -520,10 +507,6 @@ func (su *defaultStatusUpdater) recordUnschedulablePodGroup(job *podgroup_info.P
 
 	msg = su.addNodePoolPrefixIfNeeded(job, msg)
 	return su.markPodGroupUnschedulable(job, msg)
-}
-
-func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodGroup(job *podgroup_info.PodGroupInfo) bool {
-	return su.markPodGroupScenarioSearchUnresolved(job, scenarioSearchUnresolvedMessage(job.ScenarioSearchUnresolved))
 }
 
 func scenarioSearchUnresolvedMessage(unresolved *podgroup_info.ScenarioSearchUnresolved) string {

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -223,12 +223,13 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			if err := su.recordScenarioSearchUnresolvedPodsEvents(job); err != nil {
 				return err
 			}
+			updatePodgroupStatus = su.recordScenarioSearchUnresolvedPodGroup(job)
 		} else {
 			if err := su.recordUnschedulablePodsEvents(job); err != nil {
 				return err
 			}
 		}
-		updatePodgroupStatus = su.recordUnschedulablePodGroup(job)
+		updatePodgroupStatus = su.recordUnschedulablePodGroup(job) || updatePodgroupStatus
 	}
 
 	if len(patchData) > 0 || updatePodgroupStatus {
@@ -337,6 +338,18 @@ func (su *defaultStatusUpdater) markPodGroupUnschedulable(job *podgroup_info.Pod
 		Message:  message,
 		Status:   v1.ConditionTrue,
 		Reasons:  unschedulableExplanations,
+	})
+}
+
+func (su *defaultStatusUpdater) markPodGroupScenarioSearchUnresolved(job *podgroup_info.PodGroupInfo, message string) bool {
+	su.recorder.Event(job.PodGroup, v1.EventTypeNormal, string(enginev2alpha2.ScenarioSearchUnresolved), message)
+
+	return su.updatePodGroupSchedulingCondition(job.PodGroup, &enginev2alpha2.SchedulingCondition{
+		Type:     enginev2alpha2.ScenarioSearchUnresolved,
+		NodePool: utils.GetNodePoolNameFromLabels(job.PodGroup.Labels, su.nodePoolLabelKey),
+		Reason:   string(enginev2alpha2.ScenarioSearchUnresolved),
+		Message:  message,
+		Status:   v1.ConditionTrue,
 	})
 }
 
@@ -509,6 +522,10 @@ func (su *defaultStatusUpdater) recordUnschedulablePodGroup(job *podgroup_info.P
 	return su.markPodGroupUnschedulable(job, msg)
 }
 
+func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodGroup(job *podgroup_info.PodGroupInfo) bool {
+	return su.markPodGroupScenarioSearchUnresolved(job, scenarioSearchUnresolvedMessage(job.ScenarioSearchUnresolved))
+}
+
 func scenarioSearchUnresolvedMessage(unresolved *podgroup_info.ScenarioSearchUnresolved) string {
 	if unresolved != nil && unresolved.ReducedBudget {
 		return "KAI could not find a valid scenario within the remaining configured search time for this scheduling attempt because the action search budget was partly consumed by earlier jobs. The job remains pending and may be retried in a later scheduling cycle."
@@ -606,7 +623,7 @@ func setPodGroupLastStartTimeStamp(podGroup *enginev2alpha2.PodGroup, startTimeS
 }
 
 func setPodGroupSchedulingCondition(podGroup *enginev2alpha2.PodGroup, schedulingCondition *enginev2alpha2.SchedulingCondition) bool {
-	currentSchedulingConditionIndex := utils.GetSchedulingConditionIndex(podGroup, schedulingCondition.NodePool)
+	currentSchedulingConditionIndex := getSchedulingConditionIndex(podGroup, schedulingCondition)
 	lastSchedulingCondition := utils.GetLastSchedulingCondition(podGroup)
 
 	setTransitionID(podGroup, schedulingCondition, lastSchedulingCondition)
@@ -616,9 +633,21 @@ func setPodGroupSchedulingCondition(podGroup *enginev2alpha2.PodGroup, schedulin
 	}
 
 	// BC: older versions of pod group assigner rely on the most recent condition to be the last in the list.
-	// We want to squash all conditions of the same node pool and append ours to the end.
-	squashAndAppendConditionsForNodepool(podGroup, schedulingCondition)
+	// Squash conditions of the same node pool and type and append ours to the end.
+	squashAndAppendSchedulingCondition(podGroup, schedulingCondition)
 	return true
+}
+
+func getSchedulingConditionIndex(
+	podGroup *enginev2alpha2.PodGroup, schedulingCondition *enginev2alpha2.SchedulingCondition,
+) int {
+	for i, condition := range podGroup.Status.SchedulingConditions {
+		if condition.NodePool == schedulingCondition.NodePool && condition.Type == schedulingCondition.Type {
+			return i
+		}
+	}
+
+	return -1
 }
 
 func setTransitionID(podGroup *enginev2alpha2.PodGroup, schedulingCondition, lastSchedulingCondition *enginev2alpha2.SchedulingCondition) {
@@ -660,10 +689,10 @@ func equalSchedulingConditions(a, b *enginev2alpha2.SchedulingCondition) bool {
 		a.Status == b.Status
 }
 
-func squashAndAppendConditionsForNodepool(podGroup *enginev2alpha2.PodGroup, schedulingCondition *enginev2alpha2.SchedulingCondition) {
+func squashAndAppendSchedulingCondition(podGroup *enginev2alpha2.PodGroup, schedulingCondition *enginev2alpha2.SchedulingCondition) {
 	var squashedConditions []enginev2alpha2.SchedulingCondition
 	for _, condition := range podGroup.Status.SchedulingConditions {
-		if condition.NodePool != schedulingCondition.NodePool {
+		if condition.NodePool != schedulingCondition.NodePool || condition.Type != schedulingCondition.Type {
 			squashedConditions = append(squashedConditions, condition)
 		}
 	}

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -220,7 +220,7 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			return err
 		}
 		if job.ScenarioSearchUnresolved != nil {
-			if err := su.recordScenarioSearchUnresolvedPodsEvents(job); err != nil {
+			if err := su.recordScenarioSearchUnresolvedPodsConditions(job); err != nil {
 				return err
 			}
 			updatePodgroupStatus = su.recordScenarioSearchUnresolvedPodGroup(job)
@@ -263,9 +263,8 @@ func (su *defaultStatusUpdater) markTaskUnschedulable(pod *v1.Pod, message strin
 	return nil
 }
 
-func (su *defaultStatusUpdater) markTaskScenarioSearchUnresolved(pod *v1.Pod, message string) error {
+func (su *defaultStatusUpdater) markTaskScenarioSearchUnresolvedCondition(pod *v1.Pod, message string) error {
 	log.InfraLogger.V(6).Infof("setting scenario search unresolved message for task: %v", pod.Name)
-	su.recorder.Eventf(pod, v1.EventTypeWarning, string(enginev2alpha2.ScenarioSearchUnresolved), message)
 
 	return su.updatePodCondition(pod, &v1.PodCondition{
 		Type:    v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved),
@@ -338,8 +337,6 @@ func (su *defaultStatusUpdater) markPodGroupUnschedulable(job *podgroup_info.Pod
 }
 
 func (su *defaultStatusUpdater) markPodGroupScenarioSearchUnresolved(job *podgroup_info.PodGroupInfo, message string) bool {
-	su.recorder.Event(job.PodGroup, v1.EventTypeNormal, string(enginev2alpha2.ScenarioSearchUnresolved), message)
-
 	return su.updatePodGroupSchedulingCondition(job.PodGroup, &enginev2alpha2.SchedulingCondition{
 		Type:     enginev2alpha2.ScenarioSearchUnresolved,
 		NodePool: utils.GetNodePoolNameFromLabels(job.PodGroup.Labels, su.nodePoolLabelKey),
@@ -418,14 +415,14 @@ func (su *defaultStatusUpdater) unschedulableTaskMessage(
 	return su.addNodePoolPrefixIfNeeded(job, msg)
 }
 
-func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodsEvents(job *podgroup_info.PodGroupInfo) error {
+func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodsConditions(job *podgroup_info.PodGroupInfo) error {
 	var errs []error
 	message := scenarioSearchUnresolvedMessage(job.ScenarioSearchUnresolved)
 	for _, taskInfo := range job.PodStatusIndex[pod_status.Pending] {
 		if job.IsInvalidSubGroupTask(taskInfo.UID) {
 			continue
 		}
-		if err := su.markTaskScenarioSearchUnresolved(taskInfo.Pod, message); err != nil {
+		if err := su.markTaskScenarioSearchUnresolvedCondition(taskInfo.Pod, message); err != nil {
 			errs = append(errs, fmt.Errorf("failed to update scenario search unresolved task status <%s/%s>: %v",
 				taskInfo.Namespace, taskInfo.Name, err))
 		}

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -226,6 +226,8 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			updatePodgroupStatus = su.recordScenarioSearchUnresolvedPodGroup(job)
 		}
 		updatePodgroupStatus = su.recordUnschedulablePodGroup(job) || updatePodgroupStatus
+	} else {
+		updatePodgroupStatus = clearPodGroupSchedulingConditions(job.PodGroup)
 	}
 
 	if len(patchData) > 0 || updatePodgroupStatus {
@@ -602,6 +604,14 @@ func setPodGroupSchedulingCondition(podGroup *enginev2alpha2.PodGroup, schedulin
 	// BC: older versions of pod group assigner rely on the most recent condition to be the last in the list.
 	// Squash conditions of the same node pool and type and append ours to the end.
 	squashAndAppendSchedulingCondition(podGroup, schedulingCondition)
+	return true
+}
+
+func clearPodGroupSchedulingConditions(podGroup *enginev2alpha2.PodGroup) bool {
+	if len(podGroup.Status.SchedulingConditions) == 0 {
+		return false
+	}
+	podGroup.Status.SchedulingConditions = nil
 	return true
 }
 

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -215,10 +215,17 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			su.recordJobNotReadyEvent(job)
 			return nil
 		}
-		if err := su.recordUnschedulablePodsEvents(job); err != nil {
-			return err
+		if job.ScenarioSearchUnresolved != nil {
+			if err := su.recordScenarioSearchUnresolvedPodsEvents(job); err != nil {
+				return err
+			}
+			updatePodgroupStatus = su.recordScenarioSearchUnresolvedPodGroup(job)
+		} else {
+			if err := su.recordUnschedulablePodsEvents(job); err != nil {
+				return err
+			}
+			updatePodgroupStatus = su.recordUnschedulablePodGroup(job)
 		}
-		updatePodgroupStatus = su.recordUnschedulablePodGroup(job)
 	}
 
 	if len(patchData) > 0 || updatePodgroupStatus {
@@ -254,6 +261,18 @@ func (su *defaultStatusUpdater) markTaskUnschedulable(pod *v1.Pod, message strin
 	}
 
 	return nil
+}
+
+func (su *defaultStatusUpdater) markTaskScenarioSearchUnresolved(pod *v1.Pod, message string) error {
+	log.InfraLogger.V(6).Infof("setting scenario search unresolved message for task: %v", pod.Name)
+	su.recorder.Eventf(pod, v1.EventTypeWarning, string(enginev2alpha2.ScenarioSearchUnresolved), message)
+
+	return su.updatePodCondition(pod, &v1.PodCondition{
+		Type:    v1.PodConditionType(enginev2alpha2.ScenarioSearchUnresolved),
+		Status:  v1.ConditionTrue,
+		Reason:  string(enginev2alpha2.ScenarioSearchUnresolved),
+		Message: message,
+	})
 }
 
 func (su *defaultStatusUpdater) recordStaleJobEvent(job *podgroup_info.PodGroupInfo) {
@@ -315,6 +334,18 @@ func (su *defaultStatusUpdater) markPodGroupUnschedulable(job *podgroup_info.Pod
 		Message:  message,
 		Status:   v1.ConditionTrue,
 		Reasons:  unschedulableExplanations,
+	})
+}
+
+func (su *defaultStatusUpdater) markPodGroupScenarioSearchUnresolved(job *podgroup_info.PodGroupInfo, message string) bool {
+	su.recorder.Event(job.PodGroup, v1.EventTypeNormal, string(enginev2alpha2.ScenarioSearchUnresolved), message)
+
+	return su.updatePodGroupSchedulingCondition(job.PodGroup, &enginev2alpha2.SchedulingCondition{
+		Type:     enginev2alpha2.ScenarioSearchUnresolved,
+		NodePool: utils.GetNodePoolNameFromLabels(job.PodGroup.Labels, su.nodePoolLabelKey),
+		Reason:   string(enginev2alpha2.ScenarioSearchUnresolved),
+		Message:  message,
+		Status:   v1.ConditionTrue,
 	})
 }
 
@@ -381,6 +412,22 @@ func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info
 	return errors.Join(errs...)
 }
 
+func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodsEvents(job *podgroup_info.PodGroupInfo) error {
+	var errs []error
+	message := scenarioSearchUnresolvedMessage(job.ScenarioSearchUnresolved)
+	for _, taskInfo := range job.PodStatusIndex[pod_status.Pending] {
+		if job.IsInvalidSubGroupTask(taskInfo.UID) {
+			continue
+		}
+		if err := su.markTaskScenarioSearchUnresolved(taskInfo.Pod, message); err != nil {
+			errs = append(errs, fmt.Errorf("failed to update scenario search unresolved task status <%s/%s>: %v",
+				taskInfo.Namespace, taskInfo.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
 func (su *defaultStatusUpdater) recordInvalidSubGroupPodsEvents(job *podgroup_info.PodGroupInfo) error {
 	var errs []error
 
@@ -437,6 +484,31 @@ func (su *defaultStatusUpdater) recordUnschedulablePodGroup(job *podgroup_info.P
 
 	msg = su.addNodePoolPrefixIfNeeded(job, msg)
 	return su.markPodGroupUnschedulable(job, msg)
+}
+
+func (su *defaultStatusUpdater) recordScenarioSearchUnresolvedPodGroup(job *podgroup_info.PodGroupInfo) bool {
+	return su.markPodGroupScenarioSearchUnresolved(job, scenarioSearchUnresolvedMessage(job.ScenarioSearchUnresolved))
+}
+
+func scenarioSearchUnresolvedMessage(unresolved *podgroup_info.ScenarioSearchUnresolved) string {
+	if unresolved != nil && unresolved.ReducedBudget {
+		return "KAI could not find a valid scenario within the remaining configured search time for this scheduling attempt because the action search budget was partly consumed by earlier jobs. The job remains pending and may be retried in a later scheduling cycle."
+	}
+	if unresolved == nil {
+		return ""
+	}
+	switch unresolved.Reason {
+	case podgroup_info.ScenarioSearchResultDeadlineExhausted:
+		return "KAI could not find a valid reclaim scenario within the configured search budget for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle."
+	case podgroup_info.ScenarioSearchResultGeneratorsExhausted:
+		return "KAI tried the configured scenario-search policy and found no valid reclaim scenario for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle."
+	case podgroup_info.ScenarioSearchResultNotAttempted:
+		return "KAI did not attempt scenario search for this job in this scheduling cycle because the configured search budget was already exhausted."
+	case podgroup_info.ScenarioSearchResultNoGenerator:
+		return "KAI did not attempt scenario search for this job because no configured scenario generator applies to this action."
+	default:
+		return "KAI tried the configured scenario-search policy and found no valid reclaim scenario for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle."
+	}
 }
 
 func (su *defaultStatusUpdater) updatePodGroupSchedulingCondition(

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -216,18 +216,14 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			su.recordJobNotReadyEvent(job)
 			return nil
 		}
+		if err := su.recordUnschedulablePodsEvents(job); err != nil {
+			return err
+		}
 		if job.ScenarioSearchUnresolved != nil {
-			if err := su.recordUnschedulablePodsConditions(job); err != nil {
-				return err
-			}
 			if err := su.recordScenarioSearchUnresolvedPodsEvents(job); err != nil {
 				return err
 			}
 			updatePodgroupStatus = su.recordScenarioSearchUnresolvedPodGroup(job)
-		} else {
-			if err := su.recordUnschedulablePodsEvents(job); err != nil {
-				return err
-			}
 		}
 		updatePodgroupStatus = su.recordUnschedulablePodGroup(job) || updatePodgroupStatus
 	}
@@ -394,32 +390,6 @@ func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info
 		log.InfraLogger.V(6).Infof("setting message for task: %v, %v", taskInfo.Name, msg)
 		updatePodCondition := utils.GetMarkUnschedulableValue(job.PodGroup.Spec.MarkUnschedulable)
 		if err := su.markTaskUnschedulable(taskInfo.Pod, msg, updatePodCondition); err != nil {
-			errs = append(errs, fmt.Errorf("failed to update unschedulable task status <%s/%s>: %v",
-				taskInfo.Namespace, taskInfo.Name, err))
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (su *defaultStatusUpdater) recordUnschedulablePodsConditions(job *podgroup_info.PodGroupInfo) error {
-	if !utils.GetMarkUnschedulableValue(job.PodGroup.Spec.MarkUnschedulable) {
-		return nil
-	}
-
-	var errs []error
-	for _, taskInfo := range job.PodStatusIndex[pod_status.Pending] {
-		if job.IsInvalidSubGroupTask(taskInfo.UID) {
-			continue
-		}
-
-		msg := su.unschedulableTaskMessage(job, taskInfo)
-		if err := su.updatePodCondition(taskInfo.Pod, &v1.PodCondition{
-			Type:    v1.PodScheduled,
-			Status:  v1.ConditionFalse,
-			Reason:  v1.PodReasonUnschedulable,
-			Message: msg,
-		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to update unschedulable task status <%s/%s>: %v",
 				taskInfo.Namespace, taskInfo.Name, err))
 		}

--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -40,6 +40,57 @@ type UpdatePodGroupConditionTest struct {
 	expectedUpdated     bool
 }
 
+func TestScenarioSearchUnresolvedMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		unresolved *podgroup_info.ScenarioSearchUnresolved
+		expected   string
+	}{
+		{
+			name: "deadline exhausted",
+			unresolved: &podgroup_info.ScenarioSearchUnresolved{
+				Reason: podgroup_info.ScenarioSearchResultDeadlineExhausted,
+			},
+			expected: "KAI could not find a valid reclaim scenario within the configured search budget for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle.",
+		},
+		{
+			name: "generators exhausted",
+			unresolved: &podgroup_info.ScenarioSearchUnresolved{
+				Reason: podgroup_info.ScenarioSearchResultGeneratorsExhausted,
+			},
+			expected: "KAI tried the configured scenario-search policy and found no valid reclaim scenario for this scheduling attempt. The job remains pending and may be retried in a later scheduling cycle.",
+		},
+		{
+			name: "not attempted",
+			unresolved: &podgroup_info.ScenarioSearchUnresolved{
+				Reason: podgroup_info.ScenarioSearchResultNotAttempted,
+			},
+			expected: "KAI did not attempt scenario search for this job in this scheduling cycle because the configured search budget was already exhausted.",
+		},
+		{
+			name: "no generator",
+			unresolved: &podgroup_info.ScenarioSearchUnresolved{
+				Reason: podgroup_info.ScenarioSearchResultNoGenerator,
+			},
+			expected: "KAI did not attempt scenario search for this job because no configured scenario generator applies to this action.",
+		},
+		{
+			name: "reduced budget overrides terminal reason",
+			unresolved: &podgroup_info.ScenarioSearchUnresolved{
+				Reason:        podgroup_info.ScenarioSearchResultGeneratorsExhausted,
+				ReducedBudget: true,
+			},
+			expected: "KAI could not find a valid scenario within the remaining configured search time for this scheduling attempt because the action search budget was partly consumed by earlier jobs. The job remains pending and may be retried in a later scheduling cycle.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, scenarioSearchUnresolvedMessage(tt.unresolved))
+		})
+	}
+}
+
 func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
 	for i, test := range []UpdatePodGroupConditionTest{
 		{

--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -92,6 +92,31 @@ func TestScenarioSearchUnresolvedMessage(t *testing.T) {
 }
 
 func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
+	unschedulableCondition := func(nodePool, transitionID string) enginev2alpha2.SchedulingCondition {
+		return enginev2alpha2.SchedulingCondition{
+			Type:         enginev2alpha2.UnschedulableOnNodePool,
+			NodePool:     nodePool,
+			Reason:       "reason",
+			Message:      "message",
+			TransitionID: transitionID,
+			Status:       v1.ConditionTrue,
+		}
+	}
+	scenarioSearchCondition := func(nodePool, transitionID string) enginev2alpha2.SchedulingCondition {
+		return enginev2alpha2.SchedulingCondition{
+			Type:         enginev2alpha2.ScenarioSearchUnresolved,
+			NodePool:     nodePool,
+			Reason:       "scenario-search-unresolved",
+			Message:      "scenario search unresolved",
+			TransitionID: transitionID,
+			Status:       v1.ConditionTrue,
+		}
+	}
+	newUnschedulableCondition := func(nodePool string) *enginev2alpha2.SchedulingCondition {
+		condition := unschedulableCondition(nodePool, "0")
+		return &condition
+	}
+
 	for i, test := range []UpdatePodGroupConditionTest{
 		{
 			name: "No conditions",
@@ -100,25 +125,9 @@ func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
 					SchedulingConditions: []enginev2alpha2.SchedulingCondition{},
 				},
 			},
-			schedulingCondition: &enginev2alpha2.SchedulingCondition{
-				Type:               enginev2alpha2.UnschedulableOnNodePool,
-				NodePool:           "default",
-				Reason:             "reason",
-				Message:            "message",
-				TransitionID:       "0",
-				LastTransitionTime: metav1.Time{},
-				Status:             v1.ConditionTrue,
-			},
+			schedulingCondition: newUnschedulableCondition("default"),
 			expectedConditions: []enginev2alpha2.SchedulingCondition{
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "default",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "1",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
+				unschedulableCondition("default", "1"),
 			},
 
 			expectedUpdated: true,
@@ -128,44 +137,14 @@ func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
 			podGroup: &enginev2alpha2.PodGroup{
 				Status: enginev2alpha2.PodGroupStatus{
 					SchedulingConditions: []enginev2alpha2.SchedulingCondition{
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "existingConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "99",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
+						unschedulableCondition("existingConditionNodepool", "99"),
 					},
 				},
 			},
-			schedulingCondition: &enginev2alpha2.SchedulingCondition{
-				Type:               enginev2alpha2.UnschedulableOnNodePool,
-				NodePool:           "default",
-				Reason:             "reason",
-				Message:            "message",
-				TransitionID:       "0",
-				LastTransitionTime: metav1.Time{},
-				Status:             v1.ConditionTrue,
-			},
+			schedulingCondition: newUnschedulableCondition("default"),
 			expectedConditions: []enginev2alpha2.SchedulingCondition{
-				{
-					Type:         enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:     "existingConditionNodepool",
-					Reason:       "reason",
-					Message:      "message",
-					TransitionID: "99",
-					Status:       v1.ConditionTrue,
-				},
-				{
-					Type:         enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:     "default",
-					Reason:       "reason",
-					Message:      "message",
-					TransitionID: "100",
-					Status:       v1.ConditionTrue,
-				},
+				unschedulableCondition("existingConditionNodepool", "99"),
+				unschedulableCondition("default", "100"),
 			},
 
 			expectedUpdated: true,
@@ -175,55 +154,15 @@ func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
 			podGroup: &enginev2alpha2.PodGroup{
 				Status: enginev2alpha2.PodGroupStatus{
 					SchedulingConditions: []enginev2alpha2.SchedulingCondition{
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "existingConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "1",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "newerConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "2",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
+						unschedulableCondition("existingConditionNodepool", "1"),
+						unschedulableCondition("newerConditionNodepool", "2"),
 					},
 				},
 			},
-			schedulingCondition: &enginev2alpha2.SchedulingCondition{
-				Type:               enginev2alpha2.UnschedulableOnNodePool,
-				NodePool:           "existingConditionNodepool",
-				Reason:             "reason",
-				Message:            "message",
-				TransitionID:       "0",
-				LastTransitionTime: metav1.Time{},
-				Status:             v1.ConditionTrue,
-			},
+			schedulingCondition: newUnschedulableCondition("existingConditionNodepool"),
 			expectedConditions: []enginev2alpha2.SchedulingCondition{
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "newerConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "2",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "existingConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "3",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
+				unschedulableCondition("newerConditionNodepool", "2"),
+				unschedulableCondition("existingConditionNodepool", "3"),
 			},
 
 			expectedUpdated: true,
@@ -233,55 +172,15 @@ func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
 			podGroup: &enginev2alpha2.PodGroup{
 				Status: enginev2alpha2.PodGroupStatus{
 					SchedulingConditions: []enginev2alpha2.SchedulingCondition{
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "newerConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "2",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "existingConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "3",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
+						unschedulableCondition("newerConditionNodepool", "2"),
+						unschedulableCondition("existingConditionNodepool", "3"),
 					},
 				},
 			},
-			schedulingCondition: &enginev2alpha2.SchedulingCondition{
-				Type:               enginev2alpha2.UnschedulableOnNodePool,
-				NodePool:           "existingConditionNodepool",
-				Reason:             "reason",
-				Message:            "message",
-				TransitionID:       "0",
-				LastTransitionTime: metav1.Time{},
-				Status:             v1.ConditionTrue,
-			},
+			schedulingCondition: newUnschedulableCondition("existingConditionNodepool"),
 			expectedConditions: []enginev2alpha2.SchedulingCondition{
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "newerConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "2",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "existingConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "3",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
+				unschedulableCondition("newerConditionNodepool", "2"),
+				unschedulableCondition("existingConditionNodepool", "3"),
 			},
 
 			expectedUpdated: false,
@@ -291,122 +190,36 @@ func TestUpdatePodGroupSchedulingCondition(t *testing.T) {
 			podGroup: &enginev2alpha2.PodGroup{
 				Status: enginev2alpha2.PodGroupStatus{
 					SchedulingConditions: []enginev2alpha2.SchedulingCondition{
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "existingConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "3",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "newerConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "2",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
+						unschedulableCondition("existingConditionNodepool", "3"),
+						unschedulableCondition("newerConditionNodepool", "2"),
 					},
 				},
 			},
-			schedulingCondition: &enginev2alpha2.SchedulingCondition{
-				Type:               enginev2alpha2.UnschedulableOnNodePool,
-				NodePool:           "existingConditionNodepool",
-				Reason:             "reason",
-				Message:            "message",
-				TransitionID:       "0",
-				LastTransitionTime: metav1.Time{},
-				Status:             v1.ConditionTrue,
-			},
+			schedulingCondition: newUnschedulableCondition("existingConditionNodepool"),
 			expectedConditions: []enginev2alpha2.SchedulingCondition{
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "newerConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "2",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "existingConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "4",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
+				unschedulableCondition("newerConditionNodepool", "2"),
+				unschedulableCondition("existingConditionNodepool", "4"),
 			},
 
 			expectedUpdated: true,
 		},
 		{
-			name: "Squash conditions",
+			name: "Squash same nodepool and type",
 			podGroup: &enginev2alpha2.PodGroup{
 				Status: enginev2alpha2.PodGroupStatus{
 					SchedulingConditions: []enginev2alpha2.SchedulingCondition{
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "existingConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "1",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "newerConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "2",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
-						{
-							Type:               enginev2alpha2.UnschedulableOnNodePool,
-							NodePool:           "existingConditionNodepool",
-							Reason:             "reason",
-							Message:            "message",
-							TransitionID:       "3",
-							LastTransitionTime: metav1.Time{},
-							Status:             v1.ConditionTrue,
-						},
+						unschedulableCondition("existingConditionNodepool", "1"),
+						unschedulableCondition("newerConditionNodepool", "2"),
+						unschedulableCondition("existingConditionNodepool", "3"),
+						scenarioSearchCondition("existingConditionNodepool", "4"),
 					},
 				},
 			},
-			schedulingCondition: &enginev2alpha2.SchedulingCondition{
-				Type:               enginev2alpha2.UnschedulableOnNodePool,
-				NodePool:           "existingConditionNodepool",
-				Reason:             "reason",
-				Message:            "message",
-				TransitionID:       "0",
-				LastTransitionTime: metav1.Time{},
-				Status:             v1.ConditionTrue,
-			},
+			schedulingCondition: newUnschedulableCondition("existingConditionNodepool"),
 			expectedConditions: []enginev2alpha2.SchedulingCondition{
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "newerConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "2",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
-				{
-					Type:               enginev2alpha2.UnschedulableOnNodePool,
-					NodePool:           "existingConditionNodepool",
-					Reason:             "reason",
-					Message:            "message",
-					TransitionID:       "4",
-					LastTransitionTime: metav1.Time{},
-					Status:             v1.ConditionTrue,
-				},
+				unschedulableCondition("newerConditionNodepool", "2"),
+				scenarioSearchCondition("existingConditionNodepool", "4"),
+				unschedulableCondition("existingConditionNodepool", "5"),
 			},
 
 			expectedUpdated: true,

--- a/test/e2e/suites/api/crds/podgroup/conditions_specs.go
+++ b/test/e2e/suites/api/crds/podgroup/conditions_specs.go
@@ -126,7 +126,61 @@ func DescribeConditionsSpecs() bool {
 				})
 			})
 		})
+
+		Context("Recovering unschedulable Jobs", func() {
+			It("removes PodGroup scheduling conditions after the job is scheduled", func(ctx context.Context) {
+				schedulablePod := rd.CreatePodObject(testQueue, v1.ResourceRequirements{})
+				schedulablePod, err := rd.CreatePod(ctx, testCtx.KubeClientset, schedulablePod)
+				Expect(err).NotTo(HaveOccurred())
+				wait.ForPodScheduled(ctx, testCtx.ControllerClient, schedulablePod)
+				Expect(testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKeyFromObject(schedulablePod), schedulablePod)).
+					To(Succeed())
+				targetNodeName := schedulablePod.Spec.NodeName
+				Expect(testCtx.ControllerClient.Delete(ctx, schedulablePod)).To(Succeed())
+
+				node := &v1.Node{}
+				Expect(testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKey{Name: targetNodeName}, node)).To(Succeed())
+				labelKey := fmt.Sprintf("kai.scheduler/e2e-condition-cleanup-%s", utils.GenerateRandomK8sName(10))
+				labelValue := "true"
+				DeferCleanup(func(ctx context.Context) {
+					Expect(rd.UnLabelNode(ctx, testCtx.KubeClientset, node, labelKey)).To(Succeed())
+				})
+
+				pod := rd.CreatePodObject(testQueue, v1.ResourceRequirements{})
+				pod.Spec.Affinity = nodeAffinityForLabel(labelKey, labelValue)
+				createdPod, err := rd.CreatePod(ctx, testCtx.KubeClientset, pod)
+				Expect(err).NotTo(HaveOccurred())
+
+				podGroupName := SpecWaitForPGAnnotationOnPod(ctx, testCtx, createdPod)
+				wait.WaitForPodGroupToExist(ctx, testCtx.ControllerClient, createdPod.Namespace, podGroupName)
+				waitForPodGroupConditionType(ctx, testCtx, createdPod.Namespace, podGroupName, v2alpha2.UnschedulableOnNodePool)
+
+				Expect(rd.LabelNode(ctx, testCtx.KubeClientset, node, labelKey, labelValue)).To(Succeed())
+				wait.ForPodScheduled(ctx, testCtx.ControllerClient, createdPod)
+				waitForPodGroupSchedulingConditionsCleared(ctx, testCtx, createdPod.Namespace, podGroupName)
+			})
+		})
 	})
+}
+
+func nodeAffinityForLabel(labelKey, labelValue string) *v1.Affinity {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      labelKey,
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{labelValue},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func SpecWaitForPGConditionReason(
@@ -153,6 +207,34 @@ func SpecWaitForPGConditionReason(
 	}, time.Minute, time.Millisecond*100).Should(BeTrue())
 
 	return podGroup
+}
+
+func waitForPodGroupConditionType(
+	ctx context.Context, testCtx *testcontext.TestContext, namespace, podGroupName string,
+	conditionType v2alpha2.SchedulingConditionType,
+) {
+	podGroup := &v2alpha2.PodGroup{}
+	Eventually(func() bool {
+		Expect(testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKey{Name: podGroupName, Namespace: namespace}, podGroup)).
+			To(Succeed())
+		for _, condition := range podGroup.Status.SchedulingConditions {
+			if condition.Type == conditionType {
+				return true
+			}
+		}
+		return false
+	}, time.Minute, time.Millisecond*100).Should(BeTrue())
+}
+
+func waitForPodGroupSchedulingConditionsCleared(
+	ctx context.Context, testCtx *testcontext.TestContext, namespace, podGroupName string,
+) {
+	podGroup := &v2alpha2.PodGroup{}
+	Eventually(func() []v2alpha2.SchedulingCondition {
+		Expect(testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKey{Name: podGroupName, Namespace: namespace}, podGroup)).
+			To(Succeed())
+		return podGroup.Status.SchedulingConditions
+	}, time.Minute, time.Millisecond*100).Should(BeEmpty())
 }
 
 func SpecWaitForPGAnnotationOnPod(ctx context.Context, testCtx *testcontext.TestContext, pod *v1.Pod) string {


### PR DESCRIPTION
## Description

Stack slice 8 of 9 for the reclaim generator portfolio.

References:
- Full implementation PR: #1716
- Design: #1696 (`docs/developer/designs/reclaim-generator-portfolio-design.md`)
- Original issue: #1660

This PR adds user-facing unresolved-search explainability:
- Adds `ScenarioSearchUnresolved` condition/event behavior.
- Records unresolved search state on jobs.
- Surfaces unresolved search state on PodGroups and pending Pods.
- Includes reduced-budget reclaim failure/explanation behavior.

This slice makes bounded-search failures visible to users instead of only stopping internally.

## Related Issues

Related to #1660.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Stacking:
- Base: `erez/reclaim-generator-portfolio-07-metrics`
- Next PR: `erez/reclaim-generator-portfolio-09-benchmark-topology`

Verification for the rebuilt stack:
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache go test ./pkg/scheduler/plugins/scenariogenerators ./pkg/scheduler/conf_util ./pkg/operator/operands/scheduler ./pkg/scheduler/actions/common/solvers ./pkg/scheduler/actions/reclaim ./pkg/scheduler/actions/preempt ./pkg/scheduler/actions/consolidation ./pkg/scheduler/actions/integration_tests/reclaim ./pkg/scheduler/cache ./pkg/scheduler/cache/status_updater ./pkg/scheduler/metrics ./pkg/apis/scheduling/v2alpha2 -count=1`
- `git diff --check`
- `GOCACHE=/tmp/kai-reclaim-generator-go-cache make validate`
