### PR TITLE
fix(scheduler): filter unreclaimable reclaim victims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)
 
 ## [v0.16.0] - 2026-06-24
 

--- a/pkg/scheduler/actions/reclaim/reclaim_anchor_victim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_anchor_victim_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
@@ -17,8 +18,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
-
-func intPtr(i int) *int { return &i }
 
 // Queue hierarchy under test:
 //
@@ -91,10 +90,10 @@ func TestReclaimAnchorVictim(t *testing.T) {
 			"node-spare": {GPUs: 1},
 		},
 		Queues: []test_utils.TestQueueBasic{
-			{Name: "org-parent", DeservedGPUs: 6, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: intPtr(110)},
-			{Name: "reclaimer-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(75)},
-			{Name: "batch-queue", DeservedGPUs: 0, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(25)},
-			{Name: "protected-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: intPtr(100)},
+			{Name: "org-parent", DeservedGPUs: 6, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: ptr.To(110)},
+			{Name: "reclaimer-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: ptr.To(75)},
+			{Name: "batch-queue", DeservedGPUs: 0, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: ptr.To(25)},
+			{Name: "protected-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: ptr.To(100)},
 		},
 		Departments: []test_utils.TestDepartmentBasic{
 			{Name: "root", DeservedGPUs: 10},
@@ -168,9 +167,9 @@ func TestReclaimAnchorVictim_ControlNoProtectedQueue(t *testing.T) {
 			"node-spare":   {GPUs: 1},
 		},
 		Queues: []test_utils.TestQueueBasic{
-			{Name: "org-parent", DeservedGPUs: 6, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: intPtr(110)},
-			{Name: "reclaimer-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(75)},
-			{Name: "batch-queue", DeservedGPUs: 0, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(25)},
+			{Name: "org-parent", DeservedGPUs: 6, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: ptr.To(110)},
+			{Name: "reclaimer-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: ptr.To(75)},
+			{Name: "batch-queue", DeservedGPUs: 0, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: ptr.To(25)},
 		},
 		Departments: []test_utils.TestDepartmentBasic{
 			{Name: "root", DeservedGPUs: 10},

--- a/pkg/scheduler/actions/reclaim/reclaim_anchor_victim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_anchor_victim_test.go
@@ -1,0 +1,190 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim_test
+
+import (
+	"testing"
+
+	. "go.uber.org/mock/gomock"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+func intPtr(i int) *int { return &i }
+
+// Queue hierarchy under test:
+//
+//	root
+//	├── org-parent (priority 110)
+//	│   ├── reclaimer-queue  (under its deserved quota -> starved)
+//	│   └── batch-queue      (over its deserved quota of 0 -> reclaimable; sibling of reclaimer-queue)
+//	└── protected-queue      (priority 100, under its deserved quota -> NOT reclaimable / protected)
+//
+// A correct reclaim should evict a batch-queue pod (the reclaimer is starved and
+// batch-queue is over its deserved quota) and pipeline the reclaimer.
+//
+// Bug: both protected-queue and org-parent are under their fair share, so the victim
+// queue ordering falls to the priority tiebreak. The lower-priority subtree is popped
+// first as a victim, and protected-queue (priority 100) sorts before org-parent
+// (priority 110), so the protected-queue subtree is popped FIRST. Its node anchors
+// every candidate prefix the sub-scenario emitter produces; the reclaimer always
+// ends up evicting a protected-queue pod, and the scenario validator (which counts
+// the actually-evicted victims) only ever sees protected-queue -> rejected. A
+// batch-queue-only victim set is never offered to the validator, so the reclaim
+// fails entirely even though batch-queue is reclaimable.
+//
+// This test asserts the CORRECT behavior and currently FAILS on that bug
+// (reclaimer-job stays Pending instead of Pipelined). See the control test below,
+// which is identical except protected-queue is removed and the reclaim succeeds.
+func TestReclaimAnchorVictim(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+	defer gock.Off()
+
+	topology := test_utils.TestTopologyBasic{
+		Name: "reclaimable sibling never offered because lower-priority protected queue is popped first",
+		Jobs: []*jobs_fake.TestJobBasic{
+			{
+				Name:                "protected-job",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "protected-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{NodeName: "node-protected", State: pod_status.Running}},
+			},
+			{
+				Name:                "batch-job-a",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "batch-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{NodeName: "node-batch-1", State: pod_status.Running}},
+			},
+			{
+				Name:                "batch-job-b",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "batch-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{NodeName: "node-batch-2", State: pod_status.Running}},
+			},
+			{
+				Name:                "reclaimer-job",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "reclaimer-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+			},
+		},
+		Nodes: map[string]nodes_fake.TestNodeBasic{
+			"node-protected": {GPUs: 2},
+			"node-batch-1":   {GPUs: 2},
+			"node-batch-2":   {GPUs: 2},
+			// Tiny spare so both protected-queue and org-parent are under their fair
+			// share; too small to host the 2-GPU reclaimer or rehome a 2-GPU victim.
+			"node-spare": {GPUs: 1},
+		},
+		Queues: []test_utils.TestQueueBasic{
+			{Name: "org-parent", DeservedGPUs: 6, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: intPtr(110)},
+			{Name: "reclaimer-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(75)},
+			{Name: "batch-queue", DeservedGPUs: 0, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(25)},
+			{Name: "protected-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: intPtr(100)},
+		},
+		Departments: []test_utils.TestDepartmentBasic{
+			{Name: "root", DeservedGPUs: 10},
+		},
+		JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+			"reclaimer-job": {
+				GPUsRequired:         2,
+				Status:               pod_status.Pipelined,
+				DontValidateGPUGroup: true,
+			},
+			"protected-job": {
+				NodeName:             "node-protected",
+				GPUsRequired:         2,
+				Status:               pod_status.Running, // must never be reclaimed
+				DontValidateGPUGroup: true,
+			},
+		},
+	}
+
+	ssn := test_utils.BuildSession(topology, controller)
+	reclaim.New().Execute(ssn)
+	test_utils.MatchExpectedAndRealTasks(t, 0, topology, ssn)
+}
+
+// Control for TestReclaimAnchorVictim: the exact same reclaimer and batch-queue
+// configuration, but with the protected queue removed. Here the reclaimer correctly
+// reclaims a batch-queue pod and pipelines. The only difference from the failing
+// test is the presence of the lower-priority protected queue, which isolates the
+// defect to the victim-ordering / scenario-anchoring behavior.
+func TestReclaimAnchorVictim_ControlNoProtectedQueue(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	controller := NewController(t)
+	defer controller.Finish()
+	defer gock.Off()
+
+	topology := test_utils.TestTopologyBasic{
+		Name: "control: without the protected queue the reclaimable sibling is reclaimed",
+		Jobs: []*jobs_fake.TestJobBasic{
+			{
+				Name:                "batch-job-a",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "batch-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{NodeName: "node-batch-1", State: pod_status.Running}},
+			},
+			{
+				Name:                "batch-job-b",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "batch-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{NodeName: "node-batch-2", State: pod_status.Running}},
+			},
+			{
+				Name:                "reclaimer-job",
+				RequiredGPUsPerTask: 2,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           "reclaimer-queue",
+				Tasks:               []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+			},
+		},
+		Nodes: map[string]nodes_fake.TestNodeBasic{
+			"node-batch-1": {GPUs: 2},
+			"node-batch-2": {GPUs: 2},
+			"node-spare":   {GPUs: 1},
+		},
+		Queues: []test_utils.TestQueueBasic{
+			{Name: "org-parent", DeservedGPUs: 6, GPUOverQuotaWeight: 1, ParentQueue: "root", Priority: intPtr(110)},
+			{Name: "reclaimer-queue", DeservedGPUs: 4, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(75)},
+			{Name: "batch-queue", DeservedGPUs: 0, GPUOverQuotaWeight: 1, ParentQueue: "org-parent", Priority: intPtr(25)},
+		},
+		Departments: []test_utils.TestDepartmentBasic{
+			{Name: "root", DeservedGPUs: 10},
+		},
+		JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+			"reclaimer-job": {
+				GPUsRequired:         2,
+				Status:               pod_status.Pipelined,
+				DontValidateGPUGroup: true,
+			},
+		},
+		Mocks: &test_utils.TestMock{
+			CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds:      5,
+				NumberOfCacheEvictions:  2,
+				NumberOfPipelineActions: 2,
+			},
+		},
+	}
+
+	ssn := test_utils.BuildSession(topology, controller)
+	reclaim.New().Execute(ssn)
+	test_utils.MatchExpectedAndRealTasks(t, 0, topology, ssn)
+}

--- a/pkg/scheduler/actions/reclaim/reclaim_anchor_victim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_anchor_victim_test.go
@@ -112,6 +112,13 @@ func TestReclaimAnchorVictim(t *testing.T) {
 				DontValidateGPUGroup: true,
 			},
 		},
+		Mocks: &test_utils.TestMock{
+			CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds:      5,
+				NumberOfCacheEvictions:  2,
+				NumberOfPipelineActions: 2,
+			},
+		},
 	}
 
 	ssn := test_utils.BuildSession(topology, controller)

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -105,6 +105,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	capacityPolicy := cp.New(pp.queues, pp.minNodeGPUMemory)
 	ssn.AddQueueOrderFn(pp.queueOrder)
 	ssn.AddCanReclaimResourcesFn(pp.CanReclaimResourcesFn)
+	ssn.AddReclaimVictimFilterFn(pp.reclaimVictimFilterFn)
 	ssn.AddReclaimScenarioValidatorFn(pp.reclaimableFn)
 	ssn.AddOnJobSolutionStartFn(pp.OnJobSolutionStartFn)
 	ssn.AddIsNonPreemptibleJobOverQueueQuotaFns(capacityPolicy.IsNonPreemptibleJobOverQuota)
@@ -138,6 +139,13 @@ func (pp *proportionPlugin) OnJobSolutionStartFn() {
 func (pp *proportionPlugin) CanReclaimResourcesFn(reclaimer *podgroup_info.PodGroupInfo) bool {
 	reclaimerInfo := pp.buildReclaimerInfo(reclaimer, pp.minNodeGPUMemory)
 	return pp.reclaimablePlugin.CanReclaimResources(pp.queues, reclaimerInfo)
+}
+
+func (pp *proportionPlugin) reclaimVictimFilterFn(
+	reclaimer *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo,
+) bool {
+	reclaimerInfo := pp.buildReclaimerInfo(reclaimer, pp.minNodeGPUMemory)
+	return pp.reclaimablePlugin.FilterVictim(pp.queues, reclaimerInfo, victim.Queue)
 }
 
 func (pp *proportionPlugin) reclaimableFn(

--- a/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
@@ -7,8 +7,8 @@ import (
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/reclaimable/strategies"
 	rs "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/resource_share"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/utils"
 )
 
 // FilterVictim removes victims that cannot be reclaimed by any proportion reclaim strategy.
@@ -26,23 +26,11 @@ func (r *Reclaimable) FilterVictim(
 		return true
 	}
 
-	if !canUseGuaranteeDeservedQuotaStrategy(reclaimer, reclaimerQueue) {
-		return canBeMaintainFairShareReclaimCandidate(reclaimeeQueue)
+	if !strategies.ReclaimerFitsDeservedQuota(reclaimer.RequiredResources, reclaimer.VectorMap, reclaimerQueue) {
+		return strategies.FitsMaintainFairShare(reclaimeeQueue, reclaimeeQueue.GetAllocatedShare())
 	}
 
 	return canBeDeservedQuotaReclaimCandidate(reclaimer, reclaimeeQueue)
-}
-
-func canUseGuaranteeDeservedQuotaStrategy(
-	reclaimer *ReclaimerInfo, reclaimerQueue *rs.QueueAttributes,
-) bool {
-	allocatedWithReclaimer := reclaimerQueue.GetAllocatedShare()
-	allocatedWithReclaimer.Add(utils.QuantifyVector(reclaimer.RequiredResources, reclaimer.VectorMap))
-	return allocatedWithReclaimer.LessEqual(reclaimerQueue.GetDeservedShare())
-}
-
-func canBeMaintainFairShareReclaimCandidate(reclaimeeQueue *rs.QueueAttributes) bool {
-	return !reclaimeeQueue.GetAllocatedShare().LessEqual(reclaimeeQueue.GetAllocatableShare())
 }
 
 func canBeDeservedQuotaReclaimCandidate(

--- a/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
@@ -1,0 +1,65 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaimable
+
+import (
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	rs "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/resource_share"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/utils"
+)
+
+// FilterVictim removes victims that cannot be reclaimed by the deserved-quota strategy.
+func (r *Reclaimable) FilterVictim(
+	queues map[common_info.QueueID]*rs.QueueAttributes,
+	reclaimer *ReclaimerInfo,
+	reclaimeeQueueID common_info.QueueID,
+) bool {
+	if reclaimer == nil {
+		return true
+	}
+
+	reclaimerQueue, reclaimeeQueue := r.getLeveledQueues(queues, reclaimer.Queue, reclaimeeQueueID)
+	if reclaimerQueue == nil || reclaimeeQueue == nil {
+		return true
+	}
+
+	if !canUseGuaranteeDeservedQuotaStrategy(reclaimer, reclaimerQueue) {
+		return true
+	}
+
+	return canBeDeservedQuotaReclaimCandidate(reclaimer, reclaimeeQueue)
+}
+
+func canUseGuaranteeDeservedQuotaStrategy(
+	reclaimer *ReclaimerInfo, reclaimerQueue *rs.QueueAttributes,
+) bool {
+	allocatedWithReclaimer := reclaimerQueue.GetAllocatedShare()
+	allocatedWithReclaimer.Add(utils.QuantifyVector(reclaimer.RequiredResources, reclaimer.VectorMap))
+	return allocatedWithReclaimer.LessEqual(reclaimerQueue.GetDeservedShare())
+}
+
+func canBeDeservedQuotaReclaimCandidate(
+	reclaimer *ReclaimerInfo, reclaimeeQueue *rs.QueueAttributes,
+) bool {
+	allocated := reclaimeeQueue.GetAllocatedShare()
+	deserved := reclaimeeQueue.GetDeservedShare()
+	involvedResources := getInvolvedResourcesNames([]resource_info.ResourceVector{reclaimer.RequiredResources}, reclaimer.VectorMap)
+
+	hasUnderDeservedResource := false
+	for resource := range involvedResources {
+		if deserved[resource] == commonconstants.UnlimitedResourceQuantity {
+			continue
+		}
+		if allocated[resource] > deserved[resource] {
+			return true
+		}
+		if allocated[resource] < deserved[resource] {
+			hasUnderDeservedResource = true
+		}
+	}
+
+	return !hasUnderDeservedResource
+}

--- a/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/proportion/utils"
 )
 
-// FilterVictim removes victims that cannot be reclaimed by the deserved-quota strategy.
+// FilterVictim removes victims that cannot be reclaimed by any proportion reclaim strategy.
 func (r *Reclaimable) FilterVictim(
 	queues map[common_info.QueueID]*rs.QueueAttributes,
 	reclaimer *ReclaimerInfo,
@@ -27,7 +27,7 @@ func (r *Reclaimable) FilterVictim(
 	}
 
 	if !canUseGuaranteeDeservedQuotaStrategy(reclaimer, reclaimerQueue) {
-		return true
+		return canBeMaintainFairShareReclaimCandidate(reclaimeeQueue)
 	}
 
 	return canBeDeservedQuotaReclaimCandidate(reclaimer, reclaimeeQueue)
@@ -39,6 +39,10 @@ func canUseGuaranteeDeservedQuotaStrategy(
 	allocatedWithReclaimer := reclaimerQueue.GetAllocatedShare()
 	allocatedWithReclaimer.Add(utils.QuantifyVector(reclaimer.RequiredResources, reclaimer.VectorMap))
 	return allocatedWithReclaimer.LessEqual(reclaimerQueue.GetDeservedShare())
+}
+
+func canBeMaintainFairShareReclaimCandidate(reclaimeeQueue *rs.QueueAttributes) bool {
+	return !reclaimeeQueue.GetAllocatedShare().LessEqual(reclaimeeQueue.GetAllocatableShare())
 }
 
 func canBeDeservedQuotaReclaimCandidate(

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
@@ -1134,6 +1134,45 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 	})
 })
 
+var _ = Describe("FilterVictim", func() {
+	reclaimerInfo := &ReclaimerInfo{
+		Queue:             "reclaimer",
+		RequiredResources: resource_info.NewResource(0, 0, 2).ToVector(testVectorMap),
+		VectorMap:         testVectorMap,
+		IsPreemptable:     true,
+	}
+
+	It("filters victims whose leveled queue is strictly under deserved quota", func() {
+		reclaimable := New(1)
+		queues := buildQueues(map[common_info.QueueID]queuesTestData{
+			"reclaimer": {deserved: 4, fairShare: 4, allocated: 0},
+			"victim":    {deserved: 4, fairShare: 4, allocated: 2},
+		})
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeFalse())
+	})
+
+	It("keeps victims whose leveled queue is over deserved quota", func() {
+		reclaimable := New(1)
+		queues := buildQueues(map[common_info.QueueID]queuesTestData{
+			"reclaimer": {deserved: 4, fairShare: 4, allocated: 0},
+			"victim":    {deserved: 0, fairShare: 4, allocated: 4},
+		})
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeTrue())
+	})
+
+	It("keeps victims exactly at deserved quota for consolidation", func() {
+		reclaimable := New(1)
+		queues := buildQueues(map[common_info.QueueID]queuesTestData{
+			"reclaimer": {deserved: 4, fairShare: 4, allocated: 0},
+			"victim":    {deserved: 2, fairShare: 4, allocated: 2},
+		})
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeTrue())
+	})
+})
+
 func buildQueues(queuesData map[common_info.QueueID]queuesTestData) map[common_info.QueueID]*rs.QueueAttributes {
 	queues := map[common_info.QueueID]*rs.QueueAttributes{}
 	for name, queueData := range queuesData {

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
@@ -1171,6 +1171,26 @@ var _ = Describe("FilterVictim", func() {
 
 		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeTrue())
 	})
+
+	It("filters victims under allocatable share when the reclaimer cannot use deserved quota", func() {
+		reclaimable := New(1)
+		queues := buildQueues(map[common_info.QueueID]queuesTestData{
+			"reclaimer": {deserved: 1, fairShare: 4, allocated: 0},
+			"victim":    {deserved: 2, fairShare: 4, allocated: 3},
+		})
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeFalse())
+	})
+
+	It("keeps victims over allocatable share when the reclaimer cannot use deserved quota", func() {
+		reclaimable := New(1)
+		queues := buildQueues(map[common_info.QueueID]queuesTestData{
+			"reclaimer": {deserved: 1, fairShare: 4, allocated: 0},
+			"victim":    {deserved: 2, fairShare: 4, allocated: 5},
+		})
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeTrue())
+	})
 })
 
 func buildQueues(queuesData map[common_info.QueueID]queuesTestData) map[common_info.QueueID]*rs.QueueAttributes {

--- a/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies.go
@@ -55,7 +55,7 @@ func (mfss *MaintainFairShareStrategy) Reclaimable(
 		reclaimerQueue.Name, reclaimeeQueue.Name, reclaimeeQueue.GetRequestableShare(), reclaimeeQueue.GetDeservedShare(),
 		reclaimeeQueue.GetFairShare(), reclaimeeRemainingShare)
 
-	return !reclaimeeRemainingShare.LessEqual(reclaimeeQueue.GetAllocatableShare())
+	return FitsMaintainFairShare(reclaimeeQueue, reclaimeeRemainingShare)
 }
 
 func (gdqs *GuaranteeDeservedQuotaStrategy) Reclaimable(
@@ -75,21 +75,39 @@ func (gdqs *GuaranteeDeservedQuotaStrategy) Reclaimable(
 		reclaimerQueue.GetDeservedShare(), reclaimerQueue.GetFairShare())
 
 	// reclaimer has to be under (or equal) deserved quota in all resources (cpu, mem, gpu)
-	if reclaimerWillGoOverQuota(reclaimerResources, vectorMap, reclaimerQueue) {
+	if !ReclaimerFitsDeservedQuota(reclaimerResources, vectorMap, reclaimerQueue) {
 		return false
 	}
 
 	// reclaimee should be over deserved quota (at least in one of the resources)
-	if reclaimeeRemainingShare.LessEqual(reclaimeeQueue.GetDeservedShare()) {
+	if !ReclaimeeExceedsDeservedQuota(reclaimeeQueue, reclaimeeRemainingShare) {
 		return false
 	}
 
 	return true
 }
 
-func reclaimerWillGoOverQuota(reclaimerResources resource_info.ResourceVector, vectorMap *resource_info.ResourceVectorMap, reclaimerQueue *rs.QueueAttributes) bool {
+// FitsMaintainFairShare returns true when the reclaimee remains over its allocatable share.
+func FitsMaintainFairShare(reclaimeeQueue *rs.QueueAttributes, reclaimeeRemainingShare rs.ResourceQuantities) bool {
+	return !reclaimeeRemainingShare.LessEqual(reclaimeeQueue.GetAllocatableShare())
+}
+
+// ReclaimerFitsDeservedQuota returns true when adding the reclaimer keeps its queue within deserved quota.
+func ReclaimerFitsDeservedQuota(
+	reclaimerResources resource_info.ResourceVector,
+	vectorMap *resource_info.ResourceVectorMap,
+	reclaimerQueue *rs.QueueAttributes,
+) bool {
 	reclaimerRequestedQuota := reclaimerQueue.GetAllocatedShare()
 	reclaimerRequestedQuota.Add(utils.QuantifyVector(reclaimerResources, vectorMap))
 
-	return !reclaimerRequestedQuota.LessEqual(reclaimerQueue.GetDeservedShare())
+	return reclaimerRequestedQuota.LessEqual(reclaimerQueue.GetDeservedShare())
+}
+
+// ReclaimeeExceedsDeservedQuota returns true when the reclaimee remains over deserved quota.
+func ReclaimeeExceedsDeservedQuota(
+	reclaimeeQueue *rs.QueueAttributes,
+	reclaimeeRemainingShare rs.ResourceQuantities,
+) bool {
+	return !reclaimeeRemainingShare.LessEqual(reclaimeeQueue.GetDeservedShare())
 }

--- a/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies_test.go
@@ -22,6 +22,69 @@ func TestReclaimStrategies(t *testing.T) {
 var testVectorMap = resource_info.NewResourceVectorMap()
 
 var _ = Describe("Reclaim strategies", func() {
+	Context("Reclaim strategy predicates", func() {
+		It("checks maintain fair share against allocatable share", func() {
+			reclaimeeQueue := &rs.QueueAttributes{
+				Name: "p2",
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{
+						Deserved:   2,
+						FairShare:  4,
+						MaxAllowed: commonconstants.UnlimitedResourceQuantity,
+					},
+					CPU:    rs.ResourceShare{},
+					Memory: rs.ResourceShare{},
+				},
+			}
+
+			Expect(FitsMaintainFairShare(
+				reclaimeeQueue, rs.NewResourceQuantities(0, 0, 3),
+			)).To(BeFalse())
+			Expect(FitsMaintainFairShare(
+				reclaimeeQueue, rs.NewResourceQuantities(0, 0, 5),
+			)).To(BeTrue())
+		})
+
+		It("checks deserved quota strategy boundaries", func() {
+			reclaimerQueue := &rs.QueueAttributes{
+				Name: "p1",
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{
+						Deserved:  4,
+						FairShare: 4,
+						Allocated: 2,
+					},
+					CPU:    rs.ResourceShare{},
+					Memory: rs.ResourceShare{},
+				},
+			}
+			reclaimeeQueue := &rs.QueueAttributes{
+				Name: "p2",
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{
+						Deserved:  2,
+						FairShare: 4,
+					},
+					CPU:    rs.ResourceShare{},
+					Memory: rs.ResourceShare{},
+				},
+			}
+
+			Expect(ReclaimerFitsDeservedQuota(
+				resource_info.NewResource(0, 0, 2).ToVector(testVectorMap), testVectorMap, reclaimerQueue,
+			)).To(BeTrue())
+			Expect(ReclaimerFitsDeservedQuota(
+				resource_info.NewResource(0, 0, 3).ToVector(testVectorMap), testVectorMap, reclaimerQueue,
+			)).To(BeFalse())
+			Expect(ReclaimeeExceedsDeservedQuota(
+				reclaimeeQueue, rs.NewResourceQuantities(0, 0, 3),
+			)).To(BeTrue())
+			Expect(ReclaimeeExceedsDeservedQuota(
+				reclaimeeQueue, rs.NewResourceQuantities(0, 0, 2),
+			)).To(BeFalse())
+		})
+	})
+
 	Context("Maintain Fair Share Strategy", func() {
 		tests := map[string]struct {
 			reclaimerQueue *rs.QueueAttributes


### PR DESCRIPTION
## Description

Filters reclaim victim candidates that are definitely not eligible for the deserved-quota reclaim path. This prevents an unrelated under-deserved queue from being selected as an anchor victim and blocking a valid reclaim from an over-quota queue.

The proportion plugin now registers a reclaim victim filter, while the decision logic lives under `pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go`.

## Related Issues

Fixes #1750

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Validation:

- `go test ./pkg/scheduler/plugins/proportion/reclaimable`
- `go test ./pkg/scheduler/plugins/proportion`
- `go test ./pkg/scheduler/actions/reclaim`
