### PR TITLE
feat(podgrouper): preserve externally-assigned topology constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 ### Changed
-- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so a topology assigned by an external PodGroupAssigner is not overwritten. Workload topology annotations still take precedence when present.
+- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 ### Changed
+- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so a topology assigned by an external PodGroupAssigner is not overwritten. Workload topology annotations still take precedence when present.
 
 ### Fixed
 

--- a/pkg/podgrouper/podgroup/handler.go
+++ b/pkg/podgrouper/podgroup/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) ApplyToCluster(ctx context.Context, pgMetadata Metadata) error
 }
 
 func (h *Handler) ignoreFields(oldPodGroup, newPodGroup *schedulingv2alpha2.PodGroup) *schedulingv2alpha2.PodGroup {
-	// to avoid overriding the fields that the pod-group-assigner is responsible for
+	// to avoid overriding the fields that external services are responsible for
 	newPodGroupCopy := newPodGroup.DeepCopy()
 
 	newPodGroupCopy.Spec.MarkUnschedulable = oldPodGroup.Spec.MarkUnschedulable

--- a/pkg/podgrouper/podgroup/handler.go
+++ b/pkg/podgrouper/podgroup/handler.go
@@ -83,6 +83,10 @@ func (h *Handler) ignoreFields(oldPodGroup, newPodGroup *schedulingv2alpha2.PodG
 		newPodGroupCopy.Labels[h.queueLabelKey] = queueName
 	}
 
+	if newPodGroupCopy.Spec.TopologyConstraint.Topology == "" {
+		newPodGroupCopy.Spec.TopologyConstraint = oldPodGroup.Spec.TopologyConstraint
+	}
+
 	return newPodGroupCopy
 }
 

--- a/pkg/podgrouper/podgroup/handler_test.go
+++ b/pkg/podgrouper/podgroup/handler_test.go
@@ -731,10 +731,10 @@ func Test_createPodGroupForMetadata(t *testing.T) {
 }
 
 func Test_ignoreFields_TopologyConstraint(t *testing.T) {
-	pgaAssigned := schedulingv2alpha2.TopologyConstraint{
+	externalAssigned := schedulingv2alpha2.TopologyConstraint{
 		PreferredTopologyLevel: "rack",
 		RequiredTopologyLevel:  "zone",
-		Topology:               "pga-assigned-topology",
+		Topology:               "external-assigned-topology",
 	}
 	workloadAnnotated := schedulingv2alpha2.TopologyConstraint{
 		PreferredTopologyLevel: "node",
@@ -749,29 +749,29 @@ func Test_ignoreFields_TopologyConstraint(t *testing.T) {
 		expected *schedulingv2alpha2.PodGroup
 	}{
 		{
-			name: "new has no topology - preserve PGA-assigned constraint",
+			name: "new has no topology - preserve external-assigned constraint",
 			old: &schedulingv2alpha2.PodGroup{
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
 			},
 			new: &schedulingv2alpha2.PodGroup{
 				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
 			},
 			expected: &schedulingv2alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
 			},
 		},
 		{
-			name: "new has topology - workload annotations override PGA-assigned constraint",
+			name: "new has topology - workload annotations override external-assigned constraint",
 			old: &schedulingv2alpha2.PodGroup{
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
 			},
 			new: &schedulingv2alpha2.PodGroup{
 				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
 			},
 			expected: &schedulingv2alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
 			},
 		},
 		{
@@ -784,7 +784,7 @@ func Test_ignoreFields_TopologyConstraint(t *testing.T) {
 			},
 			expected: &schedulingv2alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
 			},
 		},
 		{
@@ -797,13 +797,13 @@ func Test_ignoreFields_TopologyConstraint(t *testing.T) {
 			},
 			expected: &schedulingv2alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
 			},
 		},
 		{
-			name: "new has only topology level but no topology name - preserve PGA-assigned constraint",
+			name: "new has only topology level but no topology name - preserve external-assigned constraint",
 			old: &schedulingv2alpha2.PodGroup{
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
 			},
 			new: &schedulingv2alpha2.PodGroup{
 				Spec: schedulingv2alpha2.PodGroupSpec{
@@ -812,7 +812,7 @@ func Test_ignoreFields_TopologyConstraint(t *testing.T) {
 			},
 			expected: &schedulingv2alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
-				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
 			},
 		},
 	}

--- a/pkg/podgrouper/podgroup/handler_test.go
+++ b/pkg/podgrouper/podgroup/handler_test.go
@@ -729,3 +729,102 @@ func Test_createPodGroupForMetadata(t *testing.T) {
 		})
 	}
 }
+
+func Test_ignoreFields_TopologyConstraint(t *testing.T) {
+	pgaAssigned := schedulingv2alpha2.TopologyConstraint{
+		PreferredTopologyLevel: "rack",
+		RequiredTopologyLevel:  "zone",
+		Topology:               "pga-assigned-topology",
+	}
+	workloadAnnotated := schedulingv2alpha2.TopologyConstraint{
+		PreferredTopologyLevel: "node",
+		RequiredTopologyLevel:  "rack",
+		Topology:               "workload-topology",
+	}
+
+	tests := []struct {
+		name     string
+		old      *schedulingv2alpha2.PodGroup
+		new      *schedulingv2alpha2.PodGroup
+		expected *schedulingv2alpha2.PodGroup
+	}{
+		{
+			name: "new has no topology - preserve PGA-assigned constraint",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+			},
+		},
+		{
+			name: "new has topology - workload annotations override PGA-assigned constraint",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+		},
+		{
+			name: "both empty - constraint stays empty",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+		},
+		{
+			name: "old empty, new has topology - use workload annotations",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+		},
+		{
+			name: "new has only topology level but no topology name - preserve PGA-assigned constraint",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{
+					TopologyConstraint: schedulingv2alpha2.TopologyConstraint{PreferredTopologyLevel: "node"},
+				},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: pgaAssigned},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &Handler{}
+			result := handler.ignoreFields(tt.old, tt.new)
+
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("ignoreFields() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so a topology assigned outside of KAI is not overwritten on reconcile.

When the workload carries topology annotations, those still take precedence — the externally-assigned constraint is only retained when the incoming PodGroup has an empty `Spec.TopologyConstraint.Topology`.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Added `Test_ignoreFields_TopologyConstraint` covering: workload without topology preserves the external constraint, workload annotations override it, both-empty stays empty, and a topology level without a topology name still preserves the existing constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)