### PR TITLE
feat(chart): expose nodePoolLabelKey value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Added a bounded scenario generator portfolio for reclaim, preempt, and consolidation search, with `SchedulingShard.spec.scenarioSearchBudgets` time-budget configuration and production scenario-search metrics.
+- Added `global.nodePoolLabelKey` Helm value to configure `spec.global.nodePoolLabelKey` in the Config CR for KAI sharding [#1774](https://github.com/kai-scheduler/KAI-Scheduler/issues/1774).
 - Added an opt-in `deviceaccess` admission plugin (`--block-nvidia-visible-devices`, config field `admission.blockNvidiaVisibleDevices`, default disabled) that (1) rejects pods overriding the `NVIDIA_VISIBLE_DEVICES` environment variable with values other than `void`/`none` (or via a `valueFrom` reference), and (2) injects `NVIDIA_VISIBLE_DEVICES=void` into containers that do not request a GPU, blocking their access to GPUs on the node.
 - Added support for configuring admission Pod Disruption Budget via Helm values (`admission.podDisruptionBudget`) [#1490](https://github.com/kai-scheduler/KAI-Scheduler/pull/1490) [dttung2905](https://github.com/dttung2905)
 - Added an opt-in `hamicore` binder plugin (depends on `gpusharing`) to write the HAMI-core GPU memory limit (`CUDA_DEVICE_MEMORY_LIMIT`) for fractional GPU pods.

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -19,6 +19,9 @@ spec:
     podLabelSelector:
       {{- toYaml .Values.global.podLabelSelector | nindent 6 }}
     {{- end }}
+    {{- if .Values.global.nodePoolLabelKey }}
+    nodePoolLabelKey: {{ .Values.global.nodePoolLabelKey | quote }}
+    {{- end }}
     {{- if .Values.global.jsonLog }}
     jsonLog: true
     {{- end }}

--- a/deployments/kai-scheduler/tests/enabled_test.yaml
+++ b/deployments/kai-scheduler/tests/enabled_test.yaml
@@ -35,6 +35,8 @@ tests:
       - equal:
           path: spec.scheduler.service.enabled
           value: true
+      - notExists:
+          path: spec.global.nodePoolLabelKey
 
   # ======================================
   # Global queueLabelKey Tests
@@ -46,6 +48,17 @@ tests:
       - equal:
           path: spec.global.queueLabelKey
           value: "runai/queue"
+
+  # ======================================
+  # Global nodePoolLabelKey Tests
+  # ======================================
+  - it: should wire global.nodePoolLabelKey into spec.global.nodePoolLabelKey
+    set:
+      global.nodePoolLabelKey: "runai/node-pool"
+    asserts:
+      - equal:
+          path: spec.global.nodePoolLabelKey
+          value: "runai/node-pool"
 
   # ======================================
   # Binder Enabled Tests

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -18,6 +18,7 @@ global:
   tolerations: []
   namespaceLabelSelector: {}
   podLabelSelector: {}
+  nodePoolLabelKey: ""
   jsonLog: false
   vpa:
     enabled: false


### PR DESCRIPTION
## Description

Expose `global.nodePoolLabelKey` in the Helm chart and render it into `spec.global.nodePoolLabelKey` on the chart-applied Config CR when set. This enables chart-based KAI sharding configuration.

## Related Issues

Fixes #1774

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes
