### PR TITLE
perf(scheduler): filter terminal pods at watch time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- Scheduler cache now filters terminal Pods at watch time to reduce memory use, while still watching Pods bound by other schedulers so their resource usage is counted in allocatable calculations. [#1645](https://github.com/kai-scheduler/KAI-Scheduler/issues/1645) [enoodle](https://github.com/enoodle)
 
 ## [v0.16.0] - 2026-06-24
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -22,6 +22,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,9 +35,11 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/informers"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	listv1 "k8s.io/client-go/listers/core/v1"
+	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	ksf "k8s.io/kube-scheduler/framework"
 
@@ -72,6 +75,36 @@ func init() {
 	}
 
 	utilruntime.Must(schemeBuilder.AddToScheme(kubeaischedulerschema.Scheme))
+}
+
+var terminalPodPhases = []v1.PodPhase{
+	v1.PodSucceeded,
+	v1.PodFailed,
+}
+
+func filterTerminalPods(options *metav1.ListOptions) {
+	selectors := make([]string, 0, len(terminalPodPhases))
+	for _, phase := range terminalPodPhases {
+		selectors = append(selectors, fmt.Sprintf("status.phase!=%s", phase))
+	}
+	selector := strings.Join(selectors, ",")
+	if options.FieldSelector == "" {
+		options.FieldSelector = selector
+		return
+	}
+	options.FieldSelector = fmt.Sprintf("%s,%s", options.FieldSelector, selector)
+}
+
+func registerSchedulerPodInformer(informerFactory informers.SharedInformerFactory) {
+	informerFactory.InformerFor(&v1.Pod{}, func(client kubernetes.Interface, resyncPeriod time.Duration) k8scache.SharedIndexInformer {
+		return corev1informers.NewFilteredPodInformer(
+			client,
+			metav1.NamespaceAll,
+			resyncPeriod,
+			k8scache.Indexers{k8scache.NamespaceIndex: k8scache.MetaNamespaceIndexFunc},
+			filterTerminalPods,
+		)
+	})
 }
 
 // New returns a Cache implementation.
@@ -156,6 +189,7 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCac
 	)
 
 	sc.informerFactory = informers.NewSharedInformerFactory(sc.kubeClient, 0)
+	registerSchedulerPodInformer(sc.informerFactory)
 	sc.kubeAiSchedulerInformerFactory = kubeaischedulerinfo.NewSharedInformerFactory(sc.kubeAiSchedulerClient, 0)
 
 	featuregates.SetDRAFeatureGate(schedulerCacheParams.DiscoveryClient)
@@ -439,7 +473,12 @@ func (sc *SchedulerCache) cleanStaleBindRequest(
 }
 
 func isTerminated(phase v1.PodPhase) bool {
-	return phase == v1.PodFailed || phase == v1.PodSucceeded
+	for _, terminalPhase := range terminalPodPhases {
+		if phase == terminalPhase {
+			return true
+		}
+	}
+	return false
 }
 
 func (sc *SchedulerCache) KubeClient() kubernetes.Interface {

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -56,6 +56,52 @@ func TestCache(t *testing.T) {
 
 var _ = Describe("Cache", func() {
 	Describe("New", func() {
+		Context("Pod informer filtering", func() {
+			It("should filter terminal pods without filtering pods by scheduler name", func() {
+				kubeClient := fake.NewSimpleClientset()
+				cache := New(&SchedulerCacheParams{
+					KubeClient:         kubeClient,
+					KAISchedulerClient: kubeaischedulerfake.NewSimpleClientset(),
+					NodePoolParams:     &conf.SchedulingNodePoolParams{},
+					DiscoveryClient:    kubeClient.Discovery(),
+				})
+
+				stopCh := make(chan struct{})
+				defer close(stopCh)
+				cache.Run(stopCh)
+				cache.WaitForCacheSync(stopCh)
+
+				podSelectors := []string{}
+				nonPodSelectors := map[string][]string{}
+				for _, action := range kubeClient.Actions() {
+					switch typedAction := action.(type) {
+					case faketesting.ListAction:
+						selector := typedAction.GetListRestrictions().Fields.String()
+						if action.GetResource().Resource == "pods" {
+							podSelectors = append(podSelectors, selector)
+						} else if selector != "" {
+							nonPodSelectors[action.GetResource().Resource] = append(nonPodSelectors[action.GetResource().Resource], selector)
+						}
+					case faketesting.WatchAction:
+						selector := typedAction.GetWatchRestrictions().Fields.String()
+						if action.GetResource().Resource == "pods" {
+							podSelectors = append(podSelectors, selector)
+						} else if selector != "" {
+							nonPodSelectors[action.GetResource().Resource] = append(nonPodSelectors[action.GetResource().Resource], selector)
+						}
+					}
+				}
+
+				Expect(podSelectors).NotTo(BeEmpty())
+				for _, selector := range podSelectors {
+					Expect(selector).To(ContainSubstring("status.phase!=Succeeded"))
+					Expect(selector).To(ContainSubstring("status.phase!=Failed"))
+					Expect(selector).NotTo(ContainSubstring("spec.schedulerName"))
+				}
+				Expect(nonPodSelectors).To(BeEmpty())
+			})
+		})
+
 		Context("DRA Feature Gate", func() {
 			DescribeTable("should record DRA availability based on Kubernetes version and resource API availability",
 				func(serverMajor, serverMinor string, resourceGroupVersions []string, expectDRAAvailable bool) {


### PR DESCRIPTION
## Description

BACKPORT of #1647 to v0.16

filter terminal pods (Succeeded or Failed) at watch time. Those pods are not used for scheduling as they don't hold resources on the cluster and can't be scheduled anymore, so we can safely ignore them to consume less memory.

## Related Issues

Fixes #1645 

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Measure memory consumption change - The scheduler generally ignore those pods, so it is really just their size that is saved. It didn't effect any of the current scale tests.

## Breaking Changes

## Additional Notes
