### PR TITLE
feat(chart): support externally managed KAI resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Added `priorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
 
 ### Changed
 
 ### Fixed
+- Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.
 
 ## [v0.16.0] - 2026-06-24
 

--- a/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
@@ -60,10 +60,12 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "Deleting deployments..."
-              kubectl -n {{ .Release.Namespace }} delete deployment --all --ignore-not-found=true
+              echo "Deleting KAI operator-managed deployments..."
+              kubectl -n {{ .Release.Namespace }} delete deployment --selector=app.kubernetes.io/managed-by=kai-operator --ignore-not-found=true
 
+              {{- if .Values.kaiConfigDeployer.enabled }}
               echo "Deleting kai-config..."
               kubectl delete Config kai-config --ignore-not-found
+              {{- end }}
               echo "Cleanup complete."
 {{- end }}

--- a/deployments/kai-scheduler/templates/priorityclasses/build-preemptible.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/build-preemptible.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.priorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,3 +7,4 @@ kind: PriorityClass
 metadata:
   name: build-preemptible
 value: 75
+{{- end }}

--- a/deployments/kai-scheduler/templates/priorityclasses/build.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/build.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.priorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,3 +7,4 @@ kind: PriorityClass
 metadata:
   name: build
 value: 100
+{{- end }}

--- a/deployments/kai-scheduler/templates/priorityclasses/inference.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/inference.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.priorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,3 +7,4 @@ kind: PriorityClass
 metadata:
   name: inference
 value: 125
+{{- end }}

--- a/deployments/kai-scheduler/templates/priorityclasses/train.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/train.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.priorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,3 +7,4 @@ kind: PriorityClass
 metadata:
   name: train
 value: 50
+{{- end }}

--- a/deployments/kai-scheduler/tests/post_delete_test.yaml
+++ b/deployments/kai-scheduler/tests/post_delete_test.yaml
@@ -5,16 +5,32 @@ suite: test post-delete cleanup hook
 templates:
   - hooks/post/post-delete-job.yaml
 tests:
-  - it: should use release namespace in kubectl delete deployment command
+  - it: should delete only operator-managed deployments in the release namespace
     release:
       namespace: custom-ns
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: kubectl -n custom-ns delete deployment --all --ignore-not-found=true
+          pattern: kubectl -n custom-ns delete deployment --selector=app.kubernetes.io/managed-by=kai-operator --ignore-not-found=true
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: kubectl -n kai-scheduler delete deployment
+          pattern: delete deployments? --all
+
+  - it: should delete kai-config when the config deployer is enabled
+    set:
+      kaiConfigDeployer.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete Config kai-config --ignore-not-found
+
+  - it: should preserve kai-config when the config deployer is disabled
+    set:
+      kaiConfigDeployer.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete Config kai-config
 
   - it: should place the cleanup job in the release namespace
     release:

--- a/deployments/kai-scheduler/tests/priority_classes_test.yaml
+++ b/deployments/kai-scheduler/tests/priority_classes_test.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test priority classes configuration
+templates:
+  - priorityclasses/build.yaml
+  - priorityclasses/train.yaml
+  - priorityclasses/inference.yaml
+  - priorityclasses/build-preemptible.yaml
+tests:
+  - it: should render the existing priority classes by default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: build
+        template: priorityclasses/build.yaml
+      - equal:
+          path: value
+          value: 100
+        template: priorityclasses/build.yaml
+      - equal:
+          path: metadata.name
+          value: train
+        template: priorityclasses/train.yaml
+      - equal:
+          path: value
+          value: 50
+        template: priorityclasses/train.yaml
+      - equal:
+          path: metadata.name
+          value: inference
+        template: priorityclasses/inference.yaml
+      - equal:
+          path: value
+          value: 125
+        template: priorityclasses/inference.yaml
+      - equal:
+          path: metadata.name
+          value: build-preemptible
+        template: priorityclasses/build-preemptible.yaml
+      - equal:
+          path: value
+          value: 75
+        template: priorityclasses/build-preemptible.yaml
+
+  - it: should not render priority classes when disabled
+    set:
+      priorityClasses.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: priorityclasses/build.yaml
+      - hasDocuments:
+          count: 0
+        template: priorityclasses/train.yaml
+      - hasDocuments:
+          count: 0
+        template: priorityclasses/inference.yaml
+      - hasDocuments:
+          count: 0
+        template: priorityclasses/build-preemptible.yaml

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -225,7 +225,8 @@ crdupgrader:
 
 kaiConfigDeployer:
   # Post-install/post-upgrade hook that applies the kai-config CR out-of-release (#1536).
-  # Disable to manage the kai-config CR outside of this chart.
+  # Disable to manage the kai-config CR outside of this chart. When disabled, the chart
+  # neither creates kai-config nor deletes it during post-delete cleanup.
   enabled: true
   image:
     name: crd-upgrader
@@ -256,6 +257,12 @@ postCleanup:
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
   serviceAccountName: post-delete-cleanup
   resources: {}
+
+# priorityClasses controls the chart-managed build, train, inference, and
+# build-preemptible PriorityClasses. Disable when these cluster-scoped resources
+# are managed externally.
+priorityClasses:
+  enabled: true
 
 prometheus:
   # Enable Prometheus integration for time-aware fairness features.

--- a/pkg/operator/operands/common/common.go
+++ b/pkg/operator/operands/common/common.go
@@ -28,6 +28,11 @@ import (
 
 var controllerTypes = []string{"Deployment", "DaemonSet"}
 
+const (
+	OperatorManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	OperatorManagedByLabelValue = "kai-operator"
+)
+
 // PodDisruptionBudgetImplementedServices lists operand resource names with operator-side PDB creation.
 var PodDisruptionBudgetImplementedServices = map[string]struct{}{
 	"admission": {},
@@ -139,6 +144,7 @@ func DeploymentForKAIConfig(
 		return nil, err
 	}
 	deployment := deploymentObj.(*appsv1.Deployment)
+	deployment.Labels[OperatorManagedByLabelKey] = OperatorManagedByLabelValue
 	deployment.TypeMeta = metav1.TypeMeta{
 		Kind:       "Deployment",
 		APIVersion: "apps/v1",

--- a/pkg/operator/operands/common/common_test.go
+++ b/pkg/operator/operands/common/common_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	kaiv1common "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/common"
 )
 
@@ -31,6 +32,27 @@ func TestCommon(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Common Functions Suite")
 }
+
+var _ = Describe("DeploymentForKAIConfig", func() {
+	It("labels operator-generated deployments for cleanup", func() {
+		config := &kaiv1.Config{Spec: kaiv1.ConfigSpec{Namespace: "kai-scheduler"}}
+		config.Spec.SetDefaultsWhereNeeded()
+		fakeKubeClient := fake.NewClientBuilder().WithObjects(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binder",
+				Namespace: config.Spec.Namespace,
+				Labels:    map[string]string{"existing-label": "preserved"},
+			},
+		}).Build()
+
+		deployment, err := DeploymentForKAIConfig(
+			context.Background(), fakeKubeClient, config, config.Spec.Binder.Service, "binder",
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deployment.Labels).To(HaveKeyWithValue(OperatorManagedByLabelKey, OperatorManagedByLabelValue))
+		Expect(deployment.Labels).To(HaveKeyWithValue("existing-label", "preserved"))
+	})
+})
 
 var _ = Describe("AllControllersAvailable", func() {
 	Context("No api errors", func() {

--- a/pkg/operator/operands/scheduler/resources_test.go
+++ b/pkg/operator/operands/scheduler/resources_test.go
@@ -19,6 +19,7 @@ import (
 	kaiv1qc "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/queue_controller"
 	kaiv1scheduler "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/scheduler"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	operatorcommon "github.com/kai-scheduler/KAI-scheduler/pkg/operator/operands/common"
 	usagedbapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/cache/usagedb/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
 
@@ -138,6 +139,8 @@ func TestDeploymentForShard(t *testing.T) {
 
 			assert.Equal(t, DeploymentName(tt.config, tt.shard), deploy.Name)
 			assert.Equal(t, tt.config.Spec.Namespace, deploy.Namespace)
+			assert.Equal(t, operatorcommon.OperatorManagedByLabelValue,
+				deploy.Labels[operatorcommon.OperatorManagedByLabelKey])
 
 			container := deploy.Spec.Template.Spec.Containers[0]
 			args := container.Args


### PR DESCRIPTION
## Description

Support embedding the KAI Helm chart as a subchart when KAI resources are managed externally, while preserving standalone defaults.

- Add `priorityClasses.enabled`, defaulting to `true`, and gate the existing `build`, `train`, `inference`, and `build-preemptible` PriorityClasses without changing their names or values.
- Preserve `Config/kai-config` during uninstall when `kaiConfigDeployer.enabled=false`.
- Replace namespace-wide Deployment cleanup with `app.kubernetes.io/managed-by=kai-operator` selection.
- Apply the cleanup ownership label through the common operator Deployment factory, including dynamically named scheduler Deployments for SchedulingShards.

The previous post-delete hook used `kubectl delete deployment --all`, which could remove unrelated workloads in a shared namespace, and always deleted `kai-config` even when its lifecycle was external to the chart.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. Existing standalone behavior remains unchanged because `priorityClasses.enabled` and `kaiConfigDeployer.enabled` both default to `true`.

## Additional Notes

Validation:

- `helm unittest -f 'tests/**/*_test.yaml' .` — 112 tests passed
- `helm lint .` — passed
- Default and external-management `helm template` renders — passed
- `go test ./pkg/operator/operands/common ./pkg/operator/operands/scheduler` — passed

A v0.16 backport commit is prepared locally and will be published after this change lands on `main`.
