### PR TITLE
feat(podgrouper): preserve externally-assigned topology constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `priorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
 
 ### Changed
+- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 
 ### Fixed
 - Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.

--- a/pkg/podgrouper/podgroup/handler.go
+++ b/pkg/podgrouper/podgroup/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) ApplyToCluster(ctx context.Context, pgMetadata Metadata) error
 }
 
 func (h *Handler) ignoreFields(oldPodGroup, newPodGroup *schedulingv2alpha2.PodGroup) *schedulingv2alpha2.PodGroup {
-	// to avoid overriding the fields that the pod-group-assigner is responsible for
+	// to avoid overriding the fields that external services are responsible for
 	newPodGroupCopy := newPodGroup.DeepCopy()
 
 	newPodGroupCopy.Spec.MarkUnschedulable = oldPodGroup.Spec.MarkUnschedulable
@@ -81,6 +81,10 @@ func (h *Handler) ignoreFields(oldPodGroup, newPodGroup *schedulingv2alpha2.PodG
 	queueName, found := oldPodGroup.Labels[h.queueLabelKey]
 	if found {
 		newPodGroupCopy.Labels[h.queueLabelKey] = queueName
+	}
+
+	if newPodGroupCopy.Spec.TopologyConstraint.Topology == "" {
+		newPodGroupCopy.Spec.TopologyConstraint = oldPodGroup.Spec.TopologyConstraint
 	}
 
 	return newPodGroupCopy

--- a/pkg/podgrouper/podgroup/handler_test.go
+++ b/pkg/podgrouper/podgroup/handler_test.go
@@ -729,3 +729,102 @@ func Test_createPodGroupForMetadata(t *testing.T) {
 		})
 	}
 }
+
+func Test_ignoreFields_TopologyConstraint(t *testing.T) {
+	externalAssigned := schedulingv2alpha2.TopologyConstraint{
+		PreferredTopologyLevel: "rack",
+		RequiredTopologyLevel:  "zone",
+		Topology:               "external-assigned-topology",
+	}
+	workloadAnnotated := schedulingv2alpha2.TopologyConstraint{
+		PreferredTopologyLevel: "node",
+		RequiredTopologyLevel:  "rack",
+		Topology:               "workload-topology",
+	}
+
+	tests := []struct {
+		name     string
+		old      *schedulingv2alpha2.PodGroup
+		new      *schedulingv2alpha2.PodGroup
+		expected *schedulingv2alpha2.PodGroup
+	}{
+		{
+			name: "new has no topology - preserve external-assigned constraint",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
+			},
+		},
+		{
+			name: "new has topology - workload annotations override external-assigned constraint",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+		},
+		{
+			name: "both empty - constraint stays empty",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+		},
+		{
+			name: "old empty, new has topology - use workload annotations",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: schedulingv2alpha2.TopologyConstraint{}},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: workloadAnnotated},
+			},
+		},
+		{
+			name: "new has only topology level but no topology name - preserve external-assigned constraint",
+			old: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
+			},
+			new: &schedulingv2alpha2.PodGroup{
+				Spec: schedulingv2alpha2.PodGroupSpec{
+					TopologyConstraint: schedulingv2alpha2.TopologyConstraint{PreferredTopologyLevel: "node"},
+				},
+			},
+			expected: &schedulingv2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec:       schedulingv2alpha2.PodGroupSpec{TopologyConstraint: externalAssigned},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &Handler{}
+			result := handler.ignoreFields(tt.old, tt.new)
+
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("ignoreFields() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Backport to `v0.16` of #1771 (merged to `main` as commit `5dd879a2`).

The podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so a topology assigned outside of KAI (e.g. by an external pod-group-assigner) is not overwritten on reconcile. When the workload carries topology annotations, those still take precedence — the externally-assigned constraint is only retained when the incoming PodGroup has an empty `Spec.TopologyConstraint.Topology`.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Clean cherry-pick of `5dd879a2` from `main` (no conflicts). Includes `Test_ignoreFields_TopologyConstraint` covering: workload without topology preserves the external constraint, workload annotations override it, both-empty stays empty, and a topology level without a topology name still preserves the existing constraint.