### PR TITLE
refactor(chart): rename priorityClasses value to defaultPriorityClasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Added `priorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
+- Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
 
 ### Changed
 - Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.

--- a/deployments/kai-scheduler/templates/priorityclasses/build-preemptible.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/build-preemptible.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.priorityClasses.enabled }}
+{{- if .Values.defaultPriorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 

--- a/deployments/kai-scheduler/templates/priorityclasses/build.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/build.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.priorityClasses.enabled }}
+{{- if .Values.defaultPriorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 

--- a/deployments/kai-scheduler/templates/priorityclasses/inference.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/inference.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.priorityClasses.enabled }}
+{{- if .Values.defaultPriorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 

--- a/deployments/kai-scheduler/templates/priorityclasses/train.yaml
+++ b/deployments/kai-scheduler/templates/priorityclasses/train.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.priorityClasses.enabled }}
+{{- if .Values.defaultPriorityClasses.enabled }}
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 

--- a/deployments/kai-scheduler/tests/priority_classes_test.yaml
+++ b/deployments/kai-scheduler/tests/priority_classes_test.yaml
@@ -45,7 +45,7 @@ tests:
 
   - it: should not render priority classes when disabled
     set:
-      priorityClasses.enabled: false
+      defaultPriorityClasses.enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -258,10 +258,10 @@ postCleanup:
   serviceAccountName: post-delete-cleanup
   resources: {}
 
-# priorityClasses controls the chart-managed build, train, inference, and
+# defaultPriorityClasses controls the chart-managed build, train, inference, and
 # build-preemptible PriorityClasses. Disable when these cluster-scoped resources
 # are managed externally.
-priorityClasses:
+defaultPriorityClasses:
   enabled: true
 
 prometheus:


### PR DESCRIPTION
## Description

Renames the chart-managed PriorityClasses toggle from `priorityClasses.enabled` to `defaultPriorityClasses.enabled`.

The value only governs KAI's built-in default PriorityClasses (`build`, `train`, `inference`, `build-preemptible`), not arbitrary user-defined ones. `defaultPriorityClasses` makes that scope explicit at the call site and avoids implying the key holds a list of class definitions. The value is unreleased (added in #1779), so no backward-compatibility handling is required.

Touches `values.yaml`, the four `priorityclasses/*.yaml` templates, the helm unittest, and the CHANGELOG entry.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. The renamed value is unreleased.

## Additional Notes

Backport to `v0.16` will follow in a separate PR.