### PR TITLE
docs(scale-tests): enhance dashboard UX with KAI branding, light mode, and inline metrics

### DIFF
--- a/docs/scale-tests/app.js
+++ b/docs/scale-tests/app.js
@@ -186,6 +186,19 @@ function renderSpecDetail(spec, detailId) {
   return `<div class="spec-detail" id="${detailId}">${sections.join('')}</div>`;
 }
 
+function specMetricsHtml(spec) {
+  const m = (typeof findMetrics === 'function' && findMetrics(spec.ReportEntries))
+    || (typeof parseMetricsFromOutput === 'function' && parseMetricsFromOutput(spec.CapturedGinkgoWriterOutput));
+  if (!m) return '';
+  const parts = [];
+  if (m.nodes != null)                            parts.push(`${m.nodes} nodes`);
+  if (m.jobs  != null)                            parts.push(`${m.jobs} jobs`);
+  const t = m.total_time || m.time;
+  if (t != null && t !== '')                      parts.push(typeof t === 'string' ? t.replace(/(\d+m)[\d.]+s/, '$1').trim() : `${t}s`);
+  if (!parts.length) return '';
+  return `<div class="spec-metrics">${parts.map(p => `<span>${esc(p)}</span>`).join('<span class="sep-dot">·</span>')}</div>`;
+}
+
 function renderSpec(spec) {
   if (!specVisible(spec)) return '';
 
@@ -207,6 +220,7 @@ function renderSpec(spec) {
           <span>${esc(fmtTime(spec.StartTime))}</span>
           ${spec.NumAttempts > 1 ? `<span class="c-skip">${spec.NumAttempts} attempts</span>` : ''}
         </div>
+        ${specMetricsHtml(spec)}
         ${detail}
       </div>
       ${detail ? `<button class="detail-btn" onclick="toggleDetail('${detailId}')">details</button>` : ''}

--- a/docs/scale-tests/app.js
+++ b/docs/scale-tests/app.js
@@ -191,10 +191,11 @@ function specMetricsHtml(spec) {
     || (typeof parseMetricsFromOutput === 'function' && parseMetricsFromOutput(spec.CapturedGinkgoWriterOutput));
   if (!m) return '';
   const parts = [];
-  if (m.nodes != null)                            parts.push(`${m.nodes} nodes`);
-  if (m.jobs  != null)                            parts.push(`${m.jobs} jobs`);
+  if (m.nodes != null) parts.push(`${m.nodes} nodes`);
+  const jobs = m.jobs ?? m['distributed jobs'] ?? m['distributed-jobs'];
+  if (jobs != null) parts.push(`${jobs} jobs`);
   const t = m.total_time || m.time;
-  if (t != null && t !== '')                      parts.push(typeof t === 'string' ? t.replace(/(\d+m)[\d.]+s/, '$1').trim() : `${t}s`);
+  if (t != null && t !== '') parts.push(String(t));
   if (!parts.length) return '';
   return `<div class="spec-metrics">${parts.map(p => `<span>${esc(p)}</span>`).join('<span class="sep-dot">·</span>')}</div>`;
 }

--- a/docs/scale-tests/app.js
+++ b/docs/scale-tests/app.js
@@ -485,16 +485,9 @@ init();
 (function () {
   const btn = document.getElementById('theme-toggle');
 
-  function syncIcon() {
-    btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀' : '☽';
-  }
-
-  syncIcon();
-
   btn.addEventListener('click', () => {
     const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('kai-theme', next);
-    syncIcon();
   });
 })();

--- a/docs/scale-tests/app.js
+++ b/docs/scale-tests/app.js
@@ -479,3 +479,22 @@ document.getElementById('sort-dir').addEventListener('click', () => {
 });
 
 init();
+
+// ── Theme toggle ───────────────────────────────────────────────────────────
+
+(function () {
+  const btn = document.getElementById('theme-toggle');
+
+  function syncIcon() {
+    btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀' : '☽';
+  }
+
+  syncIcon();
+
+  btn.addEventListener('click', () => {
+    const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('kai-theme', next);
+    syncIcon();
+  });
+})();

--- a/docs/scale-tests/index.html
+++ b/docs/scale-tests/index.html
@@ -94,22 +94,18 @@
   <div class="metrics-grid">
     <div class="chart-card">
       <h3 class="chart-title">Fill Cluster with single GPU Jobs</h3>
-      <div class="chart-stats" id="stats-1"></div>
       <div class="chart-wrapper"><canvas id="chart-1"></canvas></div>
     </div>
     <div class="chart-card">
       <h3 class="chart-title">Schedules Jobs with Pending Tasks in Background</h3>
-      <div class="chart-stats" id="stats-2"></div>
       <div class="chart-wrapper"><canvas id="chart-2"></canvas></div>
     </div>
     <div class="chart-card">
       <h3 class="chart-title">Allocate Single Distributed Job (with preferred topology)</h3>
-      <div class="chart-stats" id="stats-3"></div>
       <div class="chart-wrapper"><canvas id="chart-3"></canvas></div>
     </div>
     <div class="chart-card">
       <h3 class="chart-title">Allocate Single Distributed Job (without preferred topology)</h3>
-      <div class="chart-stats" id="stats-4"></div>
       <div class="chart-wrapper"><canvas id="chart-4"></canvas></div>
     </div>
   </div>

--- a/docs/scale-tests/index.html
+++ b/docs/scale-tests/index.html
@@ -29,6 +29,13 @@
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+  <script>
+    (function(){
+      var t = localStorage.getItem('kai-theme') ||
+              (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+      document.documentElement.setAttribute('data-theme', t);
+    })();
+  </script>
 </head>
 <body>
 
@@ -37,6 +44,7 @@
   <img src="logo.svg" width="32" height="32" alt="KAI Scheduler Logo" aria-hidden="true">
   <h1>KAI Scheduler — Scale Tests</h1>
   <div class="header-stats" id="header-stats" aria-live="polite"></div>
+  <button id="theme-toggle" class="theme-btn" title="Toggle light/dark mode" aria-label="Toggle theme">☀</button>
 </header>
 
 <!-- ── Tab navigation ──────────────────────────────────────────────── -->

--- a/docs/scale-tests/index.html
+++ b/docs/scale-tests/index.html
@@ -41,12 +41,12 @@
 
 <!-- ── Tab navigation ──────────────────────────────────────────────── -->
 <nav class="tabs">
-  <button class="tab active" data-tab="runs">Test Runs</button>
-  <button class="tab" data-tab="metrics">Metrics</button>
+  <button class="tab active" data-tab="metrics">Metrics</button>
+  <button class="tab" data-tab="runs">Test Runs</button>
 </nav>
 
 <!-- ── Controls (Test Runs tab) ────────────────────────────────────────── -->
-<div class="controls tab-content" data-content="runs">
+<div class="controls tab-content hidden" data-content="runs">
   <div class="search-wrap">
     <svg class="search-icon" width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
       <path fill="var(--muted)" d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398l3.85 3.85a1 1 0 0 0 1.415-1.415l-3.868-3.833zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
@@ -74,15 +74,15 @@
 </div>
 
 <!-- ── Summary strip ───────────────────────────────────────────────────── -->
-<div class="summary tab-content" data-content="runs" id="summary" aria-live="polite">Loading…</div>
+<div class="summary tab-content hidden" data-content="runs" id="summary" aria-live="polite">Loading…</div>
 
 <!-- ── Run list ────────────────────────────────────────────────────────── -->
-<main id="main" class="tab-content" data-content="runs">
+<main id="main" class="tab-content hidden" data-content="runs">
   <div class="msg"><div class="spinner"></div><br>Fetching scale test results…</div>
 </main>
 
 <!-- ── Metrics view ────────────────────────────────────────────────────── -->
-<main id="metrics-main" class="tab-content hidden" data-content="metrics">
+<main id="metrics-main" class="tab-content" data-content="metrics">
   <div class="metrics-grid">
     <div class="chart-card">
       <h3 class="chart-title">Fill Cluster with single GPU Jobs</h3>

--- a/docs/scale-tests/index.html
+++ b/docs/scale-tests/index.html
@@ -44,7 +44,7 @@
   <img src="logo.svg" width="32" height="32" alt="KAI Scheduler Logo" aria-hidden="true">
   <h1>KAI Scheduler — Scale Tests</h1>
   <div class="header-stats" id="header-stats" aria-live="polite"></div>
-  <button id="theme-toggle" class="theme-btn" title="Toggle light/dark mode" aria-label="Toggle theme">☀</button>
+  <button id="theme-toggle" class="theme-btn" title="Toggle light/dark mode" aria-label="Toggle theme"></button>
 </header>
 
 <!-- ── Tab navigation ──────────────────────────────────────────────── -->

--- a/docs/scale-tests/index.html
+++ b/docs/scale-tests/index.html
@@ -94,18 +94,22 @@
   <div class="metrics-grid">
     <div class="chart-card">
       <h3 class="chart-title">Fill Cluster with single GPU Jobs</h3>
+      <div class="chart-stats" id="stats-1"></div>
       <div class="chart-wrapper"><canvas id="chart-1"></canvas></div>
     </div>
     <div class="chart-card">
       <h3 class="chart-title">Schedules Jobs with Pending Tasks in Background</h3>
+      <div class="chart-stats" id="stats-2"></div>
       <div class="chart-wrapper"><canvas id="chart-2"></canvas></div>
     </div>
     <div class="chart-card">
       <h3 class="chart-title">Allocate Single Distributed Job (with preferred topology)</h3>
+      <div class="chart-stats" id="stats-3"></div>
       <div class="chart-wrapper"><canvas id="chart-3"></canvas></div>
     </div>
     <div class="chart-card">
       <h3 class="chart-title">Allocate Single Distributed Job (without preferred topology)</h3>
+      <div class="chart-stats" id="stats-4"></div>
       <div class="chart-wrapper"><canvas id="chart-4"></canvas></div>
     </div>
   </div>

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -259,11 +259,6 @@ function createChart(canvasId, dataPoints, config) {
     options: {
       responsive: true,
       maintainAspectRatio: false,
-      interaction: {
-        mode: 'nearest',
-        axis: 'x',
-        intersect: false,
-      },
       plugins: {
         legend: {
           display: true,
@@ -275,46 +270,7 @@ function createChart(canvasId, dataPoints, config) {
             usePointStyle: true,
           },
         },
-        tooltip: {
-          backgroundColor: cssVar('--surface'),
-          titleColor: cssVar('--text'),
-          bodyColor: cssVar('--text'),
-          borderColor: cssVar('--border'),
-          borderWidth: 1,
-          padding: 10,
-          displayColors: true,
-          callbacks: {
-            title: (items) => {
-              if (items[0]) {
-                const lines = [
-                  new Date(items[0].parsed.x).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'short',
-                    day: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  })
-                ];
-
-                // Access commit from raw data
-                const datasetIndex = items[0].datasetIndex;
-                const dataIndex = items[0].dataIndex;
-                const rawData = items[0].chart.data.datasets[datasetIndex].data[dataIndex];
-
-                if (rawData.commit) {
-                  lines.push(`Commit: ${rawData.commit.substring(0, 8)}`);
-                }
-
-                return lines;
-              }
-              return '';
-            },
-            label: (context) => {
-              const value = context.parsed.y;
-              return `${context.dataset.label}: ${value.toFixed(3)}s`;
-            },
-          },
-        },
+        tooltip: { enabled: false },
       },
       scales: {
         x: {

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -8,13 +8,14 @@ function cssVar(name) {
 }
 
 function formatSeconds(s) {
-  if (s === null || s === undefined) return '—';
+  if (s === null || s === undefined || typeof s !== 'number' || !isFinite(s)) return '—';
   if (s < 60) return `${s.toFixed(1)}s`;
   const m = Math.floor(s / 60);
   return `${m}m ${Math.round(s % 60)}s`;
 }
 
 function trendArrow(latest, prevMean) {
+  if (prevMean === 0) return '<span class="stat-trend flat">→</span>';
   const pct = (latest - prevMean) / prevMean;
   if (pct < -0.05) return '<span class="stat-trend down">↓</span>';
   if (pct >  0.05) return '<span class="stat-trend up">↑</span>';

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -7,6 +7,43 @@ function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
+function formatSeconds(s) {
+  if (s === null || s === undefined) return '—';
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${Math.round(s % 60)}s`;
+}
+
+function trendArrow(latest, prevMean) {
+  const pct = (latest - prevMean) / prevMean;
+  if (pct < -0.05) return '<span class="stat-trend down">↓</span>';
+  if (pct >  0.05) return '<span class="stat-trend up">↑</span>';
+  return '<span class="stat-trend flat">→</span>';
+}
+
+function renderChartStats(statsId, grouped) {
+  const el = document.getElementById(statsId);
+  if (!el) return;
+
+  const chips = Object.entries(grouped).map(([legend, points]) => {
+    const latest = points.length ? points[points.length - 1].value : null;
+    const prev   = points.length >= 2 ? points.slice(-4, -1).map(p => p.value) : null;
+    const prevMean = prev && prev.length
+      ? prev.reduce((a, b) => a + b, 0) / prev.length
+      : null;
+    const arrow = latest !== null && prevMean !== null
+      ? trendArrow(latest, prevMean)
+      : '';
+    return `<span class="stat-chip">
+      <span class="stat-label">${esc(legend)}</span>
+      <span class="stat-value">${formatSeconds(latest)}</span>
+      ${arrow}
+    </span>`;
+  }).join('');
+
+  el.innerHTML = chips;
+}
+
 // ── Metric extraction mappings ────────────────────────────────────────────
 
 // Map test names to chart configurations
@@ -318,6 +355,9 @@ function createChart(canvasId, dataPoints, config) {
       },
     },
   });
+
+  const statsId = canvasId.replace('chart-', 'stats-');
+  renderChartStats(statsId, grouped);
 }
 
 // ── Initialization ─────────────────────────────────────────────────────────

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -3,6 +3,10 @@
 
 'use strict';
 
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
 // ── Metric extraction mappings ────────────────────────────────────────────
 
 // Map test names to chart configurations
@@ -180,7 +184,7 @@ function groupByLegend(dataPoints) {
 
 // Dark theme colors for Chart.js
 const CHART_COLORS = [
-  '#58a6ff', // accent blue
+  '#e8196c', // KAI pink
   '#3fb950', // pass green
   '#d29922', // skip yellow
   '#f85149', // fail red
@@ -227,17 +231,17 @@ function createChart(canvasId, dataPoints, config) {
           display: true,
           position: 'top',
           labels: {
-            color: '#e6edf3',
+            color: cssVar('--text'),
             font: { size: 11 },
             padding: 10,
             usePointStyle: true,
           },
         },
         tooltip: {
-          backgroundColor: '#161b22',
-          titleColor: '#e6edf3',
-          bodyColor: '#e6edf3',
-          borderColor: '#30363d',
+          backgroundColor: cssVar('--surface'),
+          titleColor: cssVar('--text'),
+          bodyColor: cssVar('--text'),
+          borderColor: cssVar('--border'),
           borderWidth: 1,
           padding: 10,
           displayColors: true,
@@ -284,11 +288,11 @@ function createChart(canvasId, dataPoints, config) {
             },
           },
           grid: {
-            color: '#30363d',
+            color: cssVar('--border'),
             drawBorder: false,
           },
           ticks: {
-            color: '#8b949e',
+            color: cssVar('--muted'),
             font: { size: 10 },
           },
         },
@@ -296,18 +300,18 @@ function createChart(canvasId, dataPoints, config) {
           beginAtZero: false,
           grace: '10%',
           grid: {
-            color: '#30363d',
+            color: cssVar('--border'),
             drawBorder: false,
           },
           ticks: {
-            color: '#8b949e',
+            color: cssVar('--muted'),
             font: { size: 10 },
             callback: (value) => `${value.toFixed(3)}s`,
           },
           title: {
             display: true,
             text: config.label,
-            color: '#8b949e',
+            color: cssVar('--muted'),
             font: { size: 11 },
           },
         },

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -378,7 +378,7 @@ window.addEventListener('scale-tests:data-loaded', () => {
   // If metrics tab is currently visible, initialize now
   const metricsTab = document.getElementById('metrics-main');
   if (metricsTab && !metricsTab.classList.contains('hidden')) {
-    window._metricsInitialized = false;  // Reset flag to allow initialization
+    window._metricsInitialized = true;
     initializeMetrics();
   }
 });

--- a/docs/scale-tests/metrics.js
+++ b/docs/scale-tests/metrics.js
@@ -7,43 +7,6 @@ function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
-function formatSeconds(s) {
-  if (s === null || s === undefined || typeof s !== 'number' || !isFinite(s)) return '—';
-  if (s < 60) return `${s.toFixed(1)}s`;
-  const m = Math.floor(s / 60);
-  return `${m}m ${Math.round(s % 60)}s`;
-}
-
-function trendArrow(latest, prevMean) {
-  if (prevMean === 0) return '<span class="stat-trend flat">→</span>';
-  const pct = (latest - prevMean) / prevMean;
-  if (pct < -0.05) return '<span class="stat-trend down">↓</span>';
-  if (pct >  0.05) return '<span class="stat-trend up">↑</span>';
-  return '<span class="stat-trend flat">→</span>';
-}
-
-function renderChartStats(statsId, grouped) {
-  const el = document.getElementById(statsId);
-  if (!el) return;
-
-  const chips = Object.entries(grouped).map(([legend, points]) => {
-    const latest = points.length ? points[points.length - 1].value : null;
-    const prev   = points.length >= 2 ? points.slice(-4, -1).map(p => p.value) : null;
-    const prevMean = prev && prev.length
-      ? prev.reduce((a, b) => a + b, 0) / prev.length
-      : null;
-    const arrow = latest !== null && prevMean !== null
-      ? trendArrow(latest, prevMean)
-      : '';
-    return `<span class="stat-chip">
-      <span class="stat-label">${esc(legend)}</span>
-      <span class="stat-value">${formatSeconds(latest)}</span>
-      ${arrow}
-    </span>`;
-  }).join('');
-
-  el.innerHTML = chips;
-}
 
 // ── Metric extraction mappings ────────────────────────────────────────────
 
@@ -313,8 +276,6 @@ function createChart(canvasId, dataPoints, config) {
     },
   });
 
-  const statsId = canvasId.replace('chart-', 'stats-');
-  renderChartStats(statsId, grouped);
 }
 
 // ── Initialization ─────────────────────────────────────────────────────────

--- a/docs/scale-tests/styles.css
+++ b/docs/scale-tests/styles.css
@@ -295,6 +295,8 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
 }
 .spec-meta { display: flex; gap: 14px; margin-top: 3px; font-size: 11px; color: var(--muted); }
 .spec-meta .mono { font-family: monospace; }
+.spec-metrics { display: flex; align-items: center; gap: 6px; margin-top: 4px; font-size: 11px; font-family: monospace; color: var(--accent); }
+.spec-metrics .sep-dot { color: var(--border); }
 
 .detail-btn {
   flex-shrink: 0;
@@ -436,12 +438,12 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
 /* ── Light mode ──────────────────────────────────────────────────────────── */
 
 [data-theme="light"] {
-  --bg:       #f5f7fa;
+  --bg:       #f0f4f8;
   --surface:  #ffffff;
-  --surface2: #eef1f5;
-  --border:   #d0d7e0;
+  --surface2: #e4eaf1;
+  --border:   #9db4c8;
   --text:     #1a2540;
-  --muted:    #5a6a80;
+  --muted:    #4a6070;
   --pass:     #1a8f37;
   --fail:     #d13027;
   --skip:     #a07010;

--- a/docs/scale-tests/styles.css
+++ b/docs/scale-tests/styles.css
@@ -2,16 +2,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 :root {
-  --bg:       #0d1117;
-  --surface:  #161b22;
-  --surface2: #21262d;
-  --border:   #30363d;
+  --bg:       #0c1524;
+  --surface:  #111e2f;
+  --surface2: #182436;
+  --border:   #1f3450;
   --text:     #e6edf3;
-  --muted:    #8b949e;
+  --muted:    #7a8fa6;
   --pass:     #3fb950;
   --fail:     #f85149;
   --skip:     #d29922;
-  --accent:   #58a6ff;
+  --accent:   #e8196c;
   --radius:   6px;
 }
 
@@ -432,3 +432,32 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
 .chart-wrapper canvas {
   max-height: 100%;
 }
+
+/* ── Light mode ──────────────────────────────────────────────────────────── */
+
+[data-theme="light"] {
+  --bg:       #f5f7fa;
+  --surface:  #ffffff;
+  --surface2: #eef1f5;
+  --border:   #d0d7e0;
+  --text:     #1a2540;
+  --muted:    #5a6a80;
+  --pass:     #1a8f37;
+  --fail:     #d13027;
+  --skip:     #a07010;
+}
+
+/* ── Theme toggle button ─────────────────────────────────────────────────── */
+
+.theme-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: 14px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+  flex-shrink: 0;
+}
+.theme-btn:hover { color: var(--text); border-color: var(--accent); }

--- a/docs/scale-tests/styles.css
+++ b/docs/scale-tests/styles.css
@@ -295,8 +295,20 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
 }
 .spec-meta { display: flex; gap: 14px; margin-top: 3px; font-size: 11px; color: var(--muted); }
 .spec-meta .mono { font-family: monospace; }
-.spec-metrics { display: flex; align-items: center; gap: 6px; margin-top: 4px; font-size: 11px; font-family: monospace; color: var(--accent); }
-.spec-metrics .sep-dot { color: var(--border); }
+.spec-metrics { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.spec-metrics span {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  background: rgba(232, 25, 108, 0.12);
+  border: 1px solid rgba(232, 25, 108, 0.35);
+  border-radius: 12px;
+  font-size: 11px;
+  font-family: monospace;
+  font-weight: 600;
+  color: var(--accent);
+}
+.spec-metrics .sep-dot { display: none; }
 
 .detail-btn {
   flex-shrink: 0;
@@ -466,36 +478,3 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
 :root .theme-btn::before, [data-theme="dark"] .theme-btn::before { content: "☀"; }
 [data-theme="light"] .theme-btn::before { content: "☽"; }
 
-/* ── Stat chips ──────────────────────────────────────────────────────────── */
-
-.chart-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 12px;
-  min-height: 28px;
-}
-
-.stat-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 3px 10px;
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  font-size: 12px;
-}
-
-.stat-label { color: var(--muted); }
-
-.stat-value {
-  font-family: monospace;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.stat-trend { font-weight: 700; font-size: 13px; }
-.stat-trend.down { color: var(--pass); }
-.stat-trend.up   { color: var(--fail); }
-.stat-trend.flat { color: var(--muted); }

--- a/docs/scale-tests/styles.css
+++ b/docs/scale-tests/styles.css
@@ -461,6 +461,8 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
   flex-shrink: 0;
 }
 .theme-btn:hover { color: var(--text); border-color: var(--accent); }
+:root .theme-btn::before, [data-theme="dark"] .theme-btn::before { content: "☀"; }
+[data-theme="light"] .theme-btn::before { content: "☽"; }
 
 /* ── Stat chips ──────────────────────────────────────────────────────────── */
 

--- a/docs/scale-tests/styles.css
+++ b/docs/scale-tests/styles.css
@@ -461,3 +461,37 @@ main { padding: 16px 24px; max-width: 1280px; margin: 0 auto; }
   flex-shrink: 0;
 }
 .theme-btn:hover { color: var(--text); border-color: var(--accent); }
+
+/* ── Stat chips ──────────────────────────────────────────────────────────── */
+
+.chart-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  min-height: 28px;
+}
+
+.stat-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  font-size: 12px;
+}
+
+.stat-label { color: var(--muted); }
+
+.stat-value {
+  font-family: monospace;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.stat-trend { font-weight: 700; font-size: 13px; }
+.stat-trend.down { color: var(--pass); }
+.stat-trend.up   { color: var(--fail); }
+.stat-trend.flat { color: var(--muted); }

--- a/docs/superpowers/plans/2026-06-28-scale-tests-ux-redesign.md
+++ b/docs/superpowers/plans/2026-06-28-scale-tests-ux-redesign.md
@@ -1,0 +1,506 @@
+# Scale Tests UX Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Metrics tab the default landing view, add KAI light mode, and inject per-chart latest-value stat chips.
+
+**Architecture:** Pure client-side HTML/CSS/JS — no build step. Four tasks each touch a focused slice of the three files (`index.html`, `styles.css`, `metrics.js`) with one task also touching `app.js`. Verification is visual: a local Python HTTP server serves the page with mock data.
+
+**Tech Stack:** Vanilla JS (ES2020), Chart.js 4.4, CSS custom properties, `localStorage` for theme persistence.
+
+## Global Constraints
+
+- No new external dependencies — Chart.js and chartjs-adapter-date-fns are already loaded via CDN in `index.html`.
+- Apache-2.0 + NVIDIA copyright headers are already present in all files — do not remove them.
+- Dark mode CSS variables are **already applied** to `docs/scale-tests/styles.css` `:root` block (done during design preview). Do not re-apply them.
+- A local test server and mock data already exist. Run `python3 -m http.server 8080` from `docs/scale-tests/` and open `http://localhost:8080` to verify each task.
+- `esc()` is defined globally in `app.js` and available to `metrics.js` since both load in the same page.
+
+---
+
+### Task 1: Swap tab order and fix metrics initialization
+
+Default landing tab changes from Test Runs → Metrics. Also fixes a bug where switching away from Metrics and back would try to re-create already-existing charts.
+
+**Files:**
+- Modify: `docs/scale-tests/index.html`
+- Modify: `docs/scale-tests/metrics.js`
+
+**Interfaces:**
+- Produces: Metrics tab is `active` and visible on load; Test Runs tab and its controls/summary strip start `hidden`.
+
+- [ ] **Step 1: Swap tabs and flip visibility in `index.html`**
+
+In `<nav class="tabs">`, move the Metrics button before Test Runs and flip `active`:
+```html
+<nav class="tabs">
+  <button class="tab active" data-tab="metrics">Metrics</button>
+  <button class="tab" data-tab="runs">Test Runs</button>
+</nav>
+```
+
+The controls bar, summary strip, and runs `<main>` all carry `data-content="runs"` — add `hidden` to each so they start hidden. The metrics `<main>` loses its `hidden` class:
+```html
+<!-- Controls: add hidden -->
+<div class="controls tab-content hidden" data-content="runs">
+  ...
+</div>
+
+<!-- Summary: add hidden -->
+<div class="summary tab-content hidden" data-content="runs" id="summary" aria-live="polite">Loading…</div>
+
+<!-- Runs main: add hidden -->
+<main id="main" class="tab-content hidden" data-content="runs">
+  <div class="msg"><div class="spinner"></div><br>Fetching scale test results…</div>
+</main>
+
+<!-- Metrics main: remove hidden -->
+<main id="metrics-main" class="tab-content" data-content="metrics">
+  ...
+</main>
+```
+
+- [ ] **Step 2: Fix the `_metricsInitialized` flag in `metrics.js`**
+
+In the `scale-tests:data-loaded` listener (around line 375), the flag is incorrectly reset to `false` before calling `initializeMetrics()`. Change it to `true` so clicking away and back to Metrics doesn't try to create duplicate charts:
+
+```js
+window.addEventListener('scale-tests:data-loaded', () => {
+  console.log('[metrics] Data loaded event received');
+
+  const metricsTab = document.getElementById('metrics-main');
+  if (metricsTab && !metricsTab.classList.contains('hidden')) {
+    window._metricsInitialized = true;
+    initializeMetrics();
+  }
+});
+```
+
+- [ ] **Step 3: Verify in browser**
+
+With the local server running (`python3 -m http.server 8080` from `docs/scale-tests/`):
+- Open `http://localhost:8080` — Metrics tab should be active and the chart grid visible immediately.
+- Click "Test Runs" — the run cards list appears; controls/search/filters appear.
+- Click "Metrics" again — charts are still there, no JS errors in console.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/scale-tests/index.html docs/scale-tests/metrics.js
+git commit -m "feat(docs): make Metrics the default tab, fix re-init bug"
+```
+
+---
+
+### Task 2: Light/dark theme toggle
+
+Adds a sun/moon button to the header. Theme is persisted in `localStorage` and applied before first paint to prevent flash.
+
+**Files:**
+- Modify: `docs/scale-tests/index.html` — inline FOUC-prevention script in `<head>`, toggle button in `<header>`
+- Modify: `docs/scale-tests/styles.css` — `[data-theme="light"]` variable overrides, toggle button style
+- Modify: `docs/scale-tests/app.js` — click handler and icon sync
+
+**Interfaces:**
+- Produces: `document.documentElement` carries `data-theme="dark"` or `data-theme="light"` at all times. `localStorage` key is `kai-theme`.
+
+- [ ] **Step 1: Add FOUC-prevention script to `<head>` in `index.html`**
+
+Insert immediately before `</head>` so the theme attribute is set before any CSS renders:
+
+```html
+  <script>
+    (function(){
+      var t = localStorage.getItem('kai-theme') ||
+              (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+      document.documentElement.setAttribute('data-theme', t);
+    })();
+  </script>
+</head>
+```
+
+- [ ] **Step 2: Add toggle button to `<header>` in `index.html`**
+
+Add the button as the last child of `<header class="page-header">`, after `<div class="header-stats">`:
+
+```html
+  <button id="theme-toggle" class="theme-btn" title="Toggle light/dark mode" aria-label="Toggle theme">☀</button>
+</header>
+```
+
+- [ ] **Step 3: Add light-mode CSS variables and toggle button style to `styles.css`**
+
+Append to the end of `styles.css`:
+
+```css
+/* ── Light mode ──────────────────────────────────────────────────────────── */
+
+[data-theme="light"] {
+  --bg:       #f5f7fa;
+  --surface:  #ffffff;
+  --surface2: #eef1f5;
+  --border:   #d0d7e0;
+  --text:     #1a2540;
+  --muted:    #5a6a80;
+  --pass:     #1a8f37;
+  --fail:     #d13027;
+  --skip:     #a07010;
+}
+
+/* ── Theme toggle button ─────────────────────────────────────────────────── */
+
+.theme-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: 14px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+  flex-shrink: 0;
+}
+.theme-btn:hover { color: var(--text); border-color: var(--accent); }
+```
+
+- [ ] **Step 4: Add toggle logic to `app.js`**
+
+Append to the end of `app.js` (after `init()`):
+
+```js
+// ── Theme toggle ───────────────────────────────────────────────────────────
+
+(function () {
+  const btn = document.getElementById('theme-toggle');
+
+  function syncIcon() {
+    btn.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀' : '☽';
+  }
+
+  syncIcon();
+
+  btn.addEventListener('click', () => {
+    const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('kai-theme', next);
+    syncIcon();
+  });
+})();
+```
+
+- [ ] **Step 5: Verify in browser**
+
+- Page loads in dark mode by default (or light if your OS is set to light).
+- Click the ☀/☽ button — the entire page color scheme switches instantly.
+- Reload — the chosen theme persists.
+- In DevTools console: `localStorage.getItem('kai-theme')` returns `"light"` or `"dark"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/scale-tests/index.html docs/scale-tests/styles.css docs/scale-tests/app.js
+git commit -m "feat(docs): add light/dark theme toggle with localStorage persistence"
+```
+
+---
+
+### Task 3: Theme-aware chart colors in `metrics.js`
+
+Chart.js options use hardcoded hex values for tooltips, grids, and ticks that don't respond to CSS variables. This task replaces them with values read from CSS at chart-creation time, and updates the first palette color from blue to KAI pink.
+
+**Files:**
+- Modify: `docs/scale-tests/metrics.js`
+
+**Interfaces:**
+- Consumes: CSS custom properties on `document.documentElement` set by Task 2.
+- Produces: `cssVar(name)` helper available within `metrics.js`; `CHART_COLORS[0]` is KAI pink.
+
+- [ ] **Step 1: Add `cssVar` helper and update `CHART_COLORS` in `metrics.js`**
+
+Add the helper immediately after the `'use strict';` line (around line 4):
+
+```js
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+```
+
+Replace the `CHART_COLORS` array (around line 182):
+
+```js
+const CHART_COLORS = [
+  '#e8196c', // KAI pink
+  '#3fb950', // pass green
+  '#d29922', // skip yellow
+  '#f85149', // fail red
+  '#a371f7', // purple
+  '#ea6045', // orange
+  '#79c0ff', // light blue
+  '#56d364', // light green
+];
+```
+
+- [ ] **Step 2: Replace hardcoded hex values in `createChart()` with `cssVar()` calls**
+
+In the `new Chart(ctx, { options: { ... } })` block inside `createChart()`, replace all hardcoded color strings:
+
+```js
+plugins: {
+  legend: {
+    display: true,
+    position: 'top',
+    labels: {
+      color: cssVar('--text'),
+      font: { size: 11 },
+      padding: 10,
+      usePointStyle: true,
+    },
+  },
+  tooltip: {
+    backgroundColor: cssVar('--surface'),
+    titleColor: cssVar('--text'),
+    bodyColor: cssVar('--text'),
+    borderColor: cssVar('--border'),
+    borderWidth: 1,
+    padding: 10,
+    displayColors: true,
+    callbacks: {
+      title: (items) => {
+        if (items[0]) {
+          const lines = [
+            new Date(items[0].parsed.x).toLocaleDateString('en-US', {
+              year: 'numeric', month: 'short', day: 'numeric',
+              hour: '2-digit', minute: '2-digit',
+            }),
+          ];
+          const raw = items[0].chart.data.datasets[items[0].datasetIndex].data[items[0].dataIndex];
+          if (raw.commit) lines.push(`Commit: ${raw.commit.substring(0, 8)}`);
+          return lines;
+        }
+        return '';
+      },
+      label: (context) => `${context.dataset.label}: ${context.parsed.y.toFixed(3)}s`,
+    },
+  },
+},
+scales: {
+  x: {
+    type: 'time',
+    time: {
+      unit: 'day',
+      displayFormats: { day: 'MMM d' },
+    },
+    grid: {
+      color: cssVar('--border'),
+      drawBorder: false,
+    },
+    ticks: {
+      color: cssVar('--muted'),
+      font: { size: 10 },
+    },
+  },
+  y: {
+    beginAtZero: false,
+    grace: '10%',
+    grid: {
+      color: cssVar('--border'),
+      drawBorder: false,
+    },
+    ticks: {
+      color: cssVar('--muted'),
+      font: { size: 10 },
+      callback: (value) => `${value.toFixed(3)}s`,
+    },
+    title: {
+      display: true,
+      text: config.label,
+      color: cssVar('--muted'),
+      font: { size: 11 },
+    },
+  },
+},
+```
+
+- [ ] **Step 3: Verify in browser**
+
+- Load page in dark mode — charts render with navy grids and pink first-series color.
+- Toggle to light mode — reload (theme-switch-after-render is a known limitation per spec). Charts should render with light backgrounds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/scale-tests/metrics.js
+git commit -m "feat(docs): use CSS variables for chart colors, switch first color to KAI pink"
+```
+
+---
+
+### Task 4: Per-chart latest-value stat chips
+
+Each chart card gets a row of chips showing the most recent measured value per legend group, with a trend arrow comparing it to the previous 3 data points.
+
+**Files:**
+- Modify: `docs/scale-tests/index.html` — add `<div class="chart-stats" id="stats-N">` to each chart card
+- Modify: `docs/scale-tests/styles.css` — `.chart-stats`, `.stat-chip`, `.stat-label`, `.stat-value`, `.stat-trend` styles
+- Modify: `docs/scale-tests/metrics.js` — `formatSeconds()`, `trendArrow()`, `renderChartStats()` helpers; call from `createChart()`
+
+**Interfaces:**
+- Consumes: `grouped` object from `groupByLegend()` (already available inside `createChart()`); `esc()` from `app.js` (global).
+- Produces: `renderChartStats(statsId, grouped)` populates the stats div for a given chart.
+
+- [ ] **Step 1: Add stats divs to each chart card in `index.html`**
+
+Inside each `.chart-card`, insert `<div class="chart-stats" id="stats-N">` between the `<h3>` title and the `<div class="chart-wrapper">`:
+
+```html
+<div class="chart-card">
+  <h3 class="chart-title">Fill Cluster with single GPU Jobs</h3>
+  <div class="chart-stats" id="stats-1"></div>
+  <div class="chart-wrapper"><canvas id="chart-1"></canvas></div>
+</div>
+<div class="chart-card">
+  <h3 class="chart-title">Schedules Jobs with Pending Tasks in Background</h3>
+  <div class="chart-stats" id="stats-2"></div>
+  <div class="chart-wrapper"><canvas id="chart-2"></canvas></div>
+</div>
+<div class="chart-card">
+  <h3 class="chart-title">Allocate Single Distributed Job (with preferred topology)</h3>
+  <div class="chart-stats" id="stats-3"></div>
+  <div class="chart-wrapper"><canvas id="chart-3"></canvas></div>
+</div>
+<div class="chart-card">
+  <h3 class="chart-title">Allocate Single Distributed Job (without preferred topology)</h3>
+  <div class="chart-stats" id="stats-4"></div>
+  <div class="chart-wrapper"><canvas id="chart-4"></canvas></div>
+</div>
+```
+
+- [ ] **Step 2: Add stat chip styles to `styles.css`**
+
+Append after the theme toggle styles added in Task 2:
+
+```css
+/* ── Stat chips ──────────────────────────────────────────────────────────── */
+
+.chart-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  min-height: 28px;
+}
+
+.stat-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  font-size: 12px;
+}
+
+.stat-label { color: var(--muted); }
+
+.stat-value {
+  font-family: monospace;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.stat-trend { font-weight: 700; font-size: 13px; }
+.stat-trend.down { color: var(--pass); }
+.stat-trend.up   { color: var(--fail); }
+.stat-trend.flat { color: var(--muted); }
+```
+
+- [ ] **Step 3: Add helper functions to `metrics.js`**
+
+Add these three functions after the `cssVar` helper added in Task 3:
+
+```js
+function formatSeconds(s) {
+  if (s === null || s === undefined) return '—';
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${Math.round(s % 60)}s`;
+}
+
+function trendArrow(latest, prevMean) {
+  const pct = (latest - prevMean) / prevMean;
+  if (pct < -0.05) return '<span class="stat-trend down">↓</span>';
+  if (pct >  0.05) return '<span class="stat-trend up">↑</span>';
+  return '<span class="stat-trend flat">→</span>';
+}
+
+function renderChartStats(statsId, grouped) {
+  const el = document.getElementById(statsId);
+  if (!el) return;
+
+  const chips = Object.entries(grouped).map(([legend, points]) => {
+    const latest = points.length ? points[points.length - 1].value : null;
+    const prev   = points.length >= 2 ? points.slice(-4, -1).map(p => p.value) : null;
+    const prevMean = prev && prev.length
+      ? prev.reduce((a, b) => a + b, 0) / prev.length
+      : null;
+    const arrow = latest !== null && prevMean !== null
+      ? trendArrow(latest, prevMean)
+      : '';
+    return `<span class="stat-chip">
+      <span class="stat-label">${esc(legend)}</span>
+      <span class="stat-value">${formatSeconds(latest)}</span>
+      ${arrow}
+    </span>`;
+  }).join('');
+
+  el.innerHTML = chips;
+}
+```
+
+- [ ] **Step 4: Call `renderChartStats` from `createChart()` in `metrics.js`**
+
+`createChart` ends with `new Chart(ctx, { ... })`. Add two lines immediately after that closing `);`:
+
+```js
+  // existing last line of createChart:
+  new Chart(ctx, { type: 'line', data: { datasets }, options: { ... } });
+
+  // ADD THESE TWO LINES:
+  const statsId = canvasId.replace('chart-', 'stats-');
+  renderChartStats(statsId, grouped);
+}   // end of createChart
+```
+
+`grouped` is already in scope — it's computed earlier in `createChart` via `const grouped = groupByLegend(dataPoints);`.
+```
+
+- [ ] **Step 5: Verify in browser**
+
+- Open `http://localhost:8080` — Metrics tab loads, each chart card shows stat chips between the title and the chart.
+- The mock data has 3 runs for the same report, so each chart may show chips with `→` trend (values are identical across runs). This is correct behavior.
+- If a chart has no matching data, its `chart-stats` div stays empty — verify no JS errors occur.
+- Toggle light mode (reload) — stat chips render with correct light-mode colors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/scale-tests/index.html docs/scale-tests/styles.css docs/scale-tests/metrics.js
+git commit -m "feat(docs): add per-chart latest-value stat chips with trend arrows"
+```
+
+---
+
+## Cleanup
+
+The mock data created during design (`docs/scale-tests/Public/`) should **not** be committed — it's only for local testing. Verify it's gitignored or remove it before opening a PR.
+
+```bash
+# Check if it's tracked
+git status docs/scale-tests/Public/
+
+# If tracked, remove from index but keep locally
+git rm -r --cached docs/scale-tests/Public/
+echo "docs/scale-tests/Public/" >> .gitignore
+git commit -m "chore: gitignore local mock data directory"
+```

--- a/docs/superpowers/specs/2026-06-28-scale-tests-ux-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-28-scale-tests-ux-redesign-design.md
@@ -1,0 +1,107 @@
+# Scale Tests Dashboard — UX Redesign
+
+**Date:** 2026-06-28  
+**Branch:** `siormeir/enhance-scale-test-page`  
+**Files in scope:** `docs/scale-tests/index.html`, `docs/scale-tests/styles.css`, `docs/scale-tests/app.js`, `docs/scale-tests/metrics.js`
+
+---
+
+## Goal
+
+The dashboard's primary purpose is displaying scale behavior and performance trends over time — not CI health monitoring. The redesign makes the Metrics view the default landing experience, aligns the visual identity with KAI's brand, and adds at-a-glance stat chips so visitors understand current performance without reading chart axes.
+
+---
+
+## Changes
+
+### 1. Tab order and default
+
+- Swap the order of tabs in `<nav class="tabs">`: **Metrics** appears first, **Test Runs** second.
+- Metrics tab is `active` by default; Test Runs tab starts `hidden`.
+- The controls bar (`data-content="runs"`) is already conditioned on tab visibility — no changes needed there.
+- In `metrics.js`: the `scale-tests:data-loaded` listener already checks `!metricsTab.classList.contains('hidden')`. With Metrics now the default visible tab, `initializeMetrics()` fires automatically on data load without any logic changes.
+
+### 2. KAI brand color scheme
+
+Replace the GitHub-gray-dark palette with KAI navy/pink.
+
+#### Dark mode (default)
+
+| Variable    | Old        | New        |
+|-------------|------------|------------|
+| `--bg`      | `#0d1117`  | `#0c1524`  |
+| `--surface` | `#161b22`  | `#111e2f`  |
+| `--surface2`| `#21262d`  | `#182436`  |
+| `--border`  | `#30363d`  | `#1f3450`  |
+| `--muted`   | `#8b949e`  | `#7a8fa6`  |
+| `--accent`  | `#58a6ff`  | `#e8196c`  |
+
+`--text`, `--pass`, `--fail`, `--skip`, `--radius` are unchanged.
+
+Hardcoded hex values in `metrics.js` (tooltip backgrounds, grid lines, tick colors, first `CHART_COLORS` entry) are updated to match.
+
+#### Light mode
+
+Light mode variables are scoped to `[data-theme="light"]` on the `<html>` element:
+
+| Variable    | Light value |
+|-------------|-------------|
+| `--bg`      | `#f5f7fa`   |
+| `--surface` | `#ffffff`   |
+| `--surface2`| `#eef1f5`   |
+| `--border`  | `#d0d7e0`   |
+| `--text`    | `#1a2540`   |
+| `--muted`   | `#5a6a80`   |
+| `--accent`  | `#e8196c`   |
+| `--pass`    | `#1a8f37`   |
+| `--fail`    | `#d13027`   |
+| `--skip`    | `#a07010`   |
+
+The `metrics.js` chart hardcodes (tooltip background, grid, ticks) are updated to use the CSS variables where possible; where Chart.js requires resolved values, a helper reads the computed CSS variable at chart-creation time.
+
+### 3. Light/dark toggle
+
+- A sun/moon `<button id="theme-toggle">` is added to the page header, right of the logo/title and left of `header-stats`.
+- On load: read `localStorage.getItem('kai-theme')` first; if absent, fall back to `window.matchMedia('(prefers-color-scheme: light)')`.
+- On click: toggle `data-theme` between `"light"` and `"dark"` on `<html>`, persist to `localStorage`.
+- Icon: ☀ in dark mode (click to go light), ☽ in light mode (click to go dark). Plain text characters, no external icon dependency.
+- Styled minimally — same button style as existing `.btn-group button`, no border, sits flush in the header.
+
+### 4. Per-chart latest-value stat chips
+
+Each chart card in `index.html` gets a `<div class="chart-stats" id="stats-N">` inserted between the `<h3 class="chart-title">` and `<div class="chart-wrapper">`.
+
+After `metrics.js` creates a chart it calls `renderChartStats(statsId, grouped)` which populates that div with one chip per legend group:
+
+```
+[legend label]   4m 32s  ↓
+[legend label]   1m 08s  →
+```
+
+**Trend calculation:** compare the latest value to the mean of the previous 3 data points for that legend group.
+- **↓** (green) — latest is >5% lower than recent mean (faster = better)
+- **↑** (red) — latest is >5% higher than recent mean (slower = worse)
+- **→** (muted) — within ±5%
+- No arrow shown if fewer than 2 data points exist for that legend.
+
+**Duration formatting:** convert raw seconds to `Xm Ys` or `Xs` display format (same `nsToHuman` style, adapted for seconds input).
+
+**CSS:** `.chart-stats` is a flex row with `gap: 8px; flex-wrap: wrap; margin-bottom: 12px`. Each `.stat-chip` is a small `inline-flex` pill with monospace value and colored trend indicator.
+
+---
+
+## Known limitations
+
+- Chart.js tooltip/grid colors are resolved from CSS variables at chart-creation time. Switching themes after charts are rendered requires a page reload to fully update chart internals. The page chrome (header, tabs, cards) updates immediately.
+
+## Out of scope
+
+- Structural layout changes to the Test Runs tab
+- New chart types or additional metric patterns
+- Any backend / S3 changes
+
+---
+
+## Testing
+
+A local mock environment exists at `docs/scale-tests/Public/` (manifest + report copied from `example-report.json`). Run `python3 -m http.server 8080` from `docs/scale-tests/` and open `http://localhost:8080`.


### PR DESCRIPTION
## Description

Enhances the scale tests GitHub Pages dashboard with improved UX, KAI brand alignment, and more actionable information at a glance.

**Changes:**
- **Metrics-first layout**: Metrics tab is now the default landing view — the dashboard's primary purpose is displaying performance trends, not CI health monitoring
- **KAI brand color scheme**: Replaced GitHub gray/blue palette with KAI navy (dark mode) and KAI pink accent (`#e8196c`) across the full UI
- **Light/dark theme toggle**: Sun/moon button in the header, defaults to OS preference, persists via `localStorage`. FOUC-free via inline `<head>` script
- **Inline scale metrics on test runs**: Each spec row in the Test Runs tab now shows pill badges (nodes · jobs · duration) extracted directly from test report entries — no need to expand the details panel
- **Clean metrics charts**: Removed hover tooltips from charts; chart colors now read CSS variables at render time for theme awareness

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None — docs-only change.

## Additional Notes

The scale tests page is deployed via GitHub Pages. The `Public/` mock data directory used for local development is gitignored and not included in this PR.