### PR TITLE
docs: add v0.16 to support matrix

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,13 +20,14 @@ The following versions are currently supported.
 
 | Version | Type | Release Date | End of Support | Status |
 | :--- | :--- | :--- | :--- | :--- |
-| **v0.15** | Standard | Jun 2026 | *Until v0.16* | **Active** |
+| **v0.16** | **LTS** | Jun 2026 | Jun 2027 | **Active** |
+| **v0.15** | Standard | Jun 2026 | *Until v0.16* | **End of Life** |
 | **v0.14** | **LTS** | Mar 2026 | Mar 2027 | **Maintenance** |
 | **v0.13** | Standard | Mar 2026 | *Until v0.14* | **End of Life** |
 | **v0.12** | **LTS** | Dec 2025 | Dec 2026 | **Maintenance** |
 | **v0.10** | Standard | Dec 2025 | *Until v0.12* | **End of Life** |
 | **v0.9** | **LTS** | Sep 2025 | **Sep 2026** | **Maintenance** |
-| **v0.6** | **LTS** | Jun 2025 | **Jun 2026** | **Maintenance** |
+| **v0.6** | **LTS** | Jun 2025 | **Jun 2026** | **End of Life** |
 | **v0.4** | **LTS** | Apr 2025 | **Apr 2026** | **End of Life** |
 | **< v0.4** | Legacy | - | - | **End of Life** |
 
@@ -40,6 +41,7 @@ Historical support additions are listed after the table.
 | KAI Release Line | Kubernetes Versions Validated | Notes |
 | :--- | :--- | :--- |
 | `v0.14.x` and `v0.15.x` tags | `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0` | This matrix landed in `5f09d6dc` and is present through tag `v0.15.2`. |
+| `v0.16.x` tags | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0`, `v1.36.1` | Release workflow validation for the v0.16 line. |
 | `main` / next unreleased line | `v1.28.13`, `v1.29.8`, `v1.30.4`, `v1.31.6`, `v1.32.3` (`default`, `dra-enabled`), `v1.33.4` (`default`, `dra-enabled`), `v1.34.0`, `v1.35.0`, `v1.36.1` | Release workflow validation for the main line. |
 
 ### Historical Support Notes


### PR DESCRIPTION
## Description

Updates the support policy for the v0.16 release:

- Adds v0.16 as the active LTS release, supported through June 2027.
- Marks v0.15 and the expired v0.6 release line as end of life.
- Documents the Kubernetes versions validated by the v0.16 release workflow.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (not needed for documentation-only changes)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Validation: `git diff --check`.
