### PR TITLE
feat(chart): add flag to skip reservation namespace creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Added `global.resourceReservation.createNamespace` Helm value (default `true`) to allow disabling creation of the resource-reservation namespace, for embedding KAI in a parent chart that creates the namespace itself.
 - Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
 
 ### Changed

--- a/deployments/kai-scheduler/templates/services/resourcereservation-namespace.yaml
+++ b/deployments/kai-scheduler/templates/services/resourcereservation-namespace.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- $ns := .Values.global.resourceReservation.namespace }}
+{{- if .Values.global.resourceReservation.createNamespace }}
 {{ if not (lookup "v1" "Namespace" "" $ns) -}}
 apiVersion: v1
 kind: Namespace
@@ -13,4 +14,5 @@ metadata:
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/kai-scheduler/tests/resourcereservation_namespace_test.yaml
+++ b/deployments/kai-scheduler/tests/resourcereservation_namespace_test.yaml
@@ -1,0 +1,60 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test resource reservation Namespace template
+templates:
+  - services/resourcereservation-namespace.yaml
+kubernetesProvider:
+  scheme:
+    v1/Namespace:
+      gvr:
+        version: v1
+        resource: namespaces
+      namespaced: false
+tests:
+  - it: should render namespace by default when it does not already exist
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: kai-resource-reservation
+
+  - it: should not render namespace when createNamespace is false
+    set:
+      global.resourceReservation.createNamespace: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render namespace when it already exists
+    kubernetesProvider:
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: kai-resource-reservation
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom reservation namespace value
+    set:
+      global.resourceReservation.namespace: custom-reservation-ns
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-reservation-ns
+
+  - it: should render namespace labels when configured
+    set:
+      global.resourceReservation.namespaceLabels:
+        team: platform
+        env: staging
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.env
+          value: staging

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -39,8 +39,6 @@ global:
     serviceAccount: kai-resource-reservation
     appLabel: kai-resource-reservation
     namespaceLabels: {}
-    # createNamespace controls whether the chart creates the resource-reservation namespace.
-    # Set to false when embedding KAI in a parent chart that creates this namespace itself.
     createNamespace: true
 
 operator:

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -39,6 +39,9 @@ global:
     serviceAccount: kai-resource-reservation
     appLabel: kai-resource-reservation
     namespaceLabels: {}
+    # createNamespace controls whether the chart creates the resource-reservation namespace.
+    # Set to false when embedding KAI in a parent chart that creates this namespace itself.
+    createNamespace: true
 
 operator:
   image:


### PR DESCRIPTION
## Description

Adds a `global.resourceReservation.createNamespace` Helm value (default `true`, preserving current behavior) that lets the chart skip creating the resource-reservation namespace. This is useful when embedding KAI as a subchart inside a parent chart that creates/owns that namespace itself — the existing `lookup "v1" "Namespace"` guard is unreliable for that case (it does not work under `helm template`/`--dry-run`), so an explicit opt-out is provided.

Only the `Namespace` object is gated. The `ServiceAccount` (`resourcereservation-serviceaccount.yaml`) and `RoleBinding` (`resourcereservation-binding.yaml`) are intentionally left untouched so KAI keeps functioning when the namespace is created externally.

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. The value defaults to `true`, so existing installations are unaffected.

## Additional Notes

Added a new helm-unittest suite `deployments/kai-scheduler/tests/resourcereservation_namespace_test.yaml` covering: default render, `createNamespace=false` (no render), already-exists guard, custom namespace name, and labels. Verified locally:

- `helm template` (default) → reservation Namespace rendered; with `--set global.resourceReservation.createNamespace=false` → Namespace not rendered, while ServiceAccount + RoleBinding still render.
- `helm unittest deployments/kai-scheduler` → 17 suites / 129 tests pass.
