### PR TITLE
feat(chart): add flag to skip reservation service account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Added `global.resourceReservation.createNamespace` Helm value (default `true`) to allow disabling creation of the resource-reservation namespace, for embedding KAI in a parent chart that creates the namespace itself.
+- Added `global.resourceReservation.createServiceAccount` Helm value (default `true`) to allow disabling creation of the resource-reservation ServiceAccount, for embedding KAI in a parent chart that creates the ServiceAccount itself.
 - Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
 
 ### Changed

--- a/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
+++ b/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
@@ -3,6 +3,7 @@
 
 {{- $ns := .Values.global.resourceReservation.namespace }}
 {{- $sa := .Values.global.resourceReservation.serviceAccount }}
+{{- if .Values.global.resourceReservation.createServiceAccount }}
 {{- if not (lookup "v1" "ServiceAccount" $ns $sa) }}
 apiVersion: v1
 kind: ServiceAccount
@@ -12,5 +13,6 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/kai-scheduler/tests/resourcereservation_serviceaccount_test.yaml
+++ b/deployments/kai-scheduler/tests/resourcereservation_serviceaccount_test.yaml
@@ -23,6 +23,13 @@ tests:
           path: metadata.namespace
           value: kai-resource-reservation
 
+  - it: should not render ServiceAccount when createServiceAccount is false
+    set:
+      global.resourceReservation.createServiceAccount: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should not render ServiceAccount when it already exists
     kubernetesProvider:
       objects:

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -40,6 +40,7 @@ global:
     appLabel: kai-resource-reservation
     namespaceLabels: {}
     createNamespace: true
+    createServiceAccount: true
 
 operator:
   image:


### PR DESCRIPTION
## Description

Adds a `global.resourceReservation.createServiceAccount` Helm value (default `true`) that controls whether the chart creates the resource-reservation `ServiceAccount`. This mirrors the existing `global.resourceReservation.createNamespace` flag (#1797) and lets users disable SA creation when it is managed externally (e.g. when embedding KAI in a parent chart that provisions the ServiceAccount itself).

The existing `lookup`-based guard (skip if the SA already exists) is preserved and now nested inside the new flag check.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. The value defaults to `true`, preserving current behavior.

## Additional Notes

- `deployments/kai-scheduler/values.yaml`: new `createServiceAccount: true` value.
- `templates/services/resourcereservation-serviceaccount.yaml`: gated rendering on the flag.
- `tests/resourcereservation_serviceaccount_test.yaml`: added a case asserting no ServiceAccount is rendered when `createServiceAccount=false`.
- `CHANGELOG.md`: added under Unreleased → Added.

Verified locally with `helm unittest` (11 tests pass across the namespace and service-account suites).