### PR TITLE
feat(chart): expose nodePoolLabelKey value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Added `global.nodePoolLabelKey` Helm value to configure `spec.global.nodePoolLabelKey` in the Config CR for KAI sharding [#1774](https://github.com/kai-scheduler/KAI-Scheduler/issues/1774).
+
 ## [v0.16.2] - 2026-06-30
 
 ### Fixed

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -19,6 +19,9 @@ spec:
     podLabelSelector:
       {{- toYaml .Values.global.podLabelSelector | nindent 6 }}
     {{- end }}
+    {{- if .Values.global.nodePoolLabelKey }}
+    nodePoolLabelKey: {{ .Values.global.nodePoolLabelKey | quote }}
+    {{- end }}
     {{- if .Values.global.jsonLog }}
     jsonLog: true
     {{- end }}

--- a/deployments/kai-scheduler/tests/enabled_test.yaml
+++ b/deployments/kai-scheduler/tests/enabled_test.yaml
@@ -35,6 +35,8 @@ tests:
       - equal:
           path: spec.scheduler.service.enabled
           value: true
+      - notExists:
+          path: spec.global.nodePoolLabelKey
 
   # ======================================
   # Global queueLabelKey Tests
@@ -46,6 +48,17 @@ tests:
       - equal:
           path: spec.global.queueLabelKey
           value: "runai/queue"
+
+  # ======================================
+  # Global nodePoolLabelKey Tests
+  # ======================================
+  - it: should wire global.nodePoolLabelKey into spec.global.nodePoolLabelKey
+    set:
+      global.nodePoolLabelKey: "runai/node-pool"
+    asserts:
+      - equal:
+          path: spec.global.nodePoolLabelKey
+          value: "runai/node-pool"
 
   # ======================================
   # Binder Enabled Tests

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -18,6 +18,7 @@ global:
   tolerations: []
   namespaceLabelSelector: {}
   podLabelSelector: {}
+  nodePoolLabelKey: ""
   jsonLog: false
   vpa:
     enabled: false


### PR DESCRIPTION
## Description

BACKPORT of #1776 to v0.16

Expose `global.nodePoolLabelKey` in the Helm chart and render it into `spec.global.nodePoolLabelKey` on the chart-applied Config CR when set. This enables chart-based KAI sharding configuration.

## Related Issues

Fixes #1774

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes
