### PR TITLE
feat(operator): make numa-placement-exporter podresources socket + sysfs configurable

### DIFF
--- a/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
@@ -5640,6 +5640,18 @@ spec:
                       exporter observes). The global nodeSelector is deliberately not applied — it is used to confine
                       management pods off worker nodes, the opposite of what the exporter needs.
                     type: object
+                  podResourcesHostPath:
+                    description: |-
+                      PodResourcesHostPath is the host directory hostPath-mounted for the podresources socket.
+                      Override to point the exporter at a non-kubelet podresources socket (e.g. a simulated one).
+                      PodResourcesSocket must resolve inside it. Defaults to /var/lib/kubelet/pod-resources.
+                    type: string
+                  podResourcesSocket:
+                    description: |-
+                      PodResourcesSocket is the podresources gRPC socket path the exporter dials. It must resolve
+                      inside PodResourcesHostPath (mounted at the same in-container path).
+                      Defaults to /var/lib/kubelet/pod-resources/kubelet.sock.
+                    type: string
                   pollInterval:
                     description: |-
                       PollInterval is how often the exporter reads placement from the local kubelet podresources API.
@@ -6683,6 +6695,11 @@ spec:
                             type: object
                         type: object
                     type: object
+                  sysfsHostPath:
+                    description: |-
+                      SysfsHostPath is the host sysfs directory hostPath-mounted for CPU-to-NUMA resolution.
+                      Override to point the exporter at a synthetic sysfs tree. Defaults to /sys.
+                    type: string
                   tolerations:
                     description: |-
                       Tolerations let the DaemonSet run on tainted worker nodes. Merged with the global daemonset

--- a/pkg/apis/kai/v1/numa_placement_exporter/numa_placement_exporter.go
+++ b/pkg/apis/kai/v1/numa_placement_exporter/numa_placement_exporter.go
@@ -47,6 +47,23 @@ type NumaPlacementExporter struct {
 	// Defaults to 60s when unset.
 	// +kubebuilder:validation:Optional
 	DriftResyncInterval *metav1.Duration `json:"driftResyncInterval,omitempty"`
+
+	// PodResourcesHostPath is the host directory hostPath-mounted for the podresources socket.
+	// Override to point the exporter at a non-kubelet podresources socket (e.g. a simulated one).
+	// PodResourcesSocket must resolve inside it. Defaults to /var/lib/kubelet/pod-resources.
+	// +kubebuilder:validation:Optional
+	PodResourcesHostPath string `json:"podResourcesHostPath,omitempty"`
+
+	// PodResourcesSocket is the podresources gRPC socket path the exporter dials. It must resolve
+	// inside PodResourcesHostPath (mounted at the same in-container path).
+	// Defaults to /var/lib/kubelet/pod-resources/kubelet.sock.
+	// +kubebuilder:validation:Optional
+	PodResourcesSocket string `json:"podResourcesSocket,omitempty"`
+
+	// SysfsHostPath is the host sysfs directory hostPath-mounted for CPU-to-NUMA resolution.
+	// Override to point the exporter at a synthetic sysfs tree. Defaults to /sys.
+	// +kubebuilder:validation:Optional
+	SysfsHostPath string `json:"sysfsHostPath,omitempty"`
 }
 
 func (n *NumaPlacementExporter) SetDefaultsWhereNeeded() {

--- a/pkg/operator/operands/numa_placement_exporter/numa_placement_exporter_test.go
+++ b/pkg/operator/operands/numa_placement_exporter/numa_placement_exporter_test.go
@@ -135,6 +135,45 @@ var _ = Describe("NumaPlacementExporter DesiredState", func() {
 		Expect(envNames).To(ContainElement("NODE_NAME"))
 	})
 
+	It("honors configured podResources/sysfs path overrides", func(ctx context.Context) {
+		cfg.Spec.NumaPlacementExporter.Service.Enabled = ptr.To(true)
+		cfg.Spec.NumaPlacementExporter.PodResourcesHostPath = "/var/lib/fake-gpu-operator/pod-resources"
+		cfg.Spec.NumaPlacementExporter.PodResourcesSocket = "/var/lib/fake-gpu-operator/pod-resources/kubelet.sock"
+		cfg.Spec.NumaPlacementExporter.SysfsHostPath = "/var/lib/fake-gpu-operator/sys"
+
+		objects, err := (&NumaPlacementExporter{}).DesiredState(ctx, fakeClient(), cfg)
+		Expect(err).To(BeNil())
+
+		var ds *appsv1.DaemonSet
+		for _, o := range objects {
+			if d, ok := o.(*appsv1.DaemonSet); ok {
+				ds = d
+			}
+		}
+		Expect(ds).ToNot(BeNil())
+
+		container := ds.Spec.Template.Spec.Containers[0]
+		Expect(container.Args).To(ContainElement("--podresources-socket=/var/lib/fake-gpu-operator/pod-resources/kubelet.sock"))
+		Expect(container.Args).To(ContainElement("--sysfs-root=" + sysfsMountPath))
+
+		var podResMount string
+		for _, m := range container.VolumeMounts {
+			if m.Name == "podresources" {
+				podResMount = m.MountPath
+			}
+		}
+		Expect(podResMount).To(Equal("/var/lib/fake-gpu-operator/pod-resources"))
+
+		hostPaths := map[string]string{}
+		for _, v := range ds.Spec.Template.Spec.Volumes {
+			if v.HostPath != nil {
+				hostPaths[v.Name] = v.HostPath.Path
+			}
+		}
+		Expect(hostPaths["podresources"]).To(Equal("/var/lib/fake-gpu-operator/pod-resources"))
+		Expect(hostPaths["sysfs"]).To(Equal("/var/lib/fake-gpu-operator/sys"))
+	})
+
 	It("is idempotent across reconciles (no duplicate volumes/mounts)", func(ctx context.Context) {
 		cfg.Spec.NumaPlacementExporter.Service.Enabled = ptr.To(true)
 		c := fakeClient()

--- a/pkg/operator/operands/numa_placement_exporter/resources.go
+++ b/pkg/operator/operands/numa_placement_exporter/resources.go
@@ -51,17 +51,20 @@ func (e *NumaPlacementExporter) daemonSetForKAIConfig(
 		RunAsUser:    ptr.To(int64(0)),
 		RunAsNonRoot: ptr.To(false),
 	}
+	podResHostPath := effectivePodResourcesDir(config)
+	sysHostPath := effectiveSysfsHostPath(config)
+
 	container.VolumeMounts = []v1.VolumeMount{
-		{Name: "podresources", MountPath: podResourcesDir, ReadOnly: true},
+		{Name: "podresources", MountPath: podResHostPath, ReadOnly: true},
 		{Name: "sysfs", MountPath: sysfsMountPath, ReadOnly: true},
 	}
 
 	hostPathDir := v1.HostPathDirectory
 	ds.Spec.Template.Spec.Volumes = []v1.Volume{
 		{Name: "podresources", VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{Path: podResourcesDir, Type: &hostPathDir}}},
+			HostPath: &v1.HostPathVolumeSource{Path: podResHostPath, Type: &hostPathDir}}},
 		{Name: "sysfs", VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{Path: sysfsHostPath, Type: &hostPathDir}}},
+			HostPath: &v1.HostPathVolumeSource{Path: sysHostPath, Type: &hostPathDir}}},
 	}
 
 	return []client.Object{ds}, nil
@@ -71,7 +74,7 @@ func (e *NumaPlacementExporter) daemonSetForKAIConfig(
 // unset intervals fall through to the binary defaults.
 func buildArgsList(config *npeapi.NumaPlacementExporter) []string {
 	args := []string{
-		fmt.Sprintf("--podresources-socket=%s", consts.DefaultPodResourcesSocket),
+		fmt.Sprintf("--podresources-socket=%s", effectivePodResourcesSocket(config)),
 		fmt.Sprintf("--sysfs-root=%s", sysfsMountPath),
 	}
 	if config.PollInterval != nil {
@@ -96,4 +99,28 @@ func (e *NumaPlacementExporter) serviceAccountForKAIConfig(
 		APIVersion: "v1",
 	}
 	return []client.Object{sa}, nil
+}
+
+// effectivePodResourcesDir returns the configured podresources host directory, or the kubelet default.
+func effectivePodResourcesDir(config *npeapi.NumaPlacementExporter) string {
+	if config.PodResourcesHostPath != "" {
+		return config.PodResourcesHostPath
+	}
+	return podResourcesDir
+}
+
+// effectivePodResourcesSocket returns the configured podresources socket, or the kubelet default.
+func effectivePodResourcesSocket(config *npeapi.NumaPlacementExporter) string {
+	if config.PodResourcesSocket != "" {
+		return config.PodResourcesSocket
+	}
+	return consts.DefaultPodResourcesSocket
+}
+
+// effectiveSysfsHostPath returns the configured sysfs host path, or /sys.
+func effectiveSysfsHostPath(config *npeapi.NumaPlacementExporter) string {
+	if config.SysfsHostPath != "" {
+		return config.SysfsHostPath
+	}
+	return sysfsHostPath
 }


### PR DESCRIPTION
## What

Adds three optional fields to `NumaPlacementExporter` so the operator-managed `numa-placement-exporter` (`npe`) DaemonSet can be pointed at a non-kubelet podresources socket and a synthetic sysfs tree:

- `podResourcesHostPath` (default `/var/lib/kubelet/pod-resources`)
- `podResourcesSocket` (default `/var/lib/kubelet/pod-resources/kubelet.sock`)
- `sysfsHostPath` (default `/sys`)

When unset, the rendered DaemonSet is byte-identical to today — the operand falls back to the existing constants, so this is fully backward-compatible.

Fixes #1806.

## Why

The `npe` binary already accepts arbitrary `--podresources-socket` / `--sysfs-root`, but the operator hard-coded them (and the backing `hostPath` volumes) with no config surface. Simulated/test environments want `npe` to read a synthetic podresources socket + sysfs `cpulist` tree instead of the node's real ones, so NUMA-aware GPU scheduling can be validated without real multi-socket hardware or real device-NUMA.

Concretely, [`run-ai/fake-gpu-operator`](https://github.com/run-ai/fake-gpu-operator) serves a fake kubelet podresources gRPC socket + a rendered sysfs `cpulist` tree per node at its own paths; with these fields the operator-managed `npe` can consume that data and produce correct `kai.scheduler/numa-placement-observed` annotations. This was validated end-to-end on KIND (a real `npe` reading the fake socket/sysfs wrote the expected per-zone annotations, including cross-zone proportional cpu/memory splits) — previously it required a hand-rolled `npe` DaemonSet outside the operator.

## Changes

- `pkg/apis/kai/v1/numa_placement_exporter`: three optional string fields.
- `pkg/operator/operands/numa_placement_exporter/resources.go`: `effectivePodResourcesDir` / `effectivePodResourcesSocket` / `effectiveSysfsHostPath` helpers; the podresources volume mount + `hostPath` source, the sysfs `hostPath` source, and the `--podresources-socket` arg now use them.
- Regenerated CRD (`make manifests`); deepcopy unchanged (plain string fields).
- Operand test: added a case asserting the override paths flow into args + volumes; existing default-path test unchanged.

## Compatibility

Defaults preserve current behavior exactly. No API removals; all new fields optional.
