### PR TITLE
perf(scheduler): reduce min-runtime reclaim memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 
 ### Fixed
+- Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)
 - Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)
 - Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.
 - Scheduler cache now filters terminal Pods at watch time to reduce memory use, while still watching Pods bound by other schedulers so their resource usage is counted in allocatable calculations. [#1645](https://github.com/kai-scheduler/KAI-Scheduler/issues/1645) [enoodle](https://github.com/enoodle)

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -82,10 +82,18 @@ func BenchmarkReclaimManySingleGPUJobs_500Node(b *testing.B) {
 	benchmarkReclaimManySingleGPUJobs(b, 500)
 }
 
+func BenchmarkReclaimManySingleGPUJobsWithMinRuntime_500Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsWithParams(b, manySingleGPUJobsReclaimParamsWithMinRuntime(500))
+}
+
 func benchmarkReclaimManySingleGPUJobs(b *testing.B, numNodes int) {
+	benchmarkReclaimManySingleGPUJobsWithParams(b, defaultManySingleGPUJobsReclaimParams(numNodes))
+}
+
+func benchmarkReclaimManySingleGPUJobsWithParams(b *testing.B, params manySingleGPUJobsReclaimParams) {
 	defer gock.Off()
 
-	topology := buildManySingleGPUJobsReclaimTopology(defaultManySingleGPUJobsReclaimParams(numNodes))
+	topology := buildManySingleGPUJobsReclaimTopology(params)
 	b.ReportAllocs()
 
 	for b.Loop() {

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -62,6 +62,40 @@ func BenchmarkReclaimLargeJobs_1000Node(b *testing.B) {
 	benchmarkReclaimLargeJobs(b, 1000)
 }
 
+func BenchmarkReclaimManySingleGPUJobs_10Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobs(b, 10)
+}
+
+func BenchmarkReclaimManySingleGPUJobs_50Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobs(b, 50)
+}
+
+func BenchmarkReclaimManySingleGPUJobs_100Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobs(b, 100)
+}
+
+func BenchmarkReclaimManySingleGPUJobs_200Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobs(b, 200)
+}
+
+func BenchmarkReclaimManySingleGPUJobs_500Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobs(b, 500)
+}
+
+func benchmarkReclaimManySingleGPUJobs(b *testing.B, numNodes int) {
+	defer gock.Off()
+
+	topology := buildManySingleGPUJobsReclaimTopology(defaultManySingleGPUJobsReclaimParams(numNodes))
+	b.ReportAllocs()
+
+	for b.Loop() {
+		ctrl := gomock.NewController(b)
+		ssn := test_utils.BuildSession(topology, ctrl)
+		reclaim.New().Execute(ssn)
+		ctrl.Finish()
+	}
+}
+
 func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {
 	defer gock.Off()
 

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_many_single_gpu_topology_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_many_single_gpu_topology_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+type manySingleGPUJobsReclaimParams struct {
+	NumNodes        int
+	GPUsPerNode     int
+	RunningJobCount int
+	PendingJobCount int
+}
+
+const (
+	manySingleGPURunningQueueName = "many-single-gpu-running-queue"
+	manySingleGPUPendingQueueName = "many-single-gpu-pending-queue"
+	manySingleGPURunningJobPrefix = "many-single-gpu-running-job-"
+	manySingleGPUPendingJobPrefix = "many-single-gpu-pending-job-"
+)
+
+func TestManySingleGPUJobsReclaimTopology(t *testing.T) {
+	defer gock.Off()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	params := defaultManySingleGPUJobsReclaimParams(10)
+	ssn := test_utils.BuildSession(buildManySingleGPUJobsReclaimTopology(params), ctrl)
+
+	onJobSolutionStartCalls := 0
+	ssn.AddOnJobSolutionStartFn(func() {
+		onJobSolutionStartCalls++
+	})
+
+	reclaim.New().Execute(ssn)
+
+	expectedTasks := params.NumNodes * params.GPUsPerNode
+	if onJobSolutionStartCalls == 0 {
+		t.Fatal("expected reclaim to attempt solving pending jobs")
+	}
+
+	runningJobs := 0
+	pendingJobs := 0
+	for _, job := range ssn.ClusterInfo.PodGroupInfos {
+		switch {
+		case strings.HasPrefix(job.Name, manySingleGPURunningJobPrefix):
+			runningJobs++
+			if len(job.PodStatusIndex[pod_status.Releasing]) != 1 {
+				t.Fatalf("expected running job %q to have one releasing task", job.Name)
+			}
+		case strings.HasPrefix(job.Name, manySingleGPUPendingJobPrefix):
+			pendingJobs++
+			if len(job.PodStatusIndex[pod_status.Pipelined]) != 1 {
+				t.Fatalf("expected pending job %q to have one pipelined task", job.Name)
+			}
+		}
+	}
+
+	if runningJobs != expectedTasks {
+		t.Fatalf("expected %d reclaimed running jobs, got %d", expectedTasks, runningJobs)
+	}
+	if pendingJobs != expectedTasks {
+		t.Fatalf("expected %d pipelined pending jobs, got %d", expectedTasks, pendingJobs)
+	}
+}
+
+func defaultManySingleGPUJobsReclaimParams(numNodes int) manySingleGPUJobsReclaimParams {
+	const gpusPerNode = 8
+	jobCount := numNodes * gpusPerNode
+	return manySingleGPUJobsReclaimParams{
+		NumNodes:        numNodes,
+		GPUsPerNode:     gpusPerNode,
+		RunningJobCount: jobCount,
+		PendingJobCount: jobCount,
+	}
+}
+
+func buildManySingleGPUJobsReclaimTopology(
+	params manySingleGPUJobsReclaimParams,
+) test_utils.TestTopologyBasic {
+	nodes := make(map[string]nodes_fake.TestNodeBasic, params.NumNodes)
+	for i := 0; i < params.NumNodes; i++ {
+		nodes[fmt.Sprintf("node%d", i)] = nodes_fake.TestNodeBasic{GPUs: params.GPUsPerNode}
+	}
+
+	jobs := make([]*jobs_fake.TestJobBasic, 0, params.RunningJobCount+params.PendingJobCount)
+	for i := 0; i < params.RunningJobCount; i++ {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("%s%d", manySingleGPURunningJobPrefix, i),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           manySingleGPURunningQueueName,
+			Tasks: []*tasks_fake.TestTaskBasic{{
+				NodeName: fmt.Sprintf("node%d", i%params.NumNodes),
+				State:    pod_status.Running,
+			}},
+		})
+	}
+	for i := 0; i < params.PendingJobCount; i++ {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("%s%d", manySingleGPUPendingJobPrefix, i),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           manySingleGPUPendingQueueName,
+			Tasks:               []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+		})
+	}
+
+	return test_utils.TestTopologyBasic{
+		Name:  "many single GPU jobs reclaim benchmark",
+		Nodes: nodes,
+		Jobs:  jobs,
+		Queues: []test_utils.TestQueueBasic{
+			{Name: manySingleGPURunningQueueName, DeservedGPUs: 0, GPUOverQuotaWeight: 0},
+			{Name: manySingleGPUPendingQueueName, DeservedGPUs: float64(params.PendingJobCount), GPUOverQuotaWeight: 0},
+		},
+		Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{
+			NumberOfCacheEvictions:  params.RunningJobCount,
+			NumberOfPipelineActions: params.PendingJobCount,
+		}},
+	}
+}

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_many_single_gpu_topology_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_many_single_gpu_topology_test.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 	"gopkg.in/h2non/gock.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
@@ -21,10 +24,11 @@ import (
 )
 
 type manySingleGPUJobsReclaimParams struct {
-	NumNodes        int
-	GPUsPerNode     int
-	RunningJobCount int
-	PendingJobCount int
+	NumNodes          int
+	GPUsPerNode       int
+	RunningJobCount   int
+	PendingJobCount   int
+	ReclaimMinRuntime *metav1.Duration
 }
 
 const (
@@ -40,8 +44,11 @@ func TestManySingleGPUJobsReclaimTopology(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	params := defaultManySingleGPUJobsReclaimParams(10)
+	params := manySingleGPUJobsReclaimParamsWithMinRuntime(10)
 	ssn := test_utils.BuildSession(buildManySingleGPUJobsReclaimTopology(params), ctrl)
+	if actual := ssn.ClusterInfo.Queues[common_info.QueueID(manySingleGPURunningQueueName)].ReclaimMinRuntime; actual == nil || *actual != *params.ReclaimMinRuntime {
+		t.Fatalf("expected running queue reclaim min-runtime %v, got %v", params.ReclaimMinRuntime, actual)
+	}
 
 	onJobSolutionStartCalls := 0
 	ssn.AddOnJobSolutionStartFn(func() {
@@ -91,6 +98,12 @@ func defaultManySingleGPUJobsReclaimParams(numNodes int) manySingleGPUJobsReclai
 	}
 }
 
+func manySingleGPUJobsReclaimParamsWithMinRuntime(numNodes int) manySingleGPUJobsReclaimParams {
+	params := defaultManySingleGPUJobsReclaimParams(numNodes)
+	params.ReclaimMinRuntime = &metav1.Duration{Duration: 30 * time.Second}
+	return params
+}
+
 func buildManySingleGPUJobsReclaimTopology(
 	params manySingleGPUJobsReclaimParams,
 ) test_utils.TestTopologyBasic {
@@ -127,7 +140,7 @@ func buildManySingleGPUJobsReclaimTopology(
 		Nodes: nodes,
 		Jobs:  jobs,
 		Queues: []test_utils.TestQueueBasic{
-			{Name: manySingleGPURunningQueueName, DeservedGPUs: 0, GPUOverQuotaWeight: 0},
+			{Name: manySingleGPURunningQueueName, DeservedGPUs: 0, GPUOverQuotaWeight: 0, ReclaimMinRuntime: params.ReclaimMinRuntime},
 			{Name: manySingleGPUPendingQueueName, DeservedGPUs: float64(params.PendingJobCount), GPUOverQuotaWeight: 0},
 		},
 		Mocks: &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{

--- a/pkg/scheduler/plugins/minruntime/minruntime.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime.go
@@ -30,8 +30,6 @@ type minruntimePlugin struct {
 	reclaimResolveMethod     string
 	queues                   map[common_info.QueueID]*queue_info.QueueInfo
 
-	preemptProtectionCache map[common_info.PodGroupID]bool
-
 	resolver *resolver
 }
 
@@ -63,9 +61,6 @@ func New(arguments framework.PluginArguments) framework.Plugin {
 		log.InfraLogger.Errorf("Invalid reclaim resolve method %v, using default value %v", plugin.reclaimResolveMethod, resolveMethodLCA)
 		plugin.reclaimResolveMethod = resolveMethodLCA
 	}
-	// setup caches on plugin init, but they will be reset on session open anyway
-	plugin.preemptProtectionCache = make(map[common_info.PodGroupID]bool)
-
 	return plugin
 }
 
@@ -79,13 +74,11 @@ func (mr *minruntimePlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddReclaimScenarioValidatorFn(mr.reclaimScenarioValidatorFn)
 	ssn.AddPreemptScenarioValidatorFn(mr.preemptScenarioValidatorFn)
 	mr.queues = ssn.ClusterInfo.Queues
-	mr.preemptProtectionCache = make(map[common_info.PodGroupID]bool)
 	mr.resolver = NewResolver(mr.queues, mr.defaultPreemptMinRuntime, mr.defaultReclaimMinRuntime)
 }
 
 func (mr *minruntimePlugin) OnSessionClose(ssn *framework.Session) {
 	mr.queues = nil
-	mr.preemptProtectionCache = nil
 	mr.resolver = nil
 }
 
@@ -161,9 +154,6 @@ func (mr *minruntimePlugin) isReclaimMinRuntimeProtected(pendingJob *podgroup_in
 }
 
 func (mr *minruntimePlugin) isPreemptMinRuntimeProtected(_ *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
-	if cached, ok := mr.preemptProtectionCache[victim.UID]; ok {
-		return cached
-	}
 	victimQueue := mr.queues[victim.Queue]
 
 	minRuntime, err := mr.resolver.getPreemptMinRuntime(victimQueue)
@@ -176,16 +166,10 @@ func (mr *minruntimePlugin) isPreemptMinRuntimeProtected(_ *podgroup_info.PodGro
 	// the victim is protected from preemption
 	if victim.LastStartTimestamp != nil && !victim.LastStartTimestamp.IsZero() {
 		protectedUntil := victim.LastStartTimestamp.Add(minRuntime.Duration)
-		protected := time.Now().Before(protectedUntil)
-		mr.cachePreemptProtection(victim, protected)
-		return protected
+		return time.Now().Before(protectedUntil)
 	}
 
 	return false
-}
-
-func (mr *minruntimePlugin) cachePreemptProtection(victim *podgroup_info.PodGroupInfo, protected bool) {
-	mr.preemptProtectionCache[victim.UID] = protected
 }
 
 func validVictimForMinAvailable(victimInfo *api.VictimInfo) bool {

--- a/pkg/scheduler/plugins/minruntime/minruntime.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime.go
@@ -31,7 +31,6 @@ type minruntimePlugin struct {
 	queues                   map[common_info.QueueID]*queue_info.QueueInfo
 
 	preemptProtectionCache map[common_info.PodGroupID]bool
-	reclaimProtectionCache map[common_info.PodGroupID]map[common_info.PodGroupID]bool
 
 	resolver *resolver
 }
@@ -66,7 +65,6 @@ func New(arguments framework.PluginArguments) framework.Plugin {
 	}
 	// setup caches on plugin init, but they will be reset on session open anyway
 	plugin.preemptProtectionCache = make(map[common_info.PodGroupID]bool)
-	plugin.reclaimProtectionCache = make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool)
 
 	return plugin
 }
@@ -82,14 +80,12 @@ func (mr *minruntimePlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddPreemptScenarioValidatorFn(mr.preemptScenarioValidatorFn)
 	mr.queues = ssn.ClusterInfo.Queues
 	mr.preemptProtectionCache = make(map[common_info.PodGroupID]bool)
-	mr.reclaimProtectionCache = make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool)
 	mr.resolver = NewResolver(mr.queues, mr.defaultPreemptMinRuntime, mr.defaultReclaimMinRuntime)
 }
 
 func (mr *minruntimePlugin) OnSessionClose(ssn *framework.Session) {
 	mr.queues = nil
 	mr.preemptProtectionCache = nil
-	mr.reclaimProtectionCache = nil
 	mr.resolver = nil
 }
 
@@ -146,9 +142,6 @@ func (mr *minruntimePlugin) preemptScenarioValidatorFn(scenario api.ScenarioInfo
 }
 
 func (mr *minruntimePlugin) isReclaimMinRuntimeProtected(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
-	if cached, ok := mr.reclaimProtectionCache[pendingJob.UID][victim.UID]; ok {
-		return cached
-	}
 	pendingQueue := mr.queues[pendingJob.Queue]
 	victimQueue := mr.queues[victim.Queue]
 
@@ -162,9 +155,7 @@ func (mr *minruntimePlugin) isReclaimMinRuntimeProtected(pendingJob *podgroup_in
 	// the victim is protected from reclaim
 	if victim.LastStartTimestamp != nil && !victim.LastStartTimestamp.IsZero() {
 		protectedUntil := victim.LastStartTimestamp.Add(minRuntime.Duration)
-		protected := time.Now().Before(protectedUntil)
-		mr.cacheReclaimProtection(pendingJob, victim, protected)
-		return protected
+		return time.Now().Before(protectedUntil)
 	}
 	return false
 }
@@ -195,13 +186,6 @@ func (mr *minruntimePlugin) isPreemptMinRuntimeProtected(_ *podgroup_info.PodGro
 
 func (mr *minruntimePlugin) cachePreemptProtection(victim *podgroup_info.PodGroupInfo, protected bool) {
 	mr.preemptProtectionCache[victim.UID] = protected
-}
-
-func (mr *minruntimePlugin) cacheReclaimProtection(pendingJob *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo, protected bool) {
-	if mr.reclaimProtectionCache[pendingJob.UID] == nil {
-		mr.reclaimProtectionCache[pendingJob.UID] = make(map[common_info.PodGroupID]bool)
-	}
-	mr.reclaimProtectionCache[pendingJob.UID][victim.UID] = protected
 }
 
 func validVictimForMinAvailable(victimInfo *api.VictimInfo) bool {

--- a/pkg/scheduler/plugins/minruntime/minruntime_test.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime_test.go
@@ -89,7 +89,6 @@ var _ = Describe("MinRuntime Plugin", func() {
 			defaultPreemptMinRuntime: defaultPreemptDuration,
 			defaultReclaimMinRuntime: defaultReclaimDuration,
 			reclaimResolveMethod:     resolveMethodLCA,
-			preemptProtectionCache:   make(map[common_info.PodGroupID]bool),
 			resolver:                 NewResolver(queues, defaultPreemptDuration, defaultReclaimDuration),
 		}
 	})
@@ -136,6 +135,19 @@ var _ = Describe("MinRuntime Plugin", func() {
 
 				result := plugin.preemptFilterFn(pendingJob, victim)
 				Expect(result).To(BeTrue(), "Job with no start time should not be protected")
+			})
+
+			It("re-evaluates protection for a previously checked victim", func() {
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+				recentStart := time.Now().Add(-10 * time.Second)
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 1)
+
+				Expect(plugin.preemptFilterFn(pendingJob, victim)).To(BeFalse())
+
+				oldStart := time.Now().Add(-30 * time.Second)
+				victim.LastStartTimestamp = &oldStart
+
+				Expect(plugin.preemptFilterFn(pendingJob, victim)).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/scheduler/plugins/minruntime/minruntime_test.go
+++ b/pkg/scheduler/plugins/minruntime/minruntime_test.go
@@ -90,7 +90,6 @@ var _ = Describe("MinRuntime Plugin", func() {
 			defaultReclaimMinRuntime: defaultReclaimDuration,
 			reclaimResolveMethod:     resolveMethodLCA,
 			preemptProtectionCache:   make(map[common_info.PodGroupID]bool),
-			reclaimProtectionCache:   make(map[common_info.PodGroupID]map[common_info.PodGroupID]bool),
 			resolver:                 NewResolver(queues, defaultPreemptDuration, defaultReclaimDuration),
 		}
 	})
@@ -172,6 +171,19 @@ var _ = Describe("MinRuntime Plugin", func() {
 				// The reclaim min runtime for prod-team2 is 35s, so 40s is past protection period
 				result := plugin.reclaimFilterFn(pendingJob, victim)
 				Expect(result).To(BeTrue(), "Job 'old-victim' should not be protected from reclaim")
+			})
+
+			It("re-evaluates protection for a previously checked job pair", func() {
+				pendingJob := createPodGroup("pending-job", "dev-team1", nil, 1, 1)
+				recentStart := time.Now().Add(-20 * time.Second)
+				victim := createPodGroup("victim-job", "prod-team2", &recentStart, 1, 1)
+
+				Expect(plugin.reclaimFilterFn(pendingJob, victim)).To(BeFalse())
+
+				oldStart := time.Now().Add(-40 * time.Second)
+				victim.LastStartTimestamp = &oldStart
+
+				Expect(plugin.reclaimFilterFn(pendingJob, victim)).To(BeTrue())
 			})
 		})
 

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -14,6 +14,7 @@ import (
 	// lint:ignore ST1001 we want to use gomock here
 	. "go.uber.org/mock/gomock"
 	"golang.org/x/exp/slices"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -86,6 +87,7 @@ type TestQueueBasic struct {
 	GPUOverQuotaWeight          float64
 	ParentQueue                 string
 	InteractiveTimeoutInMinutes int64
+	ReclaimMinRuntime           *metav1.Duration
 	UseOnlyFreeCPUResources     bool
 	V1                          bool
 }

--- a/pkg/scheduler/test_utils/test_utils_builder.go
+++ b/pkg/scheduler/test_utils/test_utils_builder.go
@@ -115,9 +115,10 @@ func BuildQueueInfoMap(testMetadata TestTopologyBasic) map[common_info.QueueID]*
 				CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute * time.Duration(queueIndex))},
 			},
 			Spec: enginev2.QueueSpec{
-				DisplayName: queue.Name,
-				ParentQueue: queue.ParentQueue,
-				Priority:    queue.Priority,
+				DisplayName:       queue.Name,
+				ParentQueue:       queue.ParentQueue,
+				Priority:          queue.Priority,
+				ReclaimMinRuntime: queue.ReclaimMinRuntime,
 				Resources: &enginev2.QueueResources{
 					GPU: enginev2.QueueResource{
 						Quota:           queue.DeservedGPUs,


### PR DESCRIPTION
## Description

- Adds a scalable reclaim benchmark matching the `reclaims many single GPU Jobs` scale-test shape: eight running and eight pending one-GPU jobs per node, with 10, 50, 100, 200, and 500-node entry points. A dedicated 500-node variant configures a 30-second reclaim min-runtime while keeping one-minute-old victims reclaimable.
- Removes the quadratic pending-job/victim-job min-runtime protection cache while retaining the existing queue-pair duration cache.
- Re-evaluates reclaim protection from the victim's last-start timestamp and adds a regression test for repeated checks of the same job pair.

The 500-node benchmark contains 4,000 running jobs and 4,000 pending jobs. The previous cache could retain approximately 16 million boolean entries during one scheduler session.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Reachable live heap after reclaim, with the session retained | 940.09 MB | 94.88 MB | -845.21 MB / -89.9% |
| Total benchmark allocations | 76.16 GB | 74.45 GB | -1.71 GB / -2.25% |
| Benchmark runtime | 172.48 s | 165.61 s | -4.0% |

After the change, neither the allocation profile nor the live-heap profile contains any `minruntime` samples.

### Nonzero min-runtime benchmark

`BenchmarkReclaimManySingleGPUJobsWithMinRuntime_500Node` configures a 30-second reclaim min-runtime on the victim queue. Running jobs are one minute old, so the duration has expired and the benchmark still verifies the complete replacement of all 4,000 running jobs by 4,000 pending jobs.

| Version | Runtime | Allocated | Allocations |
|---|---:|---:|---:|
| Job-pair protection cache | 154.56 s | 76.15 GB | 792,516,512 |
| Protection cache removed | 157.79 s | 74.44 GB | 792,336,359 |
| Difference | +2.1% | -1.71 GB / -2.25% | -180,153 |

The allocation reduction remains stable with a nonzero min-runtime. The 2.1% single-run timing difference is smaller than the observed variance across 500-node runs, so repeated samples are required for a statistically meaningful runtime comparison.

## Related Issues

Fixes #1808

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes
