### PR TITLE
fix(admission): remove unnecessary NaN check - v0.14

### DIFF
--- a/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator.go
+++ b/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator.go
@@ -5,7 +5,6 @@ package gpurequesthandler
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -81,9 +80,6 @@ func validateGpuFractionAnnotation(hasGpuFractionAnnotation bool, gpuFractionFro
 	if gpuFractionErr != nil || gpuFraction <= 0 || gpuFraction >= 1 {
 		return fmt.Errorf(
 			"gpu-fraction annotation value must be a positive number smaller than 1.0")
-	}
-	if math.IsNaN(gpuFraction) {
-		return fmt.Errorf("gpu-fraction annotation value must be a valid number. NaN is not allowed")
 	}
 	_, err := resource.ParseQuantity(gpuFractionFromAnnotation)
 	if err != nil {

--- a/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator_test.go
+++ b/pkg/binder/plugins/gpusharing/gpu-request/gpu_request_validator_test.go
@@ -422,7 +422,7 @@ func TestValidateGpuRequests(t *testing.T) {
 					},
 				},
 			},
-			error: fmt.Errorf("gpu-fraction annotation value must be a valid number. NaN is not allowed"),
+			error: fmt.Errorf("gpu-fraction annotation value must be a float written with a decimal point or a scientific notation .given value: NaN"),
 		},
 		{
 			name: "Allow Scientific notation fraction value",


### PR DESCRIPTION
## Description

Remove the explicit `math.IsNaN` check for gpu-fraction annotation values. This check is redundant because `resource.ParseQuantity` already rejects NaN values with a descriptive error message.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

The `ParseQuantity` function from `k8s.io/apimachinery` already handles NaN inputs and returns an appropriate error, making the manual `math.IsNaN` check unnecessary. The test expectation is updated to match the error message from `ParseQuantity`.