### PR TITLE
fix(scheduler): exit on 401 Unauthorized API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 
 ### Fixed
+- Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)
 - Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)
 - Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)
 - Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -64,6 +64,23 @@ const (
 
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
+type unauthorizedRoundTripper struct {
+	rt http.RoundTripper
+}
+
+func (t *unauthorizedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.rt.RoundTrip(req)
+	if err == nil && resp.StatusCode == http.StatusUnauthorized {
+		log.InfraLogger.Errorf("API server returned 401 Unauthorized, exiting to trigger pod restart")
+		os.Exit(1)
+	}
+	return resp, err
+}
+
+func wrapExitOnUnauthorized(rt http.RoundTripper) http.RoundTripper {
+	return &unauthorizedRoundTripper{rt: rt}
+}
+
 func flushLogs() {
 	if err := log.InfraLogger.Sync(); err != nil &&
 		!errors.Is(err, syscall.ENOTTY) && // https://github.com/uber-go/zap/issues/991#issuecomment-962098428
@@ -121,6 +138,7 @@ func RunApp() error {
 	config := clientconfig.GetConfigOrDie()
 	config.QPS = float32(so.QPS)
 	config.Burst = so.Burst
+	config.Wrap(wrapExitOnUnauthorized)
 
 	return Run(so, config, mux)
 }

--- a/cmd/scheduler/app/server_test.go
+++ b/cmd/scheduler/app/server_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnauthorizedRoundTripper_PassesNonUnauthorizedResponses(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"200 OK", http.StatusOK},
+		{"403 Forbidden", http.StatusForbidden},
+		{"404 Not Found", http.StatusNotFound},
+		{"500 Internal Server Error", http.StatusInternalServerError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			transport := wrapExitOnUnauthorized(http.DefaultTransport)
+			req, _ := http.NewRequest("GET", server.URL, nil)
+			resp, err := transport.RoundTrip(req)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.statusCode, resp.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
## Description

When the scheduler's projected ServiceAccount token becomes invalid (e.g. after a Config CR deletion triggers pod recreation), all API requests fail with 401 Unauthorized. The default client-go behavior retries indefinitely, so the scheduler stays Running while doing no useful work.

This PR wraps the scheduler's `rest.Config` transport to exit the process on any 401 response. Since a 401 on a projected ServiceAccount token is unrecoverable without a pod restart, exiting lets the kubelet restart the pod with a fresh token.

The transport wrapper covers all API calls (watches, lists, gets, creates) uniformly through a single `config.Wrap` call.

## Related Issues

Fixes #1817

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. No behavioral change in the happy path.

## Additional Notes

Reworked from per-informer WatchErrorHandler to transport-level interception per @gshaibi's suggestion.