### PR TITLE
feat(podgrouper): For the pytorch and lws plugins, validate workerindex > 0 and cap block-level segmentation size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
 - In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
 
 ## [v0.14.6] - 2026-06-22
 

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper.go
@@ -25,6 +25,8 @@ const (
 
 	replicaTypeMaster = string(pytorchv1.PyTorchJobReplicaTypeMaster)
 	replicaTypeWorker = string(pytorchv1.PyTorchJobReplicaTypeWorker)
+
+	maxAllowedSegmentation = 10000
 )
 
 type PyTorchGrouper struct {
@@ -162,6 +164,12 @@ func buildWorkerSubGroups(
 	if partialSegmentSize != 0 {
 		numSegments++
 	}
+	// Validate num of subgroups created for the segmentation
+	if numSegments > maxAllowedSegmentation {
+		return nil, fmt.Errorf("number of subgroups created for the segmentation %d is greater than max allowed segmentation %d",
+			numSegments, maxAllowedSegmentation)
+	}
+
 	segmentIndex, err := getPodSegmentIndex(pod, segmentSize)
 	if err != nil {
 		return nil, err
@@ -206,6 +214,9 @@ func getPodSegmentIndex(pod *v1.Pod, segmentSize int) (int, error) {
 	index, err := strconv.Atoi(indexLabel)
 	if err != nil {
 		return -1, fmt.Errorf("invalid replica index %s, err: %w", indexLabel, err)
+	}
+	if index < 0 {
+		return -1, fmt.Errorf("replica index %s is not valid. It must be bigger than 0", indexLabel)
 	}
 	return index / segmentSize, nil
 }

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper_test.go
@@ -575,6 +575,52 @@ func TestGetPodGroupMetadata_Segments_SegmentSizeFromPodTemplate(t *testing.T) {
 	assert.Equal(t, "test-job-worker-1", workerSegment0.PodsReferences[0])
 }
 
+func TestGetPodGroupMetadata_Segments_NegativeReplicaIndex(t *testing.T) {
+	pytorchJob := getPytorchJobWithSegments(1, 4, "2")
+	grouper := newTestPyTorchGrouper()
+
+	workerPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job-worker-negative",
+			Namespace: "test_namespace",
+			Labels: map[string]string{
+				replicaTypeLabel:                      "worker",
+				"training.kubeflow.org/replica-index": "-1",
+			},
+			Annotations: map[string]string{
+				"kai.scheduler/segment-size": "2",
+			},
+		},
+	}
+
+	_, err := grouper.GetPodGroupMetadata(pytorchJob, workerPod)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "is not valid. It must be bigger than 0")
+}
+
+func TestGetPodGroupMetadata_Segments_ExceedsMaxAllowedSegmentation(t *testing.T) {
+	pytorchJob := getPytorchJobWithSegments(1, int64(maxAllowedSegmentation+1), "1")
+	grouper := newTestPyTorchGrouper()
+
+	workerPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job-worker-0",
+			Namespace: "test_namespace",
+			Labels: map[string]string{
+				replicaTypeLabel:                      "worker",
+				"training.kubeflow.org/replica-index": "0",
+			},
+			Annotations: map[string]string{
+				"kai.scheduler/segment-size": "1",
+			},
+		},
+	}
+
+	_, err := grouper.GetPodGroupMetadata(pytorchJob, workerPod)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "greater than max allowed segmentation")
+}
+
 func getPytorchJobWithSegments(masterReplicas, workerReplicas int64, segmentSize string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper.go
@@ -29,6 +29,9 @@ const (
 	leaderSubGroupSize = 1
 	leaderIndex        = "0"
 
+	minWorkerIndex         = 0
+	maxAllowedSegmentation = 10000
+
 	// LWS annotation and label keys
 	lwsSizeAnnotation   = "leaderworkerset.sigs.k8s.io/size"
 	lwsGroupIndexLabel  = "leaderworkerset.sigs.k8s.io/group-index"
@@ -67,6 +70,10 @@ func (lwsg *LwsGrouper) GetPodGroupMetadata(
 
 	startupPolicy, err := getStartupPolicy(lwsJob)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := validateWorkerIndex(pod); err != nil {
 		return nil, err
 	}
 
@@ -122,6 +129,19 @@ func getStartupPolicy(lwsJob *unstructured.Unstructured) (string, error) {
 	return policy, nil
 }
 
+func validateWorkerIndex(pod *v1.Pod) error {
+	if workerIndex, hasWorkerIndex := pod.Labels[lwsWorkerIndexLabel]; hasWorkerIndex {
+		podWorkerIndex, err := strconv.Atoi(workerIndex)
+		if err != nil {
+			return fmt.Errorf("failed to get worker index from pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+		if podWorkerIndex < minWorkerIndex {
+			return fmt.Errorf("workerIndex %s is not valid. It must be bigger than 0", workerIndex)
+		}
+	}
+	return nil
+}
+
 func calcLeaderReadyMinAvailable(pod *v1.Pod, fallbackSize int32) int32 {
 	groupSize := fallbackSize
 
@@ -152,6 +172,12 @@ func (lwsg *LwsGrouper) buildSubGroups(lwsJob *unstructured.Unstructured, pod *v
 	if segmentationPolicy == nil {
 		return buildSubGroupsWithoutSegmentation(replicasSize, pod), nil
 	}
+
+	// Validate num of subgroups created for the segmentation
+	if numOfSegmentSubgroups := getNumOfSegmentSubgroups(replicasSize, int(*segmentationPolicy.SubGroupSize)); numOfSegmentSubgroups > maxAllowedSegmentation {
+		return nil, fmt.Errorf("number of subgroups segments %d is greater than max allowed segmentation %d", numOfSegmentSubgroups, maxAllowedSegmentation)
+	}
+
 	topologyConstraints, err := getSegmentTopologyConstraints(pod, lwsJob)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get segment topology constraints for LWS %s/%s: %w", lwsJob.GetNamespace(), lwsJob.GetName(), err)
@@ -340,8 +366,7 @@ func buildSubGroupsWithSegmentation(
 
 func createSegmentSubgroups(topologyConstraints *podgroup.TopologyConstraintMetadata, replicasSize int, segmentSize int) []*podgroup.SubGroupMetadata {
 	subGroups := []*podgroup.SubGroupMetadata{}
-	maxWorkerIndex := replicasSize - leaderSubGroupSize
-	numOfSegmentSubgroups := getSegmentIndex(maxWorkerIndex, replicasSize, segmentSize) + 1
+	numOfSegmentSubgroups := getNumOfSegmentSubgroups(replicasSize, segmentSize)
 	for segmentIndex := 0; segmentIndex < numOfSegmentSubgroups; segmentIndex++ {
 		subGroups = append(subGroups, &podgroup.SubGroupMetadata{
 			Name:                fmt.Sprintf("segment-%d", segmentIndex),
@@ -353,6 +378,12 @@ func createSegmentSubgroups(topologyConstraints *podgroup.TopologyConstraintMeta
 
 	fixLastSegmentSize(replicasSize, segmentSize, subGroups)
 	return subGroups
+}
+
+func getNumOfSegmentSubgroups(replicasSize int, segmentSize int) int {
+	maxWorkerIndex := replicasSize - leaderSubGroupSize
+	numOfSegmentSubgroups := getSegmentIndex(maxWorkerIndex, replicasSize, segmentSize) + 1
+	return numOfSegmentSubgroups
 }
 
 // The last segment might contain less pods then the other segments.

--- a/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper_test.go
@@ -259,6 +259,28 @@ func TestGetPodGroupMetadata_SubGroups_OnlyLeader(t *testing.T) {
 	assert.Equal(t, "lws-single-0-0", leaderSubGroup.PodsReferences[0])
 }
 
+func TestGetPodGroupMetadata_NegativeWorkerIndex(t *testing.T) {
+	owner := lwsOwner("lws-invalid", "LeaderCreated", 3, nil, nil, nil)
+	pod := makeLwsPod("lws-invalid-0-1", "-1")
+
+	lwsGrouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", "", fake.NewFakeClient()))
+	_, err := lwsGrouper.GetPodGroupMetadata(owner, pod)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is not valid. It must be bigger than 0")
+}
+
+func TestBuildSubGroups_Segmentation_ExceedsMaxAllowedSegmentation(t *testing.T) {
+	replicasSize := int64(maxAllowedSegmentation)*2 + 3
+	lwsJob := lwsOwner("lws-seg-cap", "LeaderCreated", replicasSize, ptr.To(int64(2)), nil, nil)
+	pod := makeLwsPod("lws-seg-cap-0-0", "0")
+	grouper := NewLwsGrouper(defaultgrouper.NewDefaultGrouper("", "", fake.NewFakeClient()))
+
+	_, err := grouper.buildSubGroups(lwsJob, pod, int(replicasSize))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "greater than max allowed segmentation")
+}
+
 func findSubGroupByName(subGroups []*podgroup.SubGroupMetadata, name string) *podgroup.SubGroupMetadata {
 	for _, sg := range subGroups {
 		if sg.Name == name {


### PR DESCRIPTION
# Description
Backport of #1816 to `v0.14`.