### PR TITLE
fix(scheduler): roll back feasible-node additions after rejected and errored simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 
 ### Fixed
+- Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
 - Reduced transient scheduler allocations during large reclaim operations by comparing proportion queue state and cached resource vectors directly instead of repeatedly materializing resource maps.
 - Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)
 - Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -85,6 +85,12 @@ func (s *byPodSolver) solve(session *framework.Session, scenario *scenario.ByNod
 
 	result := s.runSimulation(session, scenario, statement, allVictims, maps.Values(s.feasibleNodes))
 	if result != nil {
+		// Roll back on validator-rejected and error results too: the map is
+		// shared across the probe's scenarios and must stay derived from the
+		// solver's node set plus the recorded victims.
+		if !result.solved {
+			s.feasibleNodesRollback(newFeasibleNodes)
+		}
 		return result
 	}
 

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver_test.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package solvers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestSolveRollsBackFeasibleNodeAdditionsOnValidatorRejection(t *testing.T) {
+	ssn, sn := newByPodSolverRollbackTestScenario(t)
+	feasibleNodes := map[string]*node_info.NodeInfo{}
+	rejectAll := func(api.ScenarioInfo) bool { return false }
+	solver := newByPodSolver(feasibleNodes, rejectAll, false, framework.Reclaim)
+
+	result := solver.solve(ssn, sn)
+
+	require.False(t, result.solved)
+	require.Empty(t, feasibleNodes, "rejected scenario must not leak its victim nodes into the shared map")
+}
+
+// Positive control: the same scenario solves without a validator, proving the
+// rejection test exercises the post-allocation validator path rather than an
+// allocation failure.
+func TestSolveSolvesSameScenarioWithoutValidator(t *testing.T) {
+	ssn, sn := newByPodSolverRollbackTestScenario(t)
+	solver := newByPodSolver(map[string]*node_info.NodeInfo{}, nil, false, framework.Reclaim)
+
+	result := solver.solve(ssn, sn)
+
+	require.True(t, result.solved)
+	require.NotNil(t, result.statement)
+	result.statement.Discard()
+}
+
+func newByPodSolverRollbackTestScenario(t *testing.T) (*framework.Session, *scenario.ByNodeScenario) {
+	t.Helper()
+
+	ssn := newGeneratorTestSession(t, map[string]int{"node-1": 1})
+	require.NoError(t, ssn.InitNodeScoringPool())
+	_, victimTasks := addGeneratorTestJob(t, ssn, 1, 20, "team-victim", "node-1")
+	pendingJob := addGeneratorTestPendingJob(t, ssn, 1, 10, "team-pending")
+	pendingTasks := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	return ssn, scenario.NewByNodeScenario(ssn, pendingJob, pendingTasks, victimTasks, nil)
+}


### PR DESCRIPTION
## Description

`byPodSolver.solve` temporarily adds the current scenario's victim nodes to the probe-wide feasible-node map before simulating ("if these victims are evicted, their nodes have room") and removes them after the simulation. The removal only ran on the cleanly-unsolved path: **validator-rejected** and **errored** simulations returned early through `runSimulation`'s non-nil result, permanently leaking the rejected scenario's victim nodes into the map that every subsequent scenario in the same probe simulates against.

The leak cannot produce invalid placements (allocation still enforces capacity and predicates per node), but it makes the probe's search space depend on the order and outcome of previously rejected scenarios instead of being derivable from the solver's node set plus the recorded victims. This fix rolls back the additions on all non-solved results. Solved results terminate the probe immediately — the map has no further readers — so that path intentionally keeps the previous behavior.

Surfaced while reviewing #1838, whose scenario-dedup cache relies on the feasible-node map being derivable from fingerprint-covered inputs; without this fix, a rejected scenario's leak could cause an equivalent candidate to be wrongly skipped as a known-failure duplicate. The fix stands on its own, however: it restores the intended scenario-isolation invariant that has been broken since the solver was introduced.

Includes a regression test that fails without the fix (a scenario that allocates successfully but is validator-rejected must leave the shared map unchanged), plus a positive control proving the test exercises the post-allocation validator path.

Note: #1838 currently carries this same patch; the hunks are identical, so whichever merges second rebases cleanly.

## Related Issues

Related to #1719 (review finding on its PR, #1838).

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. Behavior change is limited to scenario search: scenarios following a validator-rejected or errored scenario within the same probe no longer see the rejected scenario's victim nodes as allocation candidates.

## Additional Notes

Any capacity the leaked nodes could genuinely provide is re-added legitimately per scenario by `updateFeasibleNodes` when that scenario's own victims live there, so no real solutions are lost by the rollback.
