### PR TITLE
test: NUMA plugin e2e

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: 'v1.34.0'
   feature_config:
-    description: Named feature configuration (default or dra-enabled)
+    description: Named feature configuration (default, dra-enabled, or numa-full)
     required: false
     default: 'default'
 
@@ -88,7 +88,7 @@ runs:
           DRA_PLUGIN_ENABLED="true"
         fi
         helm upgrade -i gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator --namespace gpu-operator --create-namespace \
-            --version 0.0.74 --values ./hack/fake-gpu-operator-values.yaml --set "draPlugin.enabled=$DRA_PLUGIN_ENABLED" --wait
+            --version 0.2.0 --values ./hack/fake-gpu-operator-values.yaml --set "draPlugin.enabled=$DRA_PLUGIN_ENABLED" --wait
 
     - name: Deploy Prometheus Operator
       shell: bash

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -270,7 +270,7 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          ginkgo -r --keep-going --randomize-all --randomize-suites --trace -vv --label-filter '!autoscale && !scale && !upgrade && !gitops' --output-dir=. --json-report=e2e-report.json ./test/e2e/suites
+          ginkgo -r --keep-going --randomize-all --randomize-suites --trace -vv --label-filter '!autoscale && !scale && !upgrade && !gitops && !nightly' --output-dir=. --json-report=e2e-report.json ./test/e2e/suites
           echo ""
           echo "=== Skipped Tests ==="
           jq -r '.[].SpecReports[] | select(.State == "skipped") | ([.ContainerHierarchyTexts[], .LeafNodeText] | join(" > "))' e2e-report.json 2>/dev/null || echo "No skipped tests found"

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -263,6 +263,7 @@ jobs:
           PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
         run: |
           helm upgrade -i kai-scheduler /mnt/images/kai-scheduler-$PACKAGE_VERSION.tgz -n kai-scheduler --create-namespace \
+            --values ./hack/kai-scheduler-fake-npe-values.yaml \
             --set "global.gpuSharing=true" --set "global.registry=localhost:30100" --set "prometheus.enabled=true" --debug --wait
           kubectl create clusterrole pods-patcher --verb=patch --resource=pods
           kubectl create rolebinding fake-status-updater --clusterrole=pods-patcher --serviceaccount=gpu-operator:status-updater -n kai-resource-reservation

--- a/cmd/snapshot-tool/main.go
+++ b/cmd/snapshot-tool/main.go
@@ -19,8 +19,10 @@ import (
 
 	nrtfake "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	version "k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -48,6 +50,8 @@ func main() {
 		fs.Usage()
 		return
 	}
+
+	disableWatchListClientForFakeReplay()
 
 	if err := log.InitLoggers(int(*verbosity), false); err != nil {
 		fmt.Printf("Failed to initialize logger: %v", err)
@@ -166,6 +170,25 @@ func printRunSummary(totalDuration time.Duration, actionDurations map[string]tim
 		return
 	}
 	fmt.Println(string(out))
+}
+
+// disableWatchListClientForFakeReplay turns off client-go's WatchListClient gate (default true since
+// client-go 1.35) before any client is built. Only the NodeResourceTopology client needs this: its
+// generated informer (noderesourcetopology-api, built against client-go v0.22) hangs under the
+// watch-list reflector when backed by a fake clientset, so replayed NRTs never sync. Other clients
+// (core/KAI/DRA, modern codegen) are unaffected, and the NRT client works against a real API server.
+// The alternative fix is regenerating that client against a current client-go; disabling the gate is
+// the cheaper replay-only workaround. See https://github.com/kubernetes/kubernetes/issues/129408.
+func disableWatchListClientForFakeReplay() {
+	featureGates, ok := clientfeatures.FeatureGates().(interface {
+		Set(clientfeatures.Feature, bool) error
+	})
+	if !ok {
+		return
+	}
+	if err := featureGates.Set(clientfeatures.WatchListClient, false); err != nil {
+		utilruntime.HandleError(err)
+	}
 }
 
 func loadSnapshot(filename string) (*snapshot.Snapshot, error) {

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -314,4 +314,13 @@ spec:
     {{- if .Values.numaPlacementExporter.driftResyncInterval }}
     driftResyncInterval: {{ .Values.numaPlacementExporter.driftResyncInterval | quote }}
     {{- end }}
+    {{- if .Values.numaPlacementExporter.podResourcesHostPath }}
+    podResourcesHostPath: {{ .Values.numaPlacementExporter.podResourcesHostPath | quote }}
+    {{- end }}
+    {{- if .Values.numaPlacementExporter.podResourcesSocket }}
+    podResourcesSocket: {{ .Values.numaPlacementExporter.podResourcesSocket | quote }}
+    {{- end }}
+    {{- if .Values.numaPlacementExporter.sysfsHostPath }}
+    sysfsHostPath: {{ .Values.numaPlacementExporter.sysfsHostPath | quote }}
+    {{- end }}
 {{- end -}}

--- a/deployments/kai-scheduler/tests/numa_placement_exporter_test.yaml
+++ b/deployments/kai-scheduler/tests/numa_placement_exporter_test.yaml
@@ -4,8 +4,10 @@
 suite: test numa placement exporter configuration
 
 set:
-  _test:
-    renderKaiConfig: true
+  kaiConfigDeployer:
+    enabled: false
+  kaiConfig:
+    render: true
 templates:
   - kai-config.yaml
 tests:

--- a/deployments/kai-scheduler/tests/numa_placement_exporter_test.yaml
+++ b/deployments/kai-scheduler/tests/numa_placement_exporter_test.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test numa placement exporter configuration
+
+set:
+  _test:
+    renderKaiConfig: true
+templates:
+  - kai-config.yaml
+tests:
+  - it: should not set service.enabled by default (auto - follow shards)
+    asserts:
+      - notExists:
+          path: spec.numaPlacementExporter.service.enabled
+      - equal:
+          path: spec.numaPlacementExporter.service.image.name
+          value: numa-placement-exporter
+
+  - it: should render service.enabled true when explicitly enabled
+    set:
+      numaPlacementExporter.enabled: true
+    asserts:
+      - equal:
+          path: spec.numaPlacementExporter.service.enabled
+          value: true
+
+  - it: should render service.enabled false when explicitly disabled
+    set:
+      numaPlacementExporter.enabled: false
+    asserts:
+      - equal:
+          path: spec.numaPlacementExporter.service.enabled
+          value: false
+
+  - it: should wire nodeSelector and tolerations onto the exporter
+    set:
+      numaPlacementExporter.nodeSelector:
+        nvidia.com/gpu.present: "true"
+      numaPlacementExporter.tolerations:
+        - operator: Exists
+    asserts:
+      - equal:
+          path: spec.numaPlacementExporter.nodeSelector["nvidia.com/gpu.present"]
+          value: "true"
+      - equal:
+          path: spec.numaPlacementExporter.tolerations[0].operator
+          value: Exists

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -181,6 +181,12 @@ numaPlacementExporter:
   resources: {}
   # pollInterval: 1s
   # driftResyncInterval: 60s
+  # Override the podresources socket / sysfs paths to point the exporter at a non-kubelet source
+  # (e.g. the fake-gpu-operator's simulated podresources + sysfs on kind). podResourcesSocket must
+  # resolve inside podResourcesHostPath. Defaults target the real kubelet.
+  # podResourcesHostPath: /var/lib/kubelet/pod-resources
+  # podResourcesSocket: /var/lib/kubelet/pod-resources/kubelet.sock
+  # sysfsHostPath: /sys
 
 queuecontroller:
   enabled: true

--- a/hack/fake-gpu-operator-values.yaml
+++ b/hack/fake-gpu-operator-values.yaml
@@ -19,7 +19,7 @@ topology:
       numa:
         zones: 2
         topologyManagerPolicy: restricted
-        cpuPerZone: "4"
+        cpuPerZone: "1"
         memPerZone: 2Gi
         distances:
           self: 10
@@ -39,7 +39,7 @@ topology:
       numa:
         zones: 2
         topologyManagerPolicy: single-numa-node
-        cpuPerZone: "4"
+        cpuPerZone: "1"
         memPerZone: 2Gi
         distances:
           self: 10
@@ -56,7 +56,7 @@ topology:
       numa:
         zones: 2
         topologyManagerPolicy: best-effort
-        cpuPerZone: "4"
+        cpuPerZone: "1"
         memPerZone: 2Gi
         distances:
           self: 10

--- a/hack/fake-gpu-operator-values.yaml
+++ b/hack/fake-gpu-operator-values.yaml
@@ -4,14 +4,63 @@
 topology:
   # nodePools is a map of node pool name to node pool configuration.
   # Nodes are assigned to node pools based on the node pool label's value (key is configurable via nodePoolLabelKey).
-  # 
-  # For example, nodes that have the label "run.ai/simulated-gpu-node-pool: default"
-  # will be assigned to the "default" node pool.
+  # default kind layout labels every GPU worker "default"; the "numa-full"
+  # layout (nightly) also populates numa-single/numa-besteffort.
   nodePools:
     default:
-      gpuProduct: Tesla-K80
-      gpuCount: 8
-      gpuMemory: 11441
+      gpu:
+        backend: fake
+        overrides:
+          device_defaults:
+            name: Tesla-K80
+            memory:
+              total_bytes: 11996758016   # 11441 MiB
+          devices: [ {}, {}, {}, {}, {}, {}, {}, {} ]
+      numa:
+        zones: 2
+        topologyManagerPolicy: restricted
+        cpuPerZone: "4"
+        memPerZone: 2Gi
+        distances:
+          self: 10
+          remote: 21
+    # single-numa-node & best-effort pools are only populated by the numa-full kind
+    # layout (nightly); on the default layout no node carries their label, so they
+    # publish no NRTs.
+    numa-single:
+      gpu:
+        backend: fake
+        overrides:
+          device_defaults:
+            name: Tesla-K80
+            memory:
+              total_bytes: 11996758016   # 11441 MiB
+          devices: [ {}, {}, {}, {}, {}, {}, {}, {} ]
+      numa:
+        zones: 2
+        topologyManagerPolicy: single-numa-node
+        cpuPerZone: "4"
+        memPerZone: 2Gi
+        distances:
+          self: 10
+          remote: 21
+    numa-besteffort:
+      gpu:
+        backend: fake
+        overrides:
+          device_defaults:
+            name: Tesla-K80
+            memory:
+              total_bytes: 11996758016   # 11441 MiB
+          devices: [ {}, {}, {}, {}, {}, {}, {}, {} ]
+      numa:
+        zones: 2
+        topologyManagerPolicy: best-effort
+        cpuPerZone: "4"
+        memPerZone: 2Gi
+        distances:
+          self: 10
+          remote: 21
   nodePoolLabelKey: run.ai/simulated-gpu-node-pool
 
 environment:
@@ -20,5 +69,11 @@ environment:
 statusUpdater:
   disableNodeLabeling: true
 
+statusExporter:
+  nodeResourceTopology:
+    enabled: true
+    installCRD: true
+  podResources:
+    enabled: true
 draPlugin:
   enabled: true

--- a/hack/generate-kind-config.sh
+++ b/hack/generate-kind-config.sh
@@ -18,7 +18,7 @@ while [[ $# -gt 0 ]]; do
     --output)         OUTPUT="$2"; shift 2;;
     -h|--help)
       echo "Usage: $0 --feature-config <config> --k8s-version <version> --output <path>"
-      echo "  --feature-config: default | dra-enabled"
+      echo "  --feature-config: default | dra-enabled | numa-full"
       echo "  --k8s-version:    kindest/node version tag, e.g. v1.34.0"
       echo "  --output:         path to write the generated kind config YAML"
       exit 0;;
@@ -84,12 +84,28 @@ esac
     echo "          runtime-config: \"$RUNTIME_CONFIG\""
   fi
 
+  # GPU worker pool assignment. On the default layout every worker joins the
+  # "default" pool (restricted Topology-Manager policy). The "numa-full" layout
+  # spreads workers across the numa pools so the numa suite can exercise every
+  # policy (single-numa-node, restricted, best-effort); the CPU node below stays
+  # NRT-less to cover the no-NRT pass-through case.
+  if [ "$FEATURE_CONFIG" = "numa-full" ]; then
+    WORKER_POOLS=(numa-single numa-single default numa-besteffort)
+  else
+    WORKER_POOLS=(default default default default)
+  fi
+
   echo "# Device plugin nodes"
-  for i in 1 2 3 4; do
+  for pool in "${WORKER_POOLS[@]}"; do
     echo "- role: worker"
     echo "  labels:"
-    echo "    run.ai/simulated-gpu-node-pool: default"
+    echo "    run.ai/simulated-gpu-node-pool: $pool"
     echo "    nvidia.com/gpu.deploy.device-plugin: \"true\""
+    # fake-gpu-operator's status-exporter (which publishes NodeResourceTopology)
+    # runs as the "nvidia-dcgm-exporter" DaemonSet gated on this label. With
+    # statusUpdater.disableNodeLabeling=true the operator never sets it itself,
+    # so it must be applied here or no NRTs are published.
+    echo "    nvidia.com/gpu.deploy.dcgm-exporter: \"true\""
     echo "    nvidia.com/gpu.memory: 11441"
   done
 

--- a/hack/kai-scheduler-fake-npe-values.yaml
+++ b/hack/kai-scheduler-fake-npe-values.yaml
@@ -1,0 +1,17 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Fake-GPU-only overlay for KAI's numa-placement-exporter (NPE). Applied by the fake-GPU e2e setup
+# (setup-e2e-cluster.sh / the on-pr KAI install) and NEVER by real-environment installs, which keep
+# the chart defaults (real kubelet podresources socket + /sys).
+#
+# On kind there is no real kubelet podresources reporting fake-GPU NUMA placement, so the NPE is
+# pointed at the fake-gpu-operator's simulated socket + sysfs (statusExporter.podResources) instead.
+# The fake source is served by FGO's status-exporter DaemonSet, which runs on nodes labeled
+# nvidia.com/gpu.deploy.dcgm-exporter=true — the NPE is scoped to those same nodes.
+numaPlacementExporter:
+  podResourcesHostPath: /var/lib/fake-gpu-operator/pod-resources
+  podResourcesSocket: /var/lib/fake-gpu-operator/pod-resources/kubelet.sock
+  sysfsHostPath: /var/lib/fake-gpu-operator/sys
+  nodeSelector:
+    nvidia.com/gpu.deploy.dcgm-exporter: "true"

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --local-images-build: Build and use local images instead of pulling from registry"
       echo "  --install-vpa: Install Vertical Pod Autoscaler and metrics-server"
       echo "  --skip-kai-install: Prepare the cluster (and images/chart with --local-images-build) without installing KAI (e.g. for gitops e2e tests)"
-      echo "  --feature-config: Feature configuration for kind cluster generation (default: \"default\")"
+      echo "  --feature-config: Feature configuration for kind cluster generation: default | dra-enabled | numa-full (default: \"default\")"
       echo "  --kind-config: Existing kind config file to use instead of generating one"
       exit 0
       ;;
@@ -111,7 +111,7 @@ if [ "$FEATURE_CONFIG" = "dra-enabled" ]; then
   DRA_PLUGIN_ENABLED="true"
 fi
 helm upgrade -i gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator --namespace gpu-operator --create-namespace \
-    --version 0.0.74 --values ${REPO_ROOT}/hack/fake-gpu-operator-values.yaml --set "draPlugin.enabled=$DRA_PLUGIN_ENABLED" --wait
+    --version 0.2.0 --values ${REPO_ROOT}/hack/fake-gpu-operator-values.yaml --set "draPlugin.enabled=$DRA_PLUGIN_ENABLED" --wait
 
 # Deploy Prometheus Operator
 echo "Deploying Prometheus Operator..."
@@ -203,7 +203,8 @@ if [ "$LOCAL_IMAGES_BUILD" = "true" ]; then
         echo "Skipping KAI install; packaged chart kept at ./charts/kai-scheduler-$PACKAGE_VERSION.tgz"
     else
         helm upgrade -i kai-scheduler ./charts/kai-scheduler-$PACKAGE_VERSION.tgz -n kai-scheduler --create-namespace \
-            --set "global.gpuSharing=true" --set "global.registry=localhost:30100" --set "prometheus.enabled=true" --debug --wait
+        --values ${REPO_ROOT}/hack/kai-scheduler-fake-npe-values.yaml \
+        --set "global.gpuSharing=true" --set "global.registry=localhost:30100" --set "prometheus.enabled=true" --debug --wait
         rm -rf ./charts/kai-scheduler-$PACKAGE_VERSION.tgz
     fi
     cd ${REPO_ROOT}/hack
@@ -211,6 +212,7 @@ elif [ "$SKIP_KAI_INSTALL" = "true" ]; then
     echo "Skipping KAI install."
 else
     helm upgrade -i kai-scheduler oci://ghcr.io/kai-scheduler/kai-scheduler/kai-scheduler -n kai-scheduler --create-namespace \
+        --values ${REPO_ROOT}/hack/kai-scheduler-fake-npe-values.yaml \
         --set "global.gpuSharing=true" --set "prometheus.enabled=true" --wait --version "$PACKAGE_VERSION"
 fi
 

--- a/pkg/scheduler/plugins/snapshot/snapshot.go
+++ b/pkg/scheduler/plugins/snapshot/snapshot.go
@@ -69,6 +69,7 @@ type Snapshot struct {
 
 type snapshotPlugin struct {
 	session *framework.Session
+	config  *conf.SchedulerConfiguration
 }
 
 type jsonStream struct {
@@ -89,6 +90,7 @@ func (sp *snapshotPlugin) Name() string {
 
 func (sp *snapshotPlugin) OnSessionOpen(ssn *framework.Session) {
 	sp.session = ssn
+	sp.config = ssn.Config
 	log.InfraLogger.V(3).Info("Snapshot plugin registering get-snapshot")
 	ssn.AddHttpHandler("/get-snapshot", sp.serveSnapshot)
 }
@@ -123,7 +125,7 @@ func (sp *snapshotPlugin) writeSnapshot(ctx context.Context, writer io.Writer) e
 	return stream.writeObject(func(object *jsonObjectWriter) error {
 		return writeFields(
 			object,
-			valueField("config", sp.session.Config),
+			valueField("config", sp.config),
 			valueField("schedulerParams", &sp.session.SchedulerParams),
 			streamedField("rawObjects", sp.writeRawObjects),
 			streamedField("discovery", func(stream *jsonStream) error {

--- a/test/e2e/modules/configurations/feature_flags/numa.go
+++ b/test/e2e/modules/configurations/feature_flags/numa.go
@@ -1,0 +1,43 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package feature_flags
+
+import (
+	"context"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	testContext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"k8s.io/utils/ptr"
+)
+
+const numaPluginName = "numa"
+
+// EnableNUMA turns on the numa scheduler plugin on the default shard with the given arguments
+// (e.g. reconstructAvailable, ignoreList). Passing nil arguments keeps the plugin's defaults.
+func EnableNUMA(ctx context.Context, testCtx *testContext.TestContext, arguments map[string]string) error {
+	return setNUMA(ctx, testCtx, ptr.To(true), arguments)
+}
+
+// DisableNUMA turns off the numa plugin on the default shard.
+func DisableNUMA(ctx context.Context, testCtx *testContext.TestContext) error {
+	return setNUMA(ctx, testCtx, ptr.To(false), nil)
+}
+
+func setNUMA(
+	ctx context.Context, testCtx *testContext.TestContext, enabled *bool, arguments map[string]string,
+) error {
+	return patchShard(
+		ctx, testCtx, defaultShardName,
+		func(shard *kaiv1.SchedulingShard) {
+			if shard.Spec.Plugins == nil {
+				shard.Spec.Plugins = map[string]kaiv1.PluginConfig{}
+			}
+			shard.Spec.Plugins[numaPluginName] = kaiv1.PluginConfig{
+				Enabled:   enabled,
+				Arguments: arguments,
+			}
+			shard.Status = kaiv1.SchedulingShardStatus{}
+		},
+	)
+}

--- a/test/e2e/modules/context/connectivity.go
+++ b/test/e2e/modules/context/connectivity.go
@@ -9,14 +9,16 @@ import (
 	"os"
 	"strings"
 
-	lws "sigs.k8s.io/lws/api/leaderworkerset/v1"
-
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"k8s.io/api/node/v1alpha1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+	kwokv1alpha1 "sigs.k8s.io/kwok/pkg/apis/v1alpha1"
+	lws "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
+	kubeAiSchedClient "github.com/kai-scheduler/KAI-scheduler/pkg/apis/client/clientset/versioned"
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	kaiv1alpha1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1alpha1"
 	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
@@ -24,9 +26,6 @@ import (
 	kubeAiSchedulerV2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 
 	kwokopv1beta1 "github.com/run-ai/kwok-operator/api/v1beta1"
-
-	kubeAiSchedClient "github.com/kai-scheduler/KAI-scheduler/pkg/apis/client/clientset/versioned"
-	kwokv1alpha1 "sigs.k8s.io/kwok/pkg/apis/v1alpha1"
 )
 
 var kubeConfig *rest.Config
@@ -79,6 +78,9 @@ func initConnectivity() error {
 		}
 		if err = kwokv1alpha1.AddToScheme(controllerClient.Scheme()); err != nil {
 			return fmt.Errorf("failed to add kwok v1alpha1 to scheme: %w", err)
+		}
+		if err = nrtv1alpha2.AddToScheme(controllerClient.Scheme()); err != nil {
+			return fmt.Errorf("failed to add noderesourcetopology v1alpha2 to scheme: %w", err)
 		}
 	}
 

--- a/test/e2e/modules/resources/rd/numa/numa.go
+++ b/test/e2e/modules/resources/rd/numa/numa.go
@@ -1,0 +1,353 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package numa provides read-only discovery over the cluster's NodeResourceTopology (NRT) objects and
+// helpers for building Guaranteed-QoS pods, for the NUMA-aware scheduling e2e suite. Tests never create
+// NRT/nodes; they discover pre-provisioned NUMA nodes and skip when the prerequisites are absent.
+package numa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
+)
+
+// Topology Manager policy values as reported in NRT (mirror the kubelet policy names).
+const (
+	PolicyNone           = "none"
+	PolicyBestEffort     = "best-effort"
+	PolicyRestricted     = "restricted"
+	PolicySingleNUMANode = "single-numa-node"
+)
+
+const (
+	zoneTypeNode              = "Node"
+	attrTopologyManagerPolicy = "topologyManagerPolicy"
+	hostnameLabelKey          = "kubernetes.io/hostname"
+)
+
+// Zone is a single NUMA-node zone's free/total resources as reported in NRT.
+type Zone struct {
+	ID          string
+	Available   v1.ResourceList
+	Allocatable v1.ResourceList
+}
+
+// Node is the NUMA view of a cluster node built from its NRT object.
+type Node struct {
+	Name   string
+	Policy string
+	Zones  []Zone
+}
+
+// Requirement describes what a test case needs from a NUMA node. A zero value matches any NUMA node.
+type Requirement struct {
+	Policy   string // "" matches any policy
+	Modeled  bool   // when true, match only modeled policies (single-numa-node or restricted)
+	MinNodes int    // minimum number of matching nodes (default 1)
+	MinZones int    // minimum NUMA-node zones per matching node
+	ZoneGPUs int64  // require at least one zone with this many free GPUs
+}
+
+// IsModeledPolicy reports whether the numa plugin enforces alignment on this node's policy.
+func (n Node) IsModeledPolicy() bool {
+	return n.Policy == PolicySingleNUMANode || n.Policy == PolicyRestricted
+}
+
+// Pin confines the pod to this node via a hostname nodeSelector, returning the pod for chaining. A
+// policy-specific spec must pin its pod so the discovered node's Topology Manager policy governs the
+// outcome; otherwise, when several policies coexist (the numa-full layout), the pod can schedule on a
+// more permissive node and invalidate the assertion.
+func (n Node) Pin(pod *v1.Pod) *v1.Pod {
+	if pod.Spec.NodeSelector == nil {
+		pod.Spec.NodeSelector = map[string]string{}
+	}
+	pod.Spec.NodeSelector[hostnameLabelKey] = n.Name
+	return pod
+}
+
+// HostSelector returns a nodeSelector confining a pod (or pod template) to this node's host. Use it to
+// pin pods built outside a *v1.Pod (e.g. a Job's pod template) where Pin doesn't apply.
+func (n Node) HostSelector() map[string]string {
+	return map[string]string{hostnameLabelKey: n.Name}
+}
+
+// List returns the NUMA view of every node that publishes an NRT object.
+func List(ctx context.Context, c runtimeClient.Client) ([]Node, error) {
+	nrtList := &nrtv1alpha2.NodeResourceTopologyList{}
+	if err := c.List(ctx, nrtList); err != nil {
+		return nil, err
+	}
+	nodes := make([]Node, 0, len(nrtList.Items))
+	for i := range nrtList.Items {
+		nodes = append(nodes, buildNode(&nrtList.Items[i]))
+	}
+	return nodes, nil
+}
+
+// RequireNodes discovers NUMA nodes matching req, or Skips the running spec when the NRT CRD is absent
+// or too few nodes match.
+func RequireNodes(ctx context.Context, c runtimeClient.Client, req Requirement) []Node {
+	nodes, err := List(ctx, c)
+	if err != nil {
+		ginkgo.Skip(fmt.Sprintf("NodeResourceTopology not available (%v); skipping NUMA test", err))
+	}
+
+	minNodes := req.MinNodes
+	if minNodes == 0 {
+		minNodes = 1
+	}
+
+	matches := make([]Node, 0, len(nodes))
+	for _, node := range nodes {
+		if matchesRequirement(node, req) {
+			matches = append(matches, node)
+		}
+	}
+	if len(matches) < minNodes {
+		ginkgo.Skip(fmt.Sprintf(
+			"need %d NUMA node(s) matching %+v, found %d; skipping", minNodes, req, len(matches)))
+	}
+	return matches
+}
+
+func matchesRequirement(node Node, req Requirement) bool {
+	if req.Policy != "" && node.Policy != req.Policy {
+		return false
+	}
+	if req.Modeled && !node.IsModeledPolicy() {
+		return false
+	}
+	if req.MinZones > 0 && len(node.Zones) < req.MinZones {
+		return false
+	}
+	if req.ZoneGPUs > 0 && node.MaxZoneGPUs() < req.ZoneGPUs {
+		return false
+	}
+	return true
+}
+
+// Sizing helpers read per-zone Allocatable (capacity), not Available: Available lags real free capacity
+// after workload churn (the NRT is republished on an interval), while each spec starts from a clean node
+// and the scheduler reconstructs actual availability from placements. Sizing from capacity is stable.
+
+// MaxZoneGPUs is the largest GPU capacity of any single zone.
+func (n Node) MaxZoneGPUs() int64 {
+	var max int64
+	for _, zone := range n.Zones {
+		if cap := zoneGPU(zone.Allocatable); cap > max {
+			max = cap
+		}
+	}
+	return max
+}
+
+// TotalGPUs is the GPU capacity summed across all zones.
+func (n Node) TotalGPUs() int64 {
+	var total int64
+	for _, zone := range n.Zones {
+		total += zoneGPU(zone.Allocatable)
+	}
+	return total
+}
+
+// OneZoneGPUs returns a GPU count that fits within a single zone, and whether such a request exists.
+func (n Node) OneZoneGPUs() (int64, bool) {
+	gpus := n.MaxZoneGPUs()
+	return gpus, gpus >= 1
+}
+
+// SpanTwoZonesGPUs returns a GPU count that no single zone can satisfy but the node's zones can together,
+// and whether such a request exists on this node.
+func (n Node) SpanTwoZonesGPUs() (int64, bool) {
+	maxZone := n.MaxZoneGPUs()
+	if len(n.Zones) < 2 || maxZone < 1 || n.TotalGPUs() <= maxZone {
+		return 0, false
+	}
+	return maxZone + 1, true
+}
+
+func zoneGPU(list v1.ResourceList) int64 {
+	if qty, ok := list[commonconstants.NvidiaGpuResource]; ok {
+		return qty.Value()
+	}
+	return 0
+}
+
+// MaxZoneCPU is the largest CPU capacity of any single zone.
+func (n Node) MaxZoneCPU() resource.Quantity {
+	var max resource.Quantity
+	for _, zone := range n.Zones {
+		if cpu, ok := zone.Allocatable[v1.ResourceCPU]; ok && cpu.Cmp(max) > 0 {
+			max = cpu
+		}
+	}
+	return max
+}
+
+// TotalCPU is the CPU capacity summed across all zones.
+func (n Node) TotalCPU() resource.Quantity {
+	total := resource.Quantity{}
+	for _, zone := range n.Zones {
+		if cpu, ok := zone.Allocatable[v1.ResourceCPU]; ok {
+			total.Add(cpu)
+		}
+	}
+	return total
+}
+
+// TwoZoneCPU returns a CPU request that no single zone can satisfy but the node's zones can together
+// (forcing a width-2 NUMA mask), and whether such a request exists. Used to build a restricted-policy
+// pod whose CPU and GPU minimal widths agree.
+func (n Node) TwoZoneCPU() (resource.Quantity, bool) {
+	maxZone := n.MaxZoneCPU()
+	if maxZone.IsZero() {
+		return resource.Quantity{}, false
+	}
+	req := maxZone.DeepCopy()
+	req.Add(resource.MustParse("1"))
+	if req.Cmp(n.TotalCPU()) > 0 {
+		return resource.Quantity{}, false
+	}
+	return req, true
+}
+
+// MaxZoneMemory is the largest memory capacity of any single zone.
+func (n Node) MaxZoneMemory() resource.Quantity {
+	var max resource.Quantity
+	for _, zone := range n.Zones {
+		if mem, ok := zone.Allocatable[v1.ResourceMemory]; ok && mem.Cmp(max) > 0 {
+			max = mem
+		}
+	}
+	return max
+}
+
+// TotalMemory is the memory capacity summed across all zones.
+func (n Node) TotalMemory() resource.Quantity {
+	total := resource.Quantity{}
+	for _, zone := range n.Zones {
+		if mem, ok := zone.Allocatable[v1.ResourceMemory]; ok {
+			total.Add(mem)
+		}
+	}
+	return total
+}
+
+// TwoZoneMemory returns a memory request that no single zone can satisfy but the node's zones can
+// together (forcing a width-2 NUMA mask), and whether such a request exists. Restricted requires every
+// topology-aware resource to share the same minimal width, so a width-2 GPU/CPU pod must also request
+// memory spanning two zones - otherwise memory's width-1 minimum disagrees and the pod is rejected.
+func (n Node) TwoZoneMemory() (resource.Quantity, bool) {
+	maxZone := n.MaxZoneMemory()
+	if maxZone.IsZero() {
+		return resource.Quantity{}, false
+	}
+	req := maxZone.DeepCopy()
+	req.Add(resource.MustParse("1Mi"))
+	if req.Cmp(n.TotalMemory()) > 0 {
+		return resource.Quantity{}, false
+	}
+	return req, true
+}
+
+func buildNode(nrt *nrtv1alpha2.NodeResourceTopology) Node {
+	node := Node{Name: nrt.Name, Policy: policyOf(nrt)}
+	for i := range nrt.Zones {
+		nrtZone := &nrt.Zones[i]
+		if nrtZone.Type != zoneTypeNode {
+			continue
+		}
+		zone := Zone{
+			ID:          nrtZone.Name,
+			Available:   v1.ResourceList{},
+			Allocatable: v1.ResourceList{},
+		}
+		for _, ri := range nrtZone.Resources {
+			zone.Available[v1.ResourceName(ri.Name)] = ri.Available.DeepCopy()
+			zone.Allocatable[v1.ResourceName(ri.Name)] = ri.Allocatable.DeepCopy()
+		}
+		node.Zones = append(node.Zones, zone)
+	}
+	return node
+}
+
+func policyOf(nrt *nrtv1alpha2.NodeResourceTopology) string {
+	for _, attr := range nrt.Attributes {
+		if attr.Name == attrTopologyManagerPolicy {
+			return attr.Value
+		}
+	}
+	if len(nrt.TopologyPolicies) > 0 {
+		return nrt.TopologyPolicies[0]
+	}
+	return ""
+}
+
+// ObservedZones returns the NUMA placement the exporter published for a pod, or nil when the annotation
+// is absent or malformed.
+func ObservedZones(pod *v1.Pod) []schedulingv1alpha2.NUMAZonePlacement {
+	raw, ok := pod.Annotations[commonconstants.NumaPlacementObserved]
+	if !ok {
+		return nil
+	}
+	var record []schedulingv1alpha2.NUMAZonePlacement
+	if err := json.Unmarshal([]byte(raw), &record); err != nil {
+		return nil
+	}
+	return record
+}
+
+// GuaranteedGPUPod builds (does not create) a Guaranteed-QoS pod requesting the given number of GPUs.
+// GPU alignment is what the NUMA plugin reasons about; the small cpu/memory limits==requests make the
+// pod Guaranteed so the plugin handles it.
+func GuaranteedGPUPod(q *v2.Queue, gpus int64) *v1.Pod {
+	return GuaranteedPod(q, gpuResourceList(gpus))
+}
+
+// GuaranteedGPURequirements returns the ResourceRequirements of a Guaranteed GPU pod, for callers (e.g.
+// PodGroup creation) that build pods from requirements rather than a queue.
+func GuaranteedGPURequirements(gpus int64) v1.ResourceRequirements {
+	rl := gpuResourceList(gpus)
+	return v1.ResourceRequirements{Limits: rl, Requests: rl.DeepCopy()}
+}
+
+func gpuResourceList(gpus int64) v1.ResourceList {
+	return v1.ResourceList{
+		v1.ResourceCPU:                    resource.MustParse("100m"),
+		v1.ResourceMemory:                 resource.MustParse("128Mi"),
+		commonconstants.NvidiaGpuResource: *resource.NewQuantity(gpus, resource.DecimalSI),
+	}
+}
+
+// GuaranteedGPUCPUPod builds (does not create) a Guaranteed-QoS pod requesting GPUs plus specific CPU
+// and memory quantities. Used by restricted-policy tests that need every topology-aware resource's
+// minimal width to agree: a width-2 GPU request must be paired with width-2 CPU and memory.
+func GuaranteedGPUCPUPod(q *v2.Queue, gpus int64, cpu, memory resource.Quantity) *v1.Pod {
+	return GuaranteedPod(q, v1.ResourceList{
+		v1.ResourceCPU:                    cpu,
+		v1.ResourceMemory:                 memory,
+		commonconstants.NvidiaGpuResource: *resource.NewQuantity(gpus, resource.DecimalSI),
+	})
+}
+
+// GuaranteedPod builds (does not create) a pod whose single container sets limits == requests for every
+// resource in rl, yielding Guaranteed QoS.
+func GuaranteedPod(q *v2.Queue, rl v1.ResourceList) *v1.Pod {
+	requests := rl.DeepCopy()
+	return rd.CreatePodObject(q, v1.ResourceRequirements{
+		Limits:   rl,
+		Requests: requests,
+	})
+}

--- a/test/e2e/modules/resources/rd/pod.go
+++ b/test/e2e/modules/resources/rd/pod.go
@@ -116,7 +116,8 @@ func CreatePod(ctx context.Context, client *kubernetes.Clientset, pod *v1.Pod) (
 	}
 
 	for range numCreatePodRetries {
-		actualPod, err := client.
+		var actualPod *v1.Pod
+		actualPod, err = client.
 			CoreV1().
 			Pods(pod.Namespace).
 			Create(ctx, pod, metav1.CreateOptions{})

--- a/test/e2e/suites/numa/helpers_test.go
+++ b/test/e2e/suites/numa/helpers_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
+	numautil "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/numa"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+)
+
+const (
+	npeDaemonSetName = "numa-placement-exporter"
+	reconcileTimeout = 2 * time.Minute
+	reconcilePoll    = 3 * time.Second
+	placementTimeout = 2 * time.Minute
+)
+
+// gpuQueues builds a parent/child queue pair with the given GPU quota and an unbounded limit, so NUMA
+// tests can freely allocate GPUs without hitting queue limits.
+func gpuQueues(gpuQuota float64) (parent, child *v2.Queue) {
+	parentName := utils.GenerateRandomK8sName(10)
+	parent = queue.CreateQueueObjectWithGpuResource(parentName,
+		v2.QueueResource{Quota: gpuQuota, Limit: -1, OverQuotaWeight: 1}, "")
+	child = queue.CreateQueueObjectWithGpuResource(utils.GenerateRandomK8sName(10),
+		v2.QueueResource{Quota: gpuQuota, Limit: -1, OverQuotaWeight: 1}, parentName)
+	return parent, child
+}
+
+// childQueue returns the leaf queue tests submit pods into (gpuQueues installs it as Queues[0]).
+func childQueue(testCtx *testcontext.TestContext) *v2.Queue {
+	return testCtx.Queues[0]
+}
+
+// gpuQueuesTriple builds a parent with two leaf queues (reclaimee, reclaimer) for reclaim scenarios.
+func gpuQueuesTriple(parentQuota, reclaimeeQuota, reclaimerQuota float64) (parent, reclaimee, reclaimer *v2.Queue) {
+	parentName := utils.GenerateRandomK8sName(10)
+	parent = queue.CreateQueueObjectWithGpuResource(parentName,
+		v2.QueueResource{Quota: parentQuota, Limit: parentQuota, OverQuotaWeight: 1}, "")
+	reclaimee = queue.CreateQueueObjectWithGpuResource(utils.GenerateRandomK8sName(10),
+		v2.QueueResource{Quota: reclaimeeQuota, Limit: -1, OverQuotaWeight: 1}, parentName)
+	reclaimer = queue.CreateQueueObjectWithGpuResource(utils.GenerateRandomK8sName(10),
+		v2.QueueResource{Quota: reclaimerQuota, Limit: -1, OverQuotaWeight: 1}, parentName)
+	return parent, reclaimee, reclaimer
+}
+
+func createPod(ctx context.Context, testCtx *testcontext.TestContext, pod *v1.Pod) *v1.Pod {
+	created, err := rd.CreatePod(ctx, testCtx.KubeClientset, pod)
+	Expect(err).To(Succeed())
+	return created
+}
+
+// expectGuaranteed asserts the (already created) pod was admitted as Guaranteed QoS, the only class the
+// numa plugin acts on.
+func expectGuaranteed(ctx context.Context, testCtx *testcontext.TestContext, pod *v1.Pod) {
+	Eventually(func(g Gomega) {
+		fetched, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		g.Expect(err).To(Succeed())
+		g.Expect(fetched.Status.QOSClass).To(Equal(v1.PodQOSGuaranteed))
+	}, 30*time.Second, time.Second).Should(Succeed())
+}
+
+// expectNotGuaranteed asserts the pod was admitted with a non-Guaranteed QoS class, so the numa plugin
+// leaves it alone.
+func expectNotGuaranteed(ctx context.Context, testCtx *testcontext.TestContext, pod *v1.Pod) {
+	Eventually(func(g Gomega) {
+		fetched, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		g.Expect(err).To(Succeed())
+		g.Expect(fetched.Status.QOSClass).ToNot(Equal(v1.PodQOSGuaranteed))
+	}, 30*time.Second, time.Second).Should(Succeed())
+}
+
+// expectGPUPlacement waits for the NPE to publish the pod's observed NUMA placement, then asserts it
+// spans exactly wantZones zones and accounts for wantGPUs GPUs in total. Only zone count and total GPU
+// are checked (not per-zone splits or specific zone ids): when several pods are scheduled together the
+// exact split depends on bind order, but a request's zone width and total are deterministic. Requires
+// the real exporter to be running (enabling the numa plugin auto-deploys it).
+func expectGPUPlacement(ctx context.Context, testCtx *testcontext.TestContext, pod *v1.Pod, wantZones int, wantGPUs int64) {
+	observed := awaitObservedZones(ctx, testCtx, pod)
+	Expect(observed).To(HaveLen(wantZones), "observed placement should span %d NUMA zone(s)", wantZones)
+	Expect(observedGPUs(observed)).To(Equal(wantGPUs), "observed placement should account for %d GPU(s)", wantGPUs)
+}
+
+// awaitObservedZones waits for the NPE to publish the pod's observed NUMA placement and returns it.
+func awaitObservedZones(ctx context.Context, testCtx *testcontext.TestContext, pod *v1.Pod) []schedulingv1alpha2.NUMAZonePlacement {
+	var observed []schedulingv1alpha2.NUMAZonePlacement
+	Eventually(func(g Gomega) {
+		fresh, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		g.Expect(err).To(Succeed())
+		observed = numautil.ObservedZones(fresh)
+		g.Expect(observed).ToNot(BeEmpty(), "waiting for the NUMA placement exporter to publish observed placement")
+	}, placementTimeout, 2*time.Second).Should(Succeed())
+	return observed
+}
+
+func observedGPUs(zones []schedulingv1alpha2.NUMAZonePlacement) int64 {
+	var total int64
+	for _, zone := range zones {
+		if qty, ok := zone.Amount[constants.NvidiaGpuResource]; ok {
+			total += qty.Value()
+		}
+	}
+	return total
+}
+
+// kaiNamespace returns the namespace KAI components (including the NPE DaemonSet) are deployed into.
+func kaiNamespace(ctx context.Context, testCtx *testcontext.TestContext) string {
+	cfg := &kaiv1.Config{}
+	Expect(testCtx.ControllerClient.Get(
+		ctx, runtimeClient.ObjectKey{Name: constants.DefaultKAIConfigSingeltonInstanceName}, cfg)).To(Succeed())
+	return cfg.Spec.Namespace
+}
+
+// expectNPEDaemonSet waits until the NUMA placement exporter DaemonSet is present or pruned.
+func expectNPEDaemonSet(ctx context.Context, testCtx *testcontext.TestContext, shouldExist bool) {
+	namespace := kaiNamespace(ctx, testCtx)
+	Eventually(func(g Gomega) {
+		ds := &appsv1.DaemonSet{}
+		err := testCtx.ControllerClient.Get(
+			ctx, runtimeClient.ObjectKey{Namespace: namespace, Name: npeDaemonSetName}, ds)
+		if shouldExist {
+			g.Expect(err).To(Succeed())
+			return
+		}
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected DaemonSet to be absent, got err=%v", err)
+	}, reconcileTimeout, reconcilePoll).Should(Succeed())
+}

--- a/test/e2e/suites/numa/modes_specs_test.go
+++ b/test/e2e/suites/numa/modes_specs_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	numautil "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/numa"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
+)
+
+// DescribeNUMAModesSpecs covers the per-node Topology Manager modes: single-numa-node and restricted
+// filter Guaranteed pods the kubelet would reject, while best-effort/none/no-NRT pass through. The suite
+// mutates the shard plugin config, so it runs Serial.
+func DescribeNUMAModesSpecs() bool {
+	return Describe("NUMA modes", Ordered, Serial, Label("numa", "nightly"), func() {
+		var testCtx *testcontext.TestContext
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			parent, child := gpuQueues(64)
+			testCtx.InitQueues([]*v2.Queue{child, parent})
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+		})
+
+		AfterAll(func(ctx context.Context) {
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			testCtx.ClusterCleanup(ctx)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			testCtx.TestContextCleanup(ctx)
+		})
+
+		It("single-numa-node - request fitting one zone is scheduled", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicySingleNUMANode, ZoneGPUs: 1})
+			gpus, ok := node.OneZoneGPUs()
+			if !ok {
+				Skip("no single-numa-node node exposes a GPU-bearing zone")
+			}
+
+			pod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), gpus)))
+			expectGuaranteed(ctx, testCtx, pod)
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, pod)
+			expectGPUPlacement(ctx, testCtx, pod, 1, gpus)
+		})
+
+		It("single-numa-node - request spanning two zones stays pending", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicySingleNUMANode, MinZones: 2})
+			gpus, ok := node.SpanTwoZonesGPUs()
+			if !ok {
+				Skip("no single-numa-node node can express a two-zone-spanning request")
+			}
+
+			pod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), gpus)))
+			expectGuaranteed(ctx, testCtx, pod)
+			wait.ForPodUnschedulable(ctx, testCtx.ControllerClient, pod)
+
+			// Negative control: the same pod downsized to one zone schedules on the same class of node.
+			fit, ok := node.OneZoneGPUs()
+			if !ok {
+				return
+			}
+			fitPod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), fit)))
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, fitPod)
+		})
+
+		It("restricted - two-zone request at matching minimal width is scheduled", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicyRestricted, MinZones: 2})
+			gpus, gpusOK := node.SpanTwoZonesGPUs()
+			cpu, cpuOK := node.TwoZoneCPU()
+			memory, memOK := node.TwoZoneMemory()
+			if !gpusOK || !cpuOK || !memOK {
+				Skip("no restricted node where GPU, CPU and memory can all span two zones")
+			}
+
+			// GPU, CPU and memory all need width 2, so restricted has a common preferred mask (both NUMA
+			// nodes). A small CPU or memory request would force width 1 and conflict with the GPU span.
+			pod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUCPUPod(childQueue(testCtx), gpus, cpu, memory)))
+			expectGuaranteed(ctx, testCtx, pod)
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, pod)
+			expectGPUPlacement(ctx, testCtx, pod, 2, gpus)
+		})
+
+		It("restricted - request exceeding summed capacity stays pending", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicyRestricted, ZoneGPUs: 1})
+			gpus := node.TotalGPUs() + 1
+
+			pod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), gpus)))
+			expectGuaranteed(ctx, testCtx, pod)
+			wait.ForPodUnschedulable(ctx, testCtx.ControllerClient, pod)
+		})
+
+		It("best-effort/none pass through even for cross-zone requests", func(ctx context.Context) {
+			node := passthroughNode(ctx, testCtx)
+			gpus, ok := node.SpanTwoZonesGPUs()
+			if !ok {
+				gpus, ok = node.OneZoneGPUs()
+			}
+			if !ok {
+				Skip("no best-effort/none node exposes a GPU-bearing zone")
+			}
+
+			pod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), gpus)))
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, pod)
+		})
+
+		It("node without NRT passes through", func(ctx context.Context) {
+			// A CPU-only Guaranteed pod is enough: without an NRT object the plugin never handles the pod,
+			// so it schedules purely on ordinary capacity.
+			pod := createPod(ctx, testCtx, numautil.GuaranteedPod(childQueue(testCtx), v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("250m"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			}))
+			expectGuaranteed(ctx, testCtx, pod)
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, pod)
+		})
+	})
+}
+
+// firstMatch discovers a node matching req (skipping the spec if none) and returns the first match.
+func firstMatch(ctx context.Context, testCtx *testcontext.TestContext, req numautil.Requirement) numautil.Node {
+	return numautil.RequireNodes(ctx, testCtx.ControllerClient, req)[0]
+}
+
+// passthroughNode returns a best-effort or none node, skipping when neither is present.
+func passthroughNode(ctx context.Context, testCtx *testcontext.TestContext) numautil.Node {
+	nodes, err := numautil.List(ctx, testCtx.ControllerClient)
+	if err != nil {
+		Skip("NodeResourceTopology not available; skipping NUMA test")
+	}
+	for _, node := range nodes {
+		if node.Policy == numautil.PolicyBestEffort || node.Policy == numautil.PolicyNone {
+			return node
+		}
+	}
+	Skip("no best-effort/none NUMA node found")
+	return numautil.Node{}
+}

--- a/test/e2e/suites/numa/numa_suite_test.go
+++ b/test/e2e/suites/numa/numa_suite_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"testing"
+
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeNUMAModesSpecs()
+var _ = DescribeNUMAQoSSpecs()
+var _ = DescribeNUMAReclaimSpecs()
+var _ = DescribeNUMAPreemptSpecs()
+var _ = DescribeNUMAOperandSpecs()
+
+func TestNUMA(t *testing.T) {
+	utils.SetLogger()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NUMA Aware Scheduling Suite")
+}

--- a/test/e2e/suites/numa/operand_specs_test.go
+++ b/test/e2e/suites/numa/operand_specs_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+
+	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/common"
+	npeapi "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/numa_placement_exporter"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+)
+
+// DescribeNUMAOperandSpecs validates the operator's tri-state deployment of the NUMA placement exporter
+// DaemonSet: auto-on-shard-enable, explicit on/off in kaiconfig, and prune-on-disable. These cases need
+// no NUMA nodes, only the operator.
+func DescribeNUMAOperandSpecs() bool {
+	return Describe("NUMA placement exporter operand", Ordered, Serial, Label("numa", "nightly"), func() {
+		var testCtx *testcontext.TestContext
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			// Restore auto (unset) config and disable the plugin so each case starts clean.
+			Expect(setNPEEnabled(ctx, testCtx, nil)).To(Succeed())
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			expectNPEDaemonSet(ctx, testCtx, false)
+		})
+
+		It("auto - deploys when the numa plugin is enabled in a shard", func(ctx context.Context) {
+			Expect(setNPEEnabled(ctx, testCtx, nil)).To(Succeed())
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+			expectNPEDaemonSet(ctx, testCtx, true)
+		})
+
+		It("explicit disabled overrides a numa-enabled shard", func(ctx context.Context) {
+			Expect(setNPEEnabled(ctx, testCtx, ptr.To(false))).To(Succeed())
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+			expectNPEDaemonSet(ctx, testCtx, false)
+		})
+
+		It("explicit enabled deploys with no numa-enabled shard", func(ctx context.Context) {
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			Expect(setNPEEnabled(ctx, testCtx, ptr.To(true))).To(Succeed())
+			expectNPEDaemonSet(ctx, testCtx, true)
+		})
+
+		It("prunes the DaemonSet when the numa plugin is disabled", func(ctx context.Context) {
+			Expect(setNPEEnabled(ctx, testCtx, nil)).To(Succeed())
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+			expectNPEDaemonSet(ctx, testCtx, true)
+
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			expectNPEDaemonSet(ctx, testCtx, false)
+		})
+	})
+}
+
+// setNPEEnabled sets the kaiconfig tri-state for the NUMA placement exporter (nil = auto).
+func setNPEEnabled(ctx context.Context, testCtx *testcontext.TestContext, enabled *bool) error {
+	return configurations.PatchKAIConfig(ctx, testCtx, func(c *kaiv1.Config) {
+		if c.Spec.NumaPlacementExporter == nil {
+			c.Spec.NumaPlacementExporter = &npeapi.NumaPlacementExporter{}
+		}
+		if c.Spec.NumaPlacementExporter.Service == nil {
+			c.Spec.NumaPlacementExporter.Service = &common.Service{}
+		}
+		c.Spec.NumaPlacementExporter.Service.Enabled = enabled
+	})
+}

--- a/test/e2e/suites/numa/preempt_specs_test.go
+++ b/test/e2e/suites/numa/preempt_specs_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	e2econstant "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/constant"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
+	numautil "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/numa"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
+)
+
+// DescribeNUMAPreemptSpecs asserts NUMA constraints are honored when a higher-priority pod preempts:
+// preemption frees a zone the preemptor can then occupy.
+func DescribeNUMAPreemptSpecs() bool {
+	return Describe("NUMA preempt", Ordered, Serial, Label("numa"), func() {
+		var (
+			testCtx      *testcontext.TestContext
+			lowPriority  string
+			highPriority string
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+
+			lowPriority = utils.GenerateRandomK8sName(10)
+			highPriority = utils.GenerateRandomK8sName(10)
+			_, err := testCtx.KubeClientset.SchedulingV1().PriorityClasses().Create(
+				ctx, rd.CreatePriorityClass(lowPriority, e2econstant.NonPreemptiblePriorityThreshold/4), metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			_, err = testCtx.KubeClientset.SchedulingV1().PriorityClasses().Create(
+				ctx, rd.CreatePriorityClass(highPriority, e2econstant.NonPreemptiblePriorityThreshold/2), metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+		})
+
+		AfterAll(func(ctx context.Context) {
+			Expect(rd.DeleteAllE2EPriorityClasses(ctx, testCtx.ControllerClient)).To(Succeed())
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			testCtx.ClusterCleanup(ctx)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			testCtx.TestContextCleanup(ctx)
+		})
+
+		It("high-priority pod preempts a single victim to open a NUMA zone", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := numautil.RequireNodes(ctx, testCtx.ControllerClient,
+				numautil.Requirement{Modeled: true, MinZones: 2, ZoneGPUs: 1})[0]
+
+			zoneGPUs, ok := node.OneZoneGPUs()
+			if !ok {
+				Skip("no GPU-bearing zone on the discovered node")
+			}
+			// Need >=2 GPUs per zone: after freeing one GPU per zone a zone still holds a victim, and the
+			// two-GPU preemptor needs a zone that can hold two once a victim is evicted.
+			if zoneGPUs < 2 {
+				Skip("need at least two GPUs per zone")
+			}
+			const preemptorGPUs = 2
+			total := int(node.TotalGPUs())
+
+			parent, child := gpuQueues(float64(total))
+			testCtx.InitQueues([]*v2.Queue{child, parent})
+
+			// Fill every GPU with a single-GPU low-priority pod
+			fillers := make([]*v1.Pod, 0, total)
+			for range total {
+				pod := node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), 1))
+				pod.Spec.PriorityClassName = lowPriority
+				fillers = append(fillers, createPod(ctx, testCtx, pod))
+			}
+			for _, pod := range fillers {
+				wait.ForPodScheduled(ctx, testCtx.ControllerClient, pod)
+			}
+
+			// Delete one filler per zone, leaving exactly one free GPU in each zone.
+			victimByZone := map[string]*v1.Pod{}
+			for _, pod := range fillers {
+				zones := awaitObservedZones(ctx, testCtx, pod)
+				if len(zones) != 1 {
+					continue
+				}
+				if _, seen := victimByZone[zones[0].Zone]; !seen {
+					victimByZone[zones[0].Zone] = pod
+				}
+			}
+			Expect(len(victimByZone)).To(BeNumerically(">=", 2), "fillers should cover at least two zones")
+
+			freed := map[string]bool{}
+			for _, pod := range victimByZone {
+				Expect(testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Delete(
+					ctx, pod.Name, metav1.DeleteOptions{})).To(Succeed())
+				freed[pod.Name] = true
+			}
+			remaining := make([]*v1.Pod, 0, total)
+			for _, pod := range fillers {
+				if !freed[pod.Name] {
+					remaining = append(remaining, pod)
+				}
+			}
+			// Wait for the freed GPUs to be released before submitting the preemptor.
+			for _, pod := range victimByZone {
+				p := pod
+				Eventually(func(g Gomega) {
+					_, err := testCtx.KubeClientset.CoreV1().Pods(p.Namespace).Get(ctx, p.Name, metav1.GetOptions{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}, reconcileTimeout, reconcilePoll).Should(Succeed())
+			}
+
+			highPod := node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), preemptorGPUs))
+			highPod.Spec.PriorityClassName = highPriority
+			created := createPod(ctx, testCtx, highPod)
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, created)
+
+			// Assert on the preemption: the preemptor should have evicted exactly one more victim to fit in
+			// a zone.
+			Eventually(func(g Gomega) {
+				evicted := 0
+				for _, pod := range remaining {
+					_, err := testCtx.KubeClientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					if apierrors.IsNotFound(err) {
+						evicted++
+					}
+				}
+				g.Expect(evicted).To(Equal(1), "exactly one additional victim should be preempted")
+			}, reconcileTimeout, reconcilePoll).Should(Succeed())
+		})
+	})
+}

--- a/test/e2e/suites/numa/qos_specs_test.go
+++ b/test/e2e/suites/numa/qos_specs_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
+	numautil "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/numa"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
+)
+
+// DescribeNUMAQoSSpecs asserts that only Guaranteed pods are subject to NUMA alignment: a Guaranteed pod
+// with a cross-zone request is filtered, while Burstable/BestEffort equivalents pass through.
+func DescribeNUMAQoSSpecs() bool {
+	return Describe("NUMA QoS gating", Ordered, Serial, Label("numa", "nightly"), func() {
+		var testCtx *testcontext.TestContext
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			parent, child := gpuQueues(64)
+			testCtx.InitQueues([]*v2.Queue{child, parent})
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+		})
+
+		AfterAll(func(ctx context.Context) {
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			testCtx.ClusterCleanup(ctx)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			testCtx.TestContextCleanup(ctx)
+		})
+
+		It("Guaranteed cross-zone request is filtered", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicySingleNUMANode, MinZones: 2})
+			gpus, ok := node.SpanTwoZonesGPUs()
+			if !ok {
+				Skip("no single-numa-node node can express a two-zone-spanning request")
+			}
+			pod := createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(childQueue(testCtx), gpus)))
+			expectGuaranteed(ctx, testCtx, pod)
+			wait.ForPodUnschedulable(ctx, testCtx.ControllerClient, pod)
+		})
+
+		It("Burstable cross-zone request passes through", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicySingleNUMANode, MinZones: 2})
+			gpus, ok := node.SpanTwoZonesGPUs()
+			if !ok {
+				Skip("no single-numa-node node can express a two-zone-spanning request")
+			}
+			// Burstable: GPU limit without matching CPU/memory requests==limits.
+			pod := node.Pin(rd.CreatePodObject(childQueue(testCtx), v1.ResourceRequirements{
+				Limits:   v1.ResourceList{constants.NvidiaGpuResource: *resource.NewQuantity(gpus, resource.DecimalSI)},
+				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")},
+			}))
+			created := createPod(ctx, testCtx, pod)
+			expectNotGuaranteed(ctx, testCtx, created)
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, created)
+		})
+
+		It("BestEffort pod passes through", func(ctx context.Context) {
+			node := firstMatch(ctx, testCtx, numautil.Requirement{Policy: numautil.PolicySingleNUMANode})
+			pod := createPod(ctx, testCtx, node.Pin(rd.CreatePodObject(childQueue(testCtx), v1.ResourceRequirements{})))
+			expectNotGuaranteed(ctx, testCtx, pod)
+			wait.ForPodScheduled(ctx, testCtx.ControllerClient, pod)
+		})
+	})
+}

--- a/test/e2e/suites/numa/reclaim_specs_test.go
+++ b/test/e2e/suites/numa/reclaim_specs_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
+	numautil "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/numa"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
+)
+
+// DescribeNUMAReclaimSpecs asserts NUMA constraints are honored when a queue reclaims resources: the
+// reclaimer's Guaranteed pod only schedules on zones the reclaim actually frees. Restricted is covered
+// for single-zone (width 1) and multi-zone (width 2) reclaimers, including fragmented victims and gangs.
+func DescribeNUMAReclaimSpecs() bool {
+	return Describe("NUMA reclaim", Ordered, Serial, Label("numa", "nightly"), func() {
+		var testCtx *testcontext.TestContext
+
+		BeforeAll(func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			Expect(feature_flags.EnableNUMA(ctx, testCtx, nil)).To(Succeed())
+		})
+
+		AfterAll(func(ctx context.Context) {
+			Expect(feature_flags.DisableNUMA(ctx, testCtx)).To(Succeed())
+			testCtx.ClusterCleanup(ctx)
+		})
+
+		AfterEach(func(ctx context.Context) {
+			testCtx.TestContextCleanup(ctx)
+		})
+
+		It("single-numa-node - reclaim frees one zone width 1", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := reclaimNode(ctx, testCtx, numautil.PolicySingleNUMANode)
+			zone := node.MaxZoneGPUs()
+			runReclaim(ctx, testCtx, node, zone, zone)
+		})
+
+		It("restricted - reclaim frees one zone width 1", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := reclaimNode(ctx, testCtx, numautil.PolicyRestricted)
+			zone := node.MaxZoneGPUs()
+			runReclaim(ctx, testCtx, node, zone, zone)
+		})
+
+		It("restricted - two-zone reclaim from full-zone victims width 2", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := reclaimNode(ctx, testCtx, numautil.PolicyRestricted)
+			zone := node.MaxZoneGPUs()
+			// One full-zone victim per zone; a (zone+1)-GPU reclaimer must evict a victim from each zone.
+			runReclaim(ctx, testCtx, node, zone, zone+1)
+		})
+
+		It("restricted - two-zone reclaim from fragmented victims width 2", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := reclaimNode(ctx, testCtx, numautil.PolicyRestricted)
+			zone := node.MaxZoneGPUs()
+			// Single-GPU victims spread across both zones; the reclaimer partially drains each zone.
+			runReclaim(ctx, testCtx, node, 1, zone+1)
+		})
+
+		It("restricted - full-node reclaim across both zones width 2", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := reclaimNode(ctx, testCtx, numautil.PolicyRestricted)
+			runReclaim(ctx, testCtx, node, node.MaxZoneGPUs(), node.TotalGPUs())
+		})
+
+		It("restricted - gang reclaim spanning both zones", func(ctx context.Context) {
+			testCtx = testcontext.GetConnectivity(ctx, Default)
+			node := reclaimNode(ctx, testCtx, numautil.PolicyRestricted)
+			runGangReclaim(ctx, testCtx, node)
+		})
+	})
+}
+
+func reclaimNode(ctx context.Context, testCtx *testcontext.TestContext, policy string) numautil.Node {
+	return numautil.RequireNodes(ctx, testCtx.ControllerClient,
+		numautil.Requirement{Policy: policy, MinZones: 2, ZoneGPUs: 1})[0]
+}
+
+// runReclaim fills a node's GPUs with victimGPUs-sized pods from an over-quota reclaimee queue, then
+// submits a single reclaimerGPUs-sized pod in an under-quota queue and asserts the scheduler reclaims to
+// place it. The reclaimer spans one zone when it fits a zone, two zones otherwise. Only the reclaimer's
+// placement is asserted (zone count + total GPU); victim eviction order is not deterministic.
+func runReclaim(ctx context.Context, testCtx *testcontext.TestContext, node numautil.Node, victimGPUs, reclaimerGPUs int64) {
+	maxZone := node.MaxZoneGPUs()
+	total := node.TotalGPUs()
+	if victimGPUs < 1 || victimGPUs > maxZone {
+		Skip("victim size must fit within a single zone")
+	}
+	if reclaimerGPUs < 1 || reclaimerGPUs > total {
+		Skip("reclaimer must fit within the node's GPU capacity")
+	}
+	if total%victimGPUs != 0 {
+		Skip("victim size does not evenly fill the node")
+	}
+	fillerCount := int(total / victimGPUs)
+	if fillerCount < 2 {
+		Skip("need at least two victims to occupy both zones")
+	}
+
+	wantZones := 1
+	if reclaimerGPUs > maxZone {
+		wantZones = 2
+	}
+
+	// Entitle the reclaimer to the whole node, not just reclaimerGPUs: with full-zone atomic victims a
+	// width-2 reclaimer must evict a whole victim per zone (up to `total` GPUs) to place its request, so
+	// a reclaimerGPUs-sized quota would stop reclaim early and leave a surviving victim that pushes the
+	// parent over its limit. The pod still only requests reclaimerGPUs; reclaimee stays fully reclaimable.
+	parent, reclaimee, reclaimer := gpuQueuesTriple(float64(total), 0, float64(total))
+	testCtx.InitQueues([]*v2.Queue{reclaimee, reclaimer, parent})
+
+	fillNode(ctx, testCtx, node, reclaimee, victimGPUs, fillerCount)
+
+	reclaimerPod := createPod(ctx, testCtx, reclaimerPodFor(node, reclaimer, reclaimerGPUs, wantZones))
+	wait.ForPodScheduled(ctx, testCtx.ControllerClient, reclaimerPod)
+	expectGPUPlacement(ctx, testCtx, reclaimerPod, wantZones, reclaimerGPUs)
+}
+
+// runGangReclaim fills every zone from a reclaimee queue, then submits a gang of one full-zone pod per
+// zone. The gang schedules only if reclaim frees every zone; the pods must land in distinct zones.
+func runGangReclaim(ctx context.Context, testCtx *testcontext.TestContext, node numautil.Node) {
+	maxZone := node.MaxZoneGPUs()
+	total := node.TotalGPUs()
+	podCount := int(total / maxZone)
+	if podCount < 2 || maxZone < 1 {
+		Skip("need at least two full zones for a cross-zone gang")
+	}
+
+	parent, reclaimee, reclaimer := gpuQueuesTriple(float64(total), 0, float64(total))
+	testCtx.InitQueues([]*v2.Queue{reclaimee, reclaimer, parent})
+
+	fillNode(ctx, testCtx, node, reclaimee, maxZone, podCount)
+
+	// One full-zone pod per zone, submitted as a single Job pinned to the node. The podgrouper gangs the
+	// Job (minMember = parallelism), so it schedules all-or-nothing only once reclaim frees every zone.
+	job := rd.CreateBatchJobObject(reclaimer, numautil.GuaranteedGPURequirements(maxZone))
+	job.Spec.Parallelism = ptr.To(int32(podCount))
+	job.Spec.Completions = ptr.To(int32(podCount))
+	job.Spec.Template.Spec.NodeSelector = node.HostSelector()
+	job, err := testCtx.KubeClientset.BatchV1().Jobs(job.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	Expect(err).To(Succeed())
+
+	var gangPods []v1.Pod
+	Eventually(func(g Gomega) {
+		gangPods = rd.GetJobPods(ctx, testCtx.KubeClientset, job)
+		g.Expect(gangPods).To(HaveLen(podCount))
+	}, time.Minute, time.Second).Should(Succeed())
+	for i := range gangPods {
+		wait.ForPodScheduled(ctx, testCtx.ControllerClient, &gangPods[i])
+	}
+
+	// Each gang pod fills one zone; together they must occupy distinct zones spanning the node.
+	zones := map[string]bool{}
+	for i := range gangPods {
+		observed := awaitObservedZones(ctx, testCtx, &gangPods[i])
+		Expect(observed).To(HaveLen(1))
+		Expect(observedGPUs(observed)).To(Equal(maxZone))
+		zones[observed[0].Zone] = true
+	}
+	Expect(zones).To(HaveLen(podCount), "gang pods should occupy distinct zones spanning the node")
+}
+
+func fillNode(ctx context.Context, testCtx *testcontext.TestContext, node numautil.Node, queue *v2.Queue, gpusPerPod int64, count int) {
+	fillers := make([]*v1.Pod, 0, count)
+	for range count {
+		fillers = append(fillers, createPod(ctx, testCtx, node.Pin(numautil.GuaranteedGPUPod(queue, gpusPerPod))))
+	}
+	for _, filler := range fillers {
+		wait.ForPodScheduled(ctx, testCtx.ControllerClient, filler)
+	}
+}
+
+// reclaimerPodFor builds the reclaimer. A multi-zone GPU request must also carry a width-2 CPU request:
+// otherwise its minimal CPU width (1) conflicts with the GPU width under restricted and the pod is
+// rejected before any reclaim happens.
+func reclaimerPodFor(node numautil.Node, queue *v2.Queue, gpus int64, wantZones int) *v1.Pod {
+	if wantZones < 2 {
+		return node.Pin(numautil.GuaranteedGPUPod(queue, gpus))
+	}
+	cpu, cpuOK := node.TwoZoneCPU()
+	memory, memOK := node.TwoZoneMemory()
+	if !cpuOK || !memOK {
+		Skip("cannot build a width-2 CPU/memory request on the discovered node")
+	}
+	return node.Pin(numautil.GuaranteedGPUCPUPod(queue, gpus, cpu, memory))
+}


### PR DESCRIPTION
## Description

This PR:
- Updates the fake-gpu-operator for our e2e tests and updates our yamls to the new format
- Adds e2e tests for NUMA awareness

Most new tests are labeled "nightly" to avoid adding too much latency (around 4 minutes for the whole suite vs 40s).

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
