### PR TITLE
fix(operator): scope Pod, Lease and EndpointSlice informer cache to KAI namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
+- Scoped the operator's informer cache for Pods, Leases and EndpointSlices to the KAI namespace and stripped managed fields from cached objects. Since v0.15.0 the operator cached every such object in the cluster, so its memory grew with cluster size and exceeded the default 256Mi limit on large clusters. [#1780](https://github.com/kai-scheduler/KAI-Scheduler/issues/1780)
 - Reduced transient scheduler allocations during large reclaim operations by comparing proportion queue state and cached resource vectors directly instead of repeatedly materializing resource maps.
 - Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)
 - Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)

--- a/cmd/operator/app/app.go
+++ b/cmd/operator/app/app.go
@@ -16,7 +16,12 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/operator/controller"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/operator/operands"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -69,8 +74,21 @@ func New() (*App, error) {
 	clientConfig.QPS = float32(opts.Qps)
 	clientConfig.Burst = opts.Burst
 
+	// Pods, Leases and EndpointSlices are watched only to reconcile scheduler
+	// shards, and all relevant objects live in the KAI namespace. Without this
+	// scoping the shared cache stores every such object in the cluster, and
+	// operator memory grows linearly with cluster size.
+	kaiNamespace := map[string]cache.Config{opts.Namespace: {}}
 	mgr, err := ctrl.NewManager(clientConfig, ctrl.Options{
 		Scheme: scheme,
+		Cache: cache.Options{
+			DefaultTransform: cache.TransformStripManagedFields(),
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}:                {Namespaces: kaiNamespace},
+				&coordinationv1.Lease{}:      {Namespaces: kaiNamespace},
+				&discoveryv1.EndpointSlice{}: {Namespaces: kaiNamespace},
+			},
+		},
 		Metrics: server.Options{
 			BindAddress: opts.MetricsAddr,
 		},


### PR DESCRIPTION
## Description

Since #1593 (first released in v0.15.0), the SchedulingShard controller watches Pods, Leases and EndpointSlices. The manager cache has no scoping, so the operator caches every such object in the cluster and its memory grows linearly with cluster size. On clusters with thousands of pods this exceeds the default 256Mi limit and the operator gets OOMKilled on upgrade.

All objects these watches actually need live in the KAI namespace, so this PR scopes the cache for the three types to the namespace passed via `--namespace`, and strips managed fields from cached objects.

Measured on a kind cluster with 3,000 inert pending pods (~9KB each), container working set:

| operator | pods in cluster | memory |
|---|---|---|
| v0.14.6 | 3,030 | ~28MB, flat |
| v0.16.2 | ~30 | ~29MB |
| v0.16.2 | 3,030 | ~95MB (grew incrementally), ~128MB after restart |
| v0.16.2 + this fix | 3,030 | ~30MB, flat |

The restart case matches the OOMKill-on-upgrade pattern from the issue: the initial LIST of all pods lands at once.

Functional check with the fix: deleting the scheduler pod still triggers a SchedulingShard reconcile through the namespace-scoped Pod watch, and the shard's Available condition transitions correctly — the code path the watches were added for in #1593.

## Related Issues

Fixes #1780

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None. If `Config.spec.namespace` is set to a namespace different from the operator's `--namespace` flag (the Helm chart always sets both to the release namespace), shard pod/lease/endpointslice events from that namespace would no longer trigger reconciles.

## Additional Notes

Memory also validated to stay flat regardless of cluster pod count, so the default 256Mi limit is sufficient again after this change.