### PR TITLE
perf(scheduler): cache victim candidates across scenario probes

### DIFF
--- a/.changes/unreleased/fixed-20260723-135338.yaml
+++ b/.changes/unreleased/fixed-20260723-135338.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Avoid repeated victim candidate allocations during reclaim, preempt, and unlimited-candidate consolidation searches [#1850](https://github.com/kai-scheduler/KAI-Scheduler/issues/1850)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-
-### Added
-- Added `global.resourceReservation.createNamespace` Helm value (default `true`) to allow disabling creation of the resource-reservation namespace, for embedding KAI in a parent chart that creates the namespace itself.
-- Added `global.resourceReservation.createServiceAccount` Helm value (default `true`) to allow disabling creation of the resource-reservation ServiceAccount, for embedding KAI in a parent chart that creates the ServiceAccount itself.
-- Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
-- Added GitOps/ArgoCD install support ([guide](docs/gitops/README.md)): `kaiConfig.render` Helm value (default `false`) renders the `kai-config` Config CR inline as a tracked release resource (mutually exclusive with `kaiConfigDeployer.enabled`), `openshift` value (default `false`) forces OpenShift mode where `lookup` auto-detection is unavailable under offline rendering, and ArgoCD `PostDelete` hook and `Prune=false` annotations (requires ArgoCD >= 2.10). [#1794](https://github.com/kai-scheduler/KAI-Scheduler/issues/1794) [#1751](https://github.com/kai-scheduler/KAI-Scheduler/issues/1751)
-- Added **topology level aliases**: a `Topology` level may declare an `alias` (e.g. `rack`), usable in place of the raw node label key in a workload's `requiredTopologyLevel`/`preferredTopologyLevel`. Aliases are one-to-one (unique within the Topology and must not collide with a `nodeLabel`, enforced by a new Topology validating webhook) and may be edited freely (the `levels` immutability rule now freezes only the `nodeLabel` structure). When a level has no alias, behavior is unchanged and raw label keys keep working. [#1498](https://github.com/kai-scheduler/KAI-Scheduler/issues/1498)
-
-### Changed
-- Scenario search now skips re-simulating equivalent victim-set candidates that already failed simulation for the same pending job (reclaim, preempt, consolidation). Skipped candidates are recorded as `state="duplicate"` in `scenario_search_scenarios_total`. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
-- Removed unused `queuecontroller.certSecretName` and `admission.certSecretName` Helm values; webhook TLS secrets are created and managed by the operator (`queue-webhook-tls-secret`, `kai-admission-webhook-tls-secret`). [#1791](https://github.com/kai-scheduler/KAI-Scheduler/pull/1791) [dttung2905](https://github.com/dttung2905)
-- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
-- Reduced reclaim solver allocation churn by caching victim candidates for each job solve while rebuilding mutable queue state for every scenario generator.
-- Reduced preempt solver allocation churn by caching victim candidates for each job solve while preserving fresh queue state and active-job filtering.
-- Reduced consolidation solver allocation churn in unlimited-candidate mode while preserving finite candidate-limit behavior.
-
-### Fixed
-- Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
-- Scoped the operator's informer cache for Pods, Leases and EndpointSlices to the KAI namespace and stripped managed fields from cached objects. Since v0.15.0 the operator cached every such object in the cluster, so its memory grew with cluster size and exceeded the default 256Mi limit on large clusters. [#1780](https://github.com/kai-scheduler/KAI-Scheduler/issues/1780)
-- Reduced transient scheduler allocations during large reclaim operations by comparing proportion queue state and cached resource vectors directly instead of repeatedly materializing resource maps.
-- Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)
-- Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)
-- Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)
-- Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.
-- Scheduler cache now filters terminal Pods at watch time to reduce memory use, while still watching Pods bound by other schedulers so their resource usage is counted in allocatable calculations. [#1645](https://github.com/kai-scheduler/KAI-Scheduler/issues/1645) [enoodle](https://github.com/enoodle)
-- Fix the MinNodeGPUMemoryMiB calculation in the scheduler. This affected allocations for fractional pod requesting gpu "gpu-memory". [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)
-- Use the maximum gpu size ine the cluster rather then the minimum when checking a potential overLimit or isNonPreemptebleOverquota for a pod. [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)
-- Reduced allocation churn in the scheduler hot path: cached `Schedulable()` result as a package-level singleton and lazily formatted `logNodeSetsPluginResult` node names only when verbose logging is enabled.
-- Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
-- In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
-- Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)
-- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
-
-
 ## [v0.16.0] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed unused `queuecontroller.certSecretName` and `admission.certSecretName` Helm values; webhook TLS secrets are created and managed by the operator (`queue-webhook-tls-secret`, `kai-admission-webhook-tls-secret`). [#1791](https://github.com/kai-scheduler/KAI-Scheduler/pull/1791) [dttung2905](https://github.com/dttung2905)
 - Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 - Reduced reclaim solver allocation churn by caching victim candidates for each job solve while rebuilding mutable queue state for every scenario generator.
+- Reduced preempt solver allocation churn by caching victim candidates for each job solve while preserving fresh queue state and active-job filtering.
 
 ### Fixed
 - Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
 - Reduced reclaim solver allocation churn by caching victim candidates for each job solve while rebuilding mutable queue state for every scenario generator.
 - Reduced preempt solver allocation churn by caching victim candidates for each job solve while preserving fresh queue state and active-job filtering.
+- Reduced consolidation solver allocation churn in unlimited-candidate mode while preserving finite candidate-limit behavior.
 
 ### Fixed
 - Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- Added `global.resourceReservation.createNamespace` Helm value (default `true`) to allow disabling creation of the resource-reservation namespace, for embedding KAI in a parent chart that creates the namespace itself.
+- Added `global.resourceReservation.createServiceAccount` Helm value (default `true`) to allow disabling creation of the resource-reservation ServiceAccount, for embedding KAI in a parent chart that creates the ServiceAccount itself.
+- Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
+- Added GitOps/ArgoCD install support ([guide](docs/gitops/README.md)): `kaiConfig.render` Helm value (default `false`) renders the `kai-config` Config CR inline as a tracked release resource (mutually exclusive with `kaiConfigDeployer.enabled`), `openshift` value (default `false`) forces OpenShift mode where `lookup` auto-detection is unavailable under offline rendering, and ArgoCD `PostDelete` hook and `Prune=false` annotations (requires ArgoCD >= 2.10). [#1794](https://github.com/kai-scheduler/KAI-Scheduler/issues/1794) [#1751](https://github.com/kai-scheduler/KAI-Scheduler/issues/1751)
+- Added **topology level aliases**: a `Topology` level may declare an `alias` (e.g. `rack`), usable in place of the raw node label key in a workload's `requiredTopologyLevel`/`preferredTopologyLevel`. Aliases are one-to-one (unique within the Topology and must not collide with a `nodeLabel`, enforced by a new Topology validating webhook) and may be edited freely (the `levels` immutability rule now freezes only the `nodeLabel` structure). When a level has no alias, behavior is unchanged and raw label keys keep working. [#1498](https://github.com/kai-scheduler/KAI-Scheduler/issues/1498)
+
+### Changed
+- Scenario search now skips re-simulating equivalent victim-set candidates that already failed simulation for the same pending job (reclaim, preempt, consolidation). Skipped candidates are recorded as `state="duplicate"` in `scenario_search_scenarios_total`. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
+- Removed unused `queuecontroller.certSecretName` and `admission.certSecretName` Helm values; webhook TLS secrets are created and managed by the operator (`queue-webhook-tls-secret`, `kai-admission-webhook-tls-secret`). [#1791](https://github.com/kai-scheduler/KAI-Scheduler/pull/1791) [dttung2905](https://github.com/dttung2905)
+- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
+- Reduced reclaim solver allocation churn by caching victim candidates for each job solve while rebuilding mutable queue state for every scenario generator.
+
+### Fixed
+- Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
+- Scoped the operator's informer cache for Pods, Leases and EndpointSlices to the KAI namespace and stripped managed fields from cached objects. Since v0.15.0 the operator cached every such object in the cluster, so its memory grew with cluster size and exceeded the default 256Mi limit on large clusters. [#1780](https://github.com/kai-scheduler/KAI-Scheduler/issues/1780)
+- Reduced transient scheduler allocations during large reclaim operations by comparing proportion queue state and cached resource vectors directly instead of repeatedly materializing resource maps.
+- Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)
+- Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)
+- Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)
+- Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.
+- Scheduler cache now filters terminal Pods at watch time to reduce memory use, while still watching Pods bound by other schedulers so their resource usage is counted in allocatable calculations. [#1645](https://github.com/kai-scheduler/KAI-Scheduler/issues/1645) [enoodle](https://github.com/enoodle)
+- Fix the MinNodeGPUMemoryMiB calculation in the scheduler. This affected allocations for fractional pod requesting gpu "gpu-memory". [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)
+- Use the maximum gpu size ine the cluster rather then the minimum when checking a potential overLimit or isNonPreemptebleOverquota for a pod. [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)
+- Reduced allocation churn in the scheduler hot path: cached `Schedulable()` result as a package-level singleton and lazily formatted `logNodeSetsPluginResult` node names only when verbose logging is enabled.
+- Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
+
+
 ## [v0.16.0] - 2026-06-24
 
 ### Added

--- a/pkg/scheduler/actions/consolidation/consolidation.go
+++ b/pkg/scheduler/actions/consolidation/consolidation.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
 const noConsolidationPreempteesRestrcition = -1
@@ -172,23 +171,17 @@ func getOrderedVictimsQueue(ssn *framework.Session, preemptor *podgroup_info.Pod
 		}
 	}
 
-	// Unlimited candidate results stay stable for one solver run; mutable queue state is rebuilt per generator.
-	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
-	return func() *utils.JobsOrderByQueues {
-		if candidates == nil {
+	return utils.NewCachedVictimsQueueGenerator(
+		ssn,
+		func() map[common_info.PodGroupID]*podgroup_info.PodGroupInfo {
 			filter := buildPreemptibleFilterFunc(preemptor, maxPreempteesToTest)
-			candidates = utils.GetVictimCandidates(ssn, filter)
-		}
-
-		victimsQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
+			return utils.GetVictimCandidates(ssn, filter)
+		},
+		utils.JobsOrderInitOptions{
 			FilterNonPreemptible:     true,
 			FilterNonActiveAllocated: true,
-			VictimQueue:              true,
-			MaxJobsQueueDepth:        scheduler_util.QueueCapacityInfinite,
-		})
-		victimsQueue.InitializeWithJobs(candidates)
-		return &victimsQueue
-	}
+		},
+	)
 }
 
 func buildPreemptibleFilterFunc(preemptor *podgroup_info.PodGroupInfo, maxPreempteesToTest int) func(*podgroup_info.PodGroupInfo) bool {

--- a/pkg/scheduler/actions/consolidation/consolidation.go
+++ b/pkg/scheduler/actions/consolidation/consolidation.go
@@ -10,11 +10,13 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
 const noConsolidationPreempteesRestrcition = -1
@@ -116,7 +118,7 @@ func attemptToConsolidatePreemptor(
 	solver := solvers.NewJobsSolver(
 		feasibleNodes,
 		allPodsReallocated,
-		func() *utils.JobsOrderByQueues { return buildConsolidationVictimsQueue(ssn, preemptor) },
+		getOrderedVictimsQueue(ssn, preemptor),
 		framework.Consolidation,
 		actionBudget)
 
@@ -160,6 +162,33 @@ func allPodsReallocated(scenario api.ScenarioInfo) bool {
 func buildConsolidationVictimsQueue(ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo) *utils.JobsOrderByQueues {
 	filter := buildPreemptibleFilterFunc(preemptor, ssn.GetMaxNumberConsolidationPreemptees())
 	return utils.GetVictimsQueue(ssn, filter)
+}
+
+func getOrderedVictimsQueue(ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo) solvers.GenerateVictimsQueue {
+	maxPreempteesToTest := ssn.GetMaxNumberConsolidationPreemptees()
+	if maxPreempteesToTest != noConsolidationPreempteesRestrcition {
+		return func() *utils.JobsOrderByQueues {
+			return buildConsolidationVictimsQueue(ssn, preemptor)
+		}
+	}
+
+	// Unlimited candidate results stay stable for one solver run; mutable queue state is rebuilt per generator.
+	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
+	return func() *utils.JobsOrderByQueues {
+		if candidates == nil {
+			filter := buildPreemptibleFilterFunc(preemptor, maxPreempteesToTest)
+			candidates = utils.GetVictimCandidates(ssn, filter)
+		}
+
+		victimsQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
+			FilterNonPreemptible:     true,
+			FilterNonActiveAllocated: true,
+			VictimQueue:              true,
+			MaxJobsQueueDepth:        scheduler_util.QueueCapacityInfinite,
+		})
+		victimsQueue.InitializeWithJobs(candidates)
+		return &victimsQueue
+	}
 }
 
 func buildPreemptibleFilterFunc(preemptor *podgroup_info.PodGroupInfo, maxPreempteesToTest int) func(*podgroup_info.PodGroupInfo) bool {

--- a/pkg/scheduler/actions/consolidation/consolidation_victim_queue_test.go
+++ b/pkg/scheduler/actions/consolidation/consolidation_victim_queue_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package consolidation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestOrderedVictimsQueueCachesUnlimitedCandidateSnapshot(t *testing.T) {
+	ssn, preemptor, originalVictim, queueID := newConsolidationVictimQueueTestSession()
+	ssn.OverrideMaxNumberConsolidationPreemptees(noConsolidationPreempteesRestrcition)
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, preemptor)
+	firstQueue := generateVictimsQueue()
+	require.Same(t, originalVictim, firstQueue.PopNextJob())
+
+	newVictim, _ := newConsolidationVictimQueueTestJob("new-victim", queueID, v1.PodRunning)
+	ssn.ClusterInfo.PodGroupInfos[newVictim.UID] = newVictim
+	secondQueue := generateVictimsQueue()
+
+	require.NotSame(t, firstQueue, secondQueue)
+	require.Equal(t, 1, secondQueue.Len())
+	require.Same(t, originalVictim, secondQueue.PopNextJob())
+	require.True(t, secondQueue.IsEmpty())
+}
+
+func TestOrderedVictimsQueueRechecksActiveState(t *testing.T) {
+	ssn, preemptor, originalVictim, _ := newConsolidationVictimQueueTestSession()
+	ssn.OverrideMaxNumberConsolidationPreemptees(noConsolidationPreempteesRestrcition)
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, preemptor)
+	firstQueue := generateVictimsQueue()
+	require.Same(t, originalVictim, firstQueue.PopNextJob())
+
+	var victimTask *pod_info.PodInfo
+	for _, task := range originalVictim.GetAllPodsMap() {
+		victimTask = task
+		break
+	}
+	require.NotNil(t, victimTask)
+	require.NoError(t, originalVictim.UpdateTaskStatus(victimTask, pod_status.Succeeded))
+
+	secondQueue := generateVictimsQueue()
+	require.True(t, secondQueue.IsEmpty())
+}
+
+func TestOrderedVictimsQueueRescansCandidatesWithFiniteLimit(t *testing.T) {
+	ssn, preemptor, _, queueID := newConsolidationVictimQueueTestSession()
+	ssn.OverrideMaxNumberConsolidationPreemptees(10)
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, preemptor)
+	firstQueue := generateVictimsQueue()
+	require.Equal(t, 1, firstQueue.Len())
+
+	newVictim, _ := newConsolidationVictimQueueTestJob("new-victim", queueID, v1.PodRunning)
+	ssn.ClusterInfo.PodGroupInfos[newVictim.UID] = newVictim
+	secondQueue := generateVictimsQueue()
+
+	require.Equal(t, 2, secondQueue.Len())
+}
+
+func newConsolidationVictimQueueTestSession() (
+	*framework.Session,
+	*podgroup_info.PodGroupInfo,
+	*podgroup_info.PodGroupInfo,
+	common_info.QueueID,
+) {
+	queueID := common_info.QueueID("consolidation-queue")
+	preemptor, _ := newConsolidationVictimQueueTestJob("preemptor", queueID, v1.PodPending)
+	originalVictim, _ := newConsolidationVictimQueueTestJob("original-victim", queueID, v1.PodRunning)
+
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+				preemptor.UID:      preemptor,
+				originalVictim.UID: originalVictim,
+			},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				queueID: {UID: queueID, Name: string(queueID)},
+			},
+			Nodes: map[string]*node_info.NodeInfo{"node-0": nil},
+		},
+	}
+	return ssn, preemptor, originalVictim, queueID
+}
+
+func newConsolidationVictimQueueTestJob(
+	name string,
+	queueID common_info.QueueID,
+	phase v1.PodPhase,
+) (*podgroup_info.PodGroupInfo, *pod_info.PodInfo) {
+	pod := common_info.BuildPod(
+		"consolidation-victim-queue-test",
+		name+"-pod",
+		"node-0",
+		phase,
+		common_info.BuildResourceList("1", "1Gi"),
+		nil,
+		nil,
+		nil,
+	)
+	task := pod_info.NewTaskInfo(pod, resource_info.NewResourceVectorMap())
+	job := podgroup_info.NewPodGroupInfo(common_info.PodGroupID(name), task)
+	job.Name = name
+	job.Queue = queueID
+	job.Preemptibility = schedulingv2alpha2.Preemptible
+	return job, task
+}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
 type preemptAction struct {
@@ -178,9 +179,20 @@ func buildFilterFuncForPreempt(ssn *framework.Session, preemptor *podgroup_info.
 }
 
 func getOrderedVictimsQueue(ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo) solvers.GenerateVictimsQueue {
+	// Victim filter results stay stable for one solver run; mutable queue state is rebuilt per generator.
+	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
 	return func() *utils.JobsOrderByQueues {
-		filter := buildFilterFuncForPreempt(ssn, preemptor)
-		victimsQueue := utils.GetVictimsQueue(ssn, filter)
-		return victimsQueue
+		if candidates == nil {
+			candidates = utils.GetVictimCandidates(ssn, buildFilterFuncForPreempt(ssn, preemptor))
+		}
+
+		victimsQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
+			FilterNonPreemptible:     true,
+			FilterNonActiveAllocated: true,
+			VictimQueue:              true,
+			MaxJobsQueueDepth:        scheduler_util.QueueCapacityInfinite,
+		})
+		victimsQueue.InitializeWithJobs(candidates)
+		return &victimsQueue
 	}
 }

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -30,7 +30,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
 type preemptAction struct {
@@ -179,20 +178,14 @@ func buildFilterFuncForPreempt(ssn *framework.Session, preemptor *podgroup_info.
 }
 
 func getOrderedVictimsQueue(ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo) solvers.GenerateVictimsQueue {
-	// Victim filter results stay stable for one solver run; mutable queue state is rebuilt per generator.
-	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
-	return func() *utils.JobsOrderByQueues {
-		if candidates == nil {
-			candidates = utils.GetVictimCandidates(ssn, buildFilterFuncForPreempt(ssn, preemptor))
-		}
-
-		victimsQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
+	return utils.NewCachedVictimsQueueGenerator(
+		ssn,
+		func() map[common_info.PodGroupID]*podgroup_info.PodGroupInfo {
+			return utils.GetVictimCandidates(ssn, buildFilterFuncForPreempt(ssn, preemptor))
+		},
+		utils.JobsOrderInitOptions{
 			FilterNonPreemptible:     true,
 			FilterNonActiveAllocated: true,
-			VictimQueue:              true,
-			MaxJobsQueueDepth:        scheduler_util.QueueCapacityInfinite,
-		})
-		victimsQueue.InitializeWithJobs(candidates)
-		return &victimsQueue
-	}
+		},
+	)
 }

--- a/pkg/scheduler/actions/preempt/preempt_victim_queue_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_victim_queue_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package preempt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestOrderedVictimsQueueCachesCandidatesPerPreemptor(t *testing.T) {
+	ssn, preemptor, acceptedVictim, _ := newPreemptVictimQueueTestSession()
+	filterCalls := 0
+	ssn.AddPreemptVictimFilterFn(func(_ *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+		filterCalls++
+		return victim == acceptedVictim
+	})
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, preemptor)
+	firstQueue := generateVictimsQueue()
+	secondQueue := generateVictimsQueue()
+
+	require.NotSame(t, firstQueue, secondQueue)
+	require.Same(t, acceptedVictim, firstQueue.PopNextJob())
+	require.Same(t, acceptedVictim, secondQueue.PopNextJob())
+	require.True(t, firstQueue.IsEmpty())
+	require.True(t, secondQueue.IsEmpty())
+	require.Equal(t, 2, filterCalls)
+}
+
+func TestOrderedVictimsQueueRechecksActiveState(t *testing.T) {
+	ssn, preemptor, acceptedVictim, _ := newPreemptVictimQueueTestSession()
+	filterCalls := 0
+	ssn.AddPreemptVictimFilterFn(func(_ *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+		filterCalls++
+		return victim == acceptedVictim
+	})
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, preemptor)
+	firstQueue := generateVictimsQueue()
+	require.Same(t, acceptedVictim, firstQueue.PopNextJob())
+
+	var acceptedTask *pod_info.PodInfo
+	for _, task := range acceptedVictim.GetAllPodsMap() {
+		acceptedTask = task
+		break
+	}
+	require.NotNil(t, acceptedTask)
+	require.NoError(t, acceptedVictim.UpdateTaskStatus(acceptedTask, pod_status.Succeeded))
+
+	secondQueue := generateVictimsQueue()
+	require.True(t, secondQueue.IsEmpty())
+	require.Equal(t, 2, filterCalls)
+}
+
+func BenchmarkOrderedVictimsQueueConstruction(b *testing.B) {
+	const victimCount = 1000
+
+	queueID := common_info.QueueID("preempt-queue")
+	preemptor, _ := newPreemptVictimQueueTestJob("preemptor", queueID, v1.PodPending, 100)
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+				preemptor.UID: preemptor,
+			},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				queueID: {UID: queueID, Name: string(queueID)},
+			},
+			Nodes: map[string]*node_info.NodeInfo{"node-0": nil},
+		},
+	}
+	for i := 0; i < victimCount; i++ {
+		job, _ := newPreemptVictimQueueTestJob(fmt.Sprintf("victim-%d", i), queueID, v1.PodRunning, 50)
+		ssn.ClusterInfo.PodGroupInfos[job.UID] = job
+	}
+	ssn.AddPreemptVictimFilterFn(func(_, _ *podgroup_info.PodGroupInfo) bool { return true })
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, preemptor)
+	warmQueue := generateVictimsQueue()
+	for !warmQueue.IsEmpty() {
+		warmQueue.PopNextJob()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		queue := generateVictimsQueue()
+		for !queue.IsEmpty() {
+			queue.PopNextJob()
+		}
+	}
+}
+
+func newPreemptVictimQueueTestSession() (
+	*framework.Session,
+	*podgroup_info.PodGroupInfo,
+	*podgroup_info.PodGroupInfo,
+	*podgroup_info.PodGroupInfo,
+) {
+	queueID := common_info.QueueID("preempt-queue")
+	preemptor, _ := newPreemptVictimQueueTestJob("preemptor", queueID, v1.PodPending, 100)
+	acceptedVictim, _ := newPreemptVictimQueueTestJob("accepted-victim", queueID, v1.PodRunning, 50)
+	filteredVictim, _ := newPreemptVictimQueueTestJob("filtered-victim", queueID, v1.PodRunning, 50)
+
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+				preemptor.UID:      preemptor,
+				acceptedVictim.UID: acceptedVictim,
+				filteredVictim.UID: filteredVictim,
+			},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				queueID: {UID: queueID, Name: string(queueID)},
+			},
+			Nodes: map[string]*node_info.NodeInfo{"node-0": nil},
+		},
+	}
+	return ssn, preemptor, acceptedVictim, filteredVictim
+}
+
+func newPreemptVictimQueueTestJob(
+	name string,
+	queueID common_info.QueueID,
+	phase v1.PodPhase,
+	priority int32,
+) (*podgroup_info.PodGroupInfo, *pod_info.PodInfo) {
+	pod := common_info.BuildPod(
+		"preempt-victim-queue-test",
+		name+"-pod",
+		"node-0",
+		phase,
+		common_info.BuildResourceList("1", "1Gi"),
+		nil,
+		nil,
+		nil,
+	)
+	task := pod_info.NewTaskInfo(pod, resource_info.NewResourceVectorMap())
+	job := podgroup_info.NewPodGroupInfo(common_info.PodGroupID(name), task)
+	job.Name = name
+	job.Queue = queueID
+	job.Priority = priority
+	job.Preemptibility = schedulingv2alpha2.Preemptible
+	return job, task
+}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -30,7 +30,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
 type reclaimAction struct {
@@ -144,22 +143,16 @@ func shouldStopActionForSearchResult(result *solvers.SearchResult) bool {
 }
 
 func getOrderedVictimsQueue(ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo) solvers.GenerateVictimsQueue {
-	// Victim filter results stay stable for one solver run; mutable queue state is rebuilt per generator.
-	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
-	return func() *utils.JobsOrderByQueues {
-		if candidates == nil {
-			candidates = getReclaimVictimCandidates(ssn, reclaimer)
-		}
-
-		jobsOrderedByQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
+	return utils.NewCachedVictimsQueueGenerator(
+		ssn,
+		func() map[common_info.PodGroupID]*podgroup_info.PodGroupInfo {
+			return getReclaimVictimCandidates(ssn, reclaimer)
+		},
+		utils.JobsOrderInitOptions{
 			FilterNonPreemptible:     true,
 			FilterNonActiveAllocated: true,
-			VictimQueue:              true,
-			MaxJobsQueueDepth:        scheduler_util.QueueCapacityInfinite,
-		})
-		jobsOrderedByQueue.InitializeWithJobs(candidates)
-		return &jobsOrderedByQueue
-	}
+		},
+	)
 }
 
 func getReclaimVictimCandidates(

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -144,25 +144,37 @@ func shouldStopActionForSearchResult(result *solvers.SearchResult) bool {
 }
 
 func getOrderedVictimsQueue(ssn *framework.Session, reclaimer *podgroup_info.PodGroupInfo) solvers.GenerateVictimsQueue {
+	// Victim filter results stay stable for one solver run; mutable queue state is rebuilt per generator.
+	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
 	return func() *utils.JobsOrderByQueues {
+		if candidates == nil {
+			candidates = getReclaimVictimCandidates(ssn, reclaimer)
+		}
+
 		jobsOrderedByQueue := utils.NewJobsOrderByQueues(ssn, utils.JobsOrderInitOptions{
 			FilterNonPreemptible:     true,
 			FilterNonActiveAllocated: true,
 			VictimQueue:              true,
 			MaxJobsQueueDepth:        scheduler_util.QueueCapacityInfinite,
 		})
-		jobs := map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{}
-		for _, job := range ssn.ClusterInfo.PodGroupInfos {
-			if job.Queue == reclaimer.Queue {
-				continue
-			}
-			if !ssn.ReclaimVictimFilter(reclaimer, job) {
-				continue
-			}
-			jobs[job.UID] = job
-		}
-
-		jobsOrderedByQueue.InitializeWithJobs(jobs)
+		jobsOrderedByQueue.InitializeWithJobs(candidates)
 		return &jobsOrderedByQueue
 	}
+}
+
+func getReclaimVictimCandidates(
+	ssn *framework.Session,
+	reclaimer *podgroup_info.PodGroupInfo,
+) map[common_info.PodGroupID]*podgroup_info.PodGroupInfo {
+	jobs := make(map[common_info.PodGroupID]*podgroup_info.PodGroupInfo)
+	for _, job := range ssn.ClusterInfo.PodGroupInfos {
+		if job.Queue == reclaimer.Queue {
+			continue
+		}
+		if !ssn.ReclaimVictimFilter(reclaimer, job) {
+			continue
+		}
+		jobs[job.UID] = job
+	}
+	return jobs
 }

--- a/pkg/scheduler/actions/reclaim/reclaim_victim_queue_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_victim_queue_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestOrderedVictimsQueueCachesFilteredCandidatesPerReclaimer(t *testing.T) {
+	ssn, reclaimer, acceptedVictim, _ := newVictimQueueTestSession()
+	filterCalls := 0
+	ssn.AddReclaimVictimFilterFn(func(_ *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+		filterCalls++
+		return victim == acceptedVictim
+	})
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, reclaimer)
+	firstQueue := generateVictimsQueue()
+	secondQueue := generateVictimsQueue()
+
+	require.NotSame(t, firstQueue, secondQueue)
+	require.Same(t, acceptedVictim, firstQueue.PopNextJob())
+	require.Same(t, acceptedVictim, secondQueue.PopNextJob())
+	require.True(t, firstQueue.IsEmpty())
+	require.True(t, secondQueue.IsEmpty())
+	require.Equal(t, 2, filterCalls)
+}
+
+func TestOrderedVictimsQueueRechecksDynamicJobState(t *testing.T) {
+	ssn, reclaimer, acceptedVictim, _ := newVictimQueueTestSession()
+	filterCalls := 0
+	ssn.AddReclaimVictimFilterFn(func(_ *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo) bool {
+		filterCalls++
+		return victim == acceptedVictim
+	})
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, reclaimer)
+	firstQueue := generateVictimsQueue()
+	require.Same(t, acceptedVictim, firstQueue.PopNextJob())
+
+	var acceptedTask *pod_info.PodInfo
+	for _, task := range acceptedVictim.GetAllPodsMap() {
+		acceptedTask = task
+		break
+	}
+	require.NotNil(t, acceptedTask)
+	require.NoError(t, acceptedVictim.UpdateTaskStatus(acceptedTask, pod_status.Succeeded))
+
+	secondQueue := generateVictimsQueue()
+	require.True(t, secondQueue.IsEmpty())
+	require.Equal(t, 2, filterCalls)
+}
+
+func BenchmarkOrderedVictimsQueueConstruction(b *testing.B) {
+	const (
+		victimCount = 1000
+		queueCount  = 10
+	)
+
+	reclaimerQueue := common_info.QueueID("reclaimer-queue")
+	reclaimer, _ := newVictimQueueTestJob("reclaimer", reclaimerQueue, v1.PodPending)
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+				reclaimer.UID: reclaimer,
+			},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				reclaimerQueue: {UID: reclaimerQueue, Name: string(reclaimerQueue)},
+			},
+		},
+	}
+	for i := 0; i < victimCount; i++ {
+		queueID := common_info.QueueID(fmt.Sprintf("victim-queue-%d", i%queueCount))
+		if _, found := ssn.ClusterInfo.Queues[queueID]; !found {
+			ssn.ClusterInfo.Queues[queueID] = &queue_info.QueueInfo{UID: queueID, Name: string(queueID)}
+		}
+		job, _ := newVictimQueueTestJob(fmt.Sprintf("victim-%d", i), queueID, v1.PodRunning)
+		ssn.ClusterInfo.PodGroupInfos[job.UID] = job
+	}
+	ssn.AddReclaimVictimFilterFn(func(_, _ *podgroup_info.PodGroupInfo) bool { return true })
+
+	generateVictimsQueue := getOrderedVictimsQueue(ssn, reclaimer)
+	warmQueue := generateVictimsQueue()
+	for !warmQueue.IsEmpty() {
+		warmQueue.PopNextJob()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		queue := generateVictimsQueue()
+		for !queue.IsEmpty() {
+			queue.PopNextJob()
+		}
+	}
+}
+
+func newVictimQueueTestSession() (
+	*framework.Session,
+	*podgroup_info.PodGroupInfo,
+	*podgroup_info.PodGroupInfo,
+	*podgroup_info.PodGroupInfo,
+) {
+	reclaimerQueue := common_info.QueueID("reclaimer-queue")
+	acceptedQueue := common_info.QueueID("accepted-queue")
+	filteredQueue := common_info.QueueID("filtered-queue")
+
+	reclaimer, _ := newVictimQueueTestJob("reclaimer", reclaimerQueue, v1.PodPending)
+	acceptedVictim, _ := newVictimQueueTestJob("accepted-victim", acceptedQueue, v1.PodRunning)
+	filteredVictim, _ := newVictimQueueTestJob("filtered-victim", filteredQueue, v1.PodRunning)
+	sameQueueVictim, _ := newVictimQueueTestJob("same-queue-victim", reclaimerQueue, v1.PodRunning)
+
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			PodGroupInfos: map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{
+				reclaimer.UID:       reclaimer,
+				acceptedVictim.UID:  acceptedVictim,
+				filteredVictim.UID:  filteredVictim,
+				sameQueueVictim.UID: sameQueueVictim,
+			},
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				reclaimerQueue: {UID: reclaimerQueue, Name: string(reclaimerQueue)},
+				acceptedQueue:  {UID: acceptedQueue, Name: string(acceptedQueue)},
+				filteredQueue:  {UID: filteredQueue, Name: string(filteredQueue)},
+			},
+		},
+	}
+	return ssn, reclaimer, acceptedVictim, filteredVictim
+}
+
+func newVictimQueueTestJob(
+	name string,
+	queueID common_info.QueueID,
+	phase v1.PodPhase,
+) (*podgroup_info.PodGroupInfo, *pod_info.PodInfo) {
+	pod := common_info.BuildPod(
+		"victim-queue-test",
+		name+"-pod",
+		"node-0",
+		phase,
+		common_info.BuildResourceList("1", "1Gi"),
+		nil,
+		nil,
+		nil,
+	)
+	task := pod_info.NewTaskInfo(pod, resource_info.NewResourceVectorMap())
+	job := podgroup_info.NewPodGroupInfo(common_info.PodGroupID(name), task)
+	job.Name = name
+	job.Queue = queueID
+	job.Preemptibility = schedulingv2alpha2.Preemptible
+	return job, task
+}

--- a/pkg/scheduler/actions/utils/action.go
+++ b/pkg/scheduler/actions/utils/action.go
@@ -18,6 +18,20 @@ import (
 func GetVictimsQueue(
 	ssn *framework.Session,
 	filter func(*podgroup_info.PodGroupInfo) bool) *JobsOrderByQueues {
+	preemptees := GetVictimCandidates(ssn, filter)
+	victimsQueue := NewJobsOrderByQueues(ssn, JobsOrderInitOptions{
+		VictimQueue:       true,
+		MaxJobsQueueDepth: scheduler_util.QueueCapacityInfinite,
+	})
+	victimsQueue.InitializeWithJobs(preemptees)
+	return &victimsQueue
+}
+
+// GetVictimCandidates returns jobs with at least one live pod that pass filter.
+func GetVictimCandidates(
+	ssn *framework.Session,
+	filter func(*podgroup_info.PodGroupInfo) bool,
+) map[common_info.PodGroupID]*podgroup_info.PodGroupInfo {
 	preemptees := map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{}
 
 	for _, job := range ssn.ClusterInfo.PodGroupInfos {
@@ -38,12 +52,7 @@ func GetVictimsQueue(
 			preemptees[job.UID] = job
 		}
 	}
-	victimsQueue := NewJobsOrderByQueues(ssn, JobsOrderInitOptions{
-		VictimQueue:       true,
-		MaxJobsQueueDepth: scheduler_util.QueueCapacityInfinite,
-	})
-	victimsQueue.InitializeWithJobs(preemptees)
-	return &victimsQueue
+	return preemptees
 }
 
 func GetMessageOfEviction(ssn *framework.Session, actionType framework.ActionType, preempteeTask *pod_info.PodInfo,

--- a/pkg/scheduler/actions/utils/action.go
+++ b/pkg/scheduler/actions/utils/action.go
@@ -15,16 +15,13 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
+// GetVictimsQueue discovers candidates immediately and returns one mutable victim queue.
+// Use NewCachedVictimsQueueGenerator when discovery should run once for multiple independent queues.
 func GetVictimsQueue(
 	ssn *framework.Session,
 	filter func(*podgroup_info.PodGroupInfo) bool) *JobsOrderByQueues {
 	preemptees := GetVictimCandidates(ssn, filter)
-	victimsQueue := NewJobsOrderByQueues(ssn, JobsOrderInitOptions{
-		VictimQueue:       true,
-		MaxJobsQueueDepth: scheduler_util.QueueCapacityInfinite,
-	})
-	victimsQueue.InitializeWithJobs(preemptees)
-	return &victimsQueue
+	return newVictimsQueueFromCandidates(ssn, preemptees, JobsOrderInitOptions{})
 }
 
 // GetVictimCandidates returns jobs with at least one live pod that pass filter.
@@ -53,6 +50,35 @@ func GetVictimCandidates(
 		}
 	}
 	return preemptees
+}
+
+func newVictimsQueueFromCandidates(
+	ssn *framework.Session,
+	candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo,
+	options JobsOrderInitOptions,
+) *JobsOrderByQueues {
+	options.VictimQueue = true
+	options.MaxJobsQueueDepth = scheduler_util.QueueCapacityInfinite
+	victimsQueue := NewJobsOrderByQueues(ssn, options)
+	victimsQueue.InitializeWithJobs(candidates)
+	return &victimsQueue
+}
+
+// NewCachedVictimsQueueGenerator discovers candidates once and creates a fresh mutable queue for each call.
+func NewCachedVictimsQueueGenerator(
+	ssn *framework.Session,
+	getCandidates func() map[common_info.PodGroupID]*podgroup_info.PodGroupInfo,
+	options JobsOrderInitOptions,
+) func() *JobsOrderByQueues {
+	var candidates map[common_info.PodGroupID]*podgroup_info.PodGroupInfo
+	initialized := false
+	return func() *JobsOrderByQueues {
+		if !initialized {
+			candidates = getCandidates()
+			initialized = true
+		}
+		return newVictimsQueueFromCandidates(ssn, candidates, options)
+	}
 }
 
 func GetMessageOfEviction(ssn *framework.Session, actionType framework.ActionType, preempteeTask *pod_info.PodInfo,

--- a/pkg/scheduler/actions/utils/action_test.go
+++ b/pkg/scheduler/actions/utils/action_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/queue_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestNewCachedVictimsQueueGenerator(t *testing.T) {
+	job := podGroupForJobOrderTest("victim", "victim", 1)
+	job.Queue = testQueue
+	ssn := &framework.Session{
+		ClusterInfo: &api.ClusterInfo{
+			Queues: map[common_info.QueueID]*queue_info.QueueInfo{
+				testQueue: {UID: testQueue},
+			},
+		},
+	}
+
+	discoveryCalls := 0
+	generateVictimsQueue := NewCachedVictimsQueueGenerator(
+		ssn,
+		func() map[common_info.PodGroupID]*podgroup_info.PodGroupInfo {
+			discoveryCalls++
+			return map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{job.UID: job}
+		},
+		JobsOrderInitOptions{},
+	)
+
+	firstQueue := generateVictimsQueue()
+	secondQueue := generateVictimsQueue()
+
+	require.Equal(t, 1, discoveryCalls)
+	require.NotSame(t, firstQueue, secondQueue)
+	require.Same(t, job, firstQueue.PopNextJob())
+	require.Same(t, job, secondQueue.PopNextJob())
+}


### PR DESCRIPTION
## Description

Scenario generators request a new victim queue for each solver probe. Reclaim previously rescanned every PodGroup, reevaluated victim filters, and rebuilt the candidate map on every request.

This PR caches victim candidates for the lifetime of one job solve while continuing to create fresh mutable `JobsOrderByQueues` instances for each scenario generator.

The same candidate-lifetime handling is applied to:

- Reclaim victim filtering.
- Preempt victim filtering.
- Consolidation when candidate count is unlimited.

Finite consolidation candidate limits retain their existing per-probe filtering behavior.

Dynamic job state remains checked when each queue is built, so inactive or non-preemptible jobs are not returned from a cached candidate set.

## Related Issues

Fixes #1850

Related to #1653

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [x] Updated documentation

## Breaking Changes

None.

## Additional Notes

The 100-node many-single-GPU reclaim benchmark improved from:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Runtime | 4.886 s/op | 3.491 s/op | -28.6% |
| Bytes | 3.046 GB/op | 2.192 GB/op | -28.0% |
| Allocations | 32.98M/op | 23.36M/op | -29.2% |

Verification:

```text
go test ./pkg/scheduler/actions/utils \
  ./pkg/scheduler/actions/reclaim \
  ./pkg/scheduler/actions/preempt \
  ./pkg/scheduler/actions/consolidation \
  ./pkg/scheduler/actions/integration_tests/reclaim \
  -count=1
```
