### PR TITLE
docs(metrics): add example Grafana dashboards

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,22 +1,60 @@
 # Kube-Prometheus-Stack
-install prometheus operator and enable prometheus instance (and grafana if you want):
+
+Install Prometheus Operator and enable a Prometheus instance. Enable Grafana if
+you want to import the dashboards from this directory:
+
 ```
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update prometheus-community
 helm upgrade -i --create-namespace -n monitoring kube-prometheus-stack prometheus-community/kube-prometheus-stack --values kube-prometheus-values.yaml
 ```
 
-# Service Monitors for kai services
+# Service Monitors for KAI services
 
-Install a prometheus instance and the relevant service monitors in kai-scheduler namespace:
+Install a Prometheus instance and the relevant ServiceMonitors in the
+`kai-scheduler` namespace:
 
 ```sh
 kubectl apply -f prometheus.yaml
 kubectl apply -f service-monitors.yaml
 ```
 
-To enable the prometheus as a grafana datasource, if desired, apply grafana-datasource.yaml:
+To enable the Prometheus instance as a Grafana datasource, apply
+`grafana-datasource.yaml`:
 
 ```sh
 kubectl apply -f grafana-datasource.yaml
 ```
+
+# Grafana dashboards
+
+The `grafana/` directory contains importable dashboards for scale-test deep
+dives:
+
+- `kai-scheduler-internals.json`: scheduler cycle latency, action/plugin
+  latency, scenario counters, task scheduling latency, binder latency, and
+  preemption/eviction signals.
+- `kai-queues-allocation.json`: queue allocation, quota, deserved GPU,
+  scheduler fair-share, and UsageDB usage metrics.
+- `kai-service-resources.json`: CPU, memory, throttling, restarts, readiness,
+  network, and process metrics for KAI pods.
+- `kai-controller-runtime-workqueues.json`: controller-runtime reconciliation
+  and workqueue latency/backlog metrics.
+- `kubernetes-apiserver-scale.json`: Kubernetes API server request rate,
+  latency, errors, in-flight requests, API Priority and Fairness, and
+  storage/etcd signals during scale tests.
+
+Import the dashboards manually from Grafana, or load them through the Grafana
+dashboard sidecar that is enabled in `kube-prometheus-values.yaml`:
+
+```sh
+kubectl -n monitoring create configmap kai-grafana-dashboards \
+  --from-file=grafana/ \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n monitoring label configmap kai-grafana-dashboards grafana_dashboard=1 --overwrite
+```
+
+The Kubernetes API server dashboard requires your Prometheus installation to
+scrape kube-apiserver metrics. `kube-prometheus-stack` commonly configures that
+outside of KAI ServiceMonitors. If the API server dashboard is empty, verify the
+`apiserver_request_total` metric exists in Prometheus first.

--- a/docs/metrics/grafana/kai-controller-runtime-workqueues.json
+++ b/docs/metrics/grafana/kai-controller-runtime-workqueues.json
@@ -1,0 +1,612 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (controller, pod) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", controller=~\"$controller\"}[$__rate_interval]))",
+          "legendFormat": "{{controller}} {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (controller, pod) (rate(controller_runtime_reconcile_errors_total{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", controller=~\"$controller\"}[$__rate_interval]))",
+          "legendFormat": "{{controller}} {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (controller, pod) (controller_runtime_active_workers{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", controller=~\"$controller\"})",
+          "legendFormat": "{{controller}} {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (name, pod) (workqueue_depth{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"})",
+          "legendFormat": "{{name}} {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval])))",
+          "legendFormat": "p90 {{name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{name}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Workqueue Wait Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval])))",
+          "legendFormat": "p90 {{name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (name, le) (rate(workqueue_work_duration_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{name}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Workqueue Work Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, pod) (rate(workqueue_adds_total{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval]))",
+          "legendFormat": "adds {{name}} {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, pod) (rate(workqueue_retries_total{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval]))",
+          "legendFormat": "retries {{name}} {{pod}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Workqueue Adds and Retries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name, pod) (rate(workqueue_unfinished_work_seconds{namespace=~\"$namespace\", job=~\"$job\", pod=~\"$pod\", name=~\"$workqueue\"}[$__rate_interval]))",
+          "legendFormat": "{{name}} {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unfinished Work Seconds Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "kai",
+    "scale-test",
+    "controller-runtime"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "kai-scheduler",
+          "value": "kai-scheduler"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(controller_runtime_reconcile_total, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Controller",
+        "multi": true,
+        "name": "controller",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(workqueue_depth{namespace=~\"$namespace\", job=~\"$job\"}, name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Workqueue",
+        "multi": true,
+        "name": "workqueue",
+        "options": [],
+        "query": {
+          "query": "label_values(workqueue_depth{namespace=~\"$namespace\", job=~\"$job\"}, name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "KAI Controller Runtime and Workqueues",
+  "uid": "kai-controller-runtime-workqueues",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/metrics/grafana/kai-queues-allocation.json
+++ b/docs/metrics/grafana/kai-queues-allocation.json
@@ -1,0 +1,587 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_allocated_gpus{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "{{queue_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Allocated GPUs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_allocated_cpu_cores{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "{{queue_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Allocated CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_allocated_memory_bytes{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "{{queue_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Allocated Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_deserved_gpus{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "deserved {{queue_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_fair_share_gpu{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "fair share {{queue_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Deserved vs Scheduler Fair Share",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_quota_cpu_cores{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "quota {{queue_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_fair_share_cpu_cores{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "fair share {{queue_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU Quota vs Scheduler Fair Share",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_quota_memory_bytes{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "quota {{queue_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_fair_share_memory_gb{namespace=~\"$namespace\", queue_name=~\"$queue\"}) * 1024 * 1024 * 1024",
+          "legendFormat": "fair share {{queue_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Quota vs Scheduler Fair Share",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_gpu_usage{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "gpu {{queue_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_cpu_usage{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "cpu {{queue_name}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_memory_usage{namespace=~\"$namespace\", queue_name=~\"$queue\"})",
+          "legendFormat": "memory {{queue_name}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Scheduler UsageDB Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (queue_name) (kai_queue_allocated_gpus{namespace=~\"$namespace\", queue_name=~\"$queue\"}) / clamp_min(max by (queue_name) (kai_queue_deserved_gpus{namespace=~\"$namespace\", queue_name=~\"$queue\"}), 1)",
+          "legendFormat": "allocated / deserved {{queue_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Allocation vs Deserved Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, max by (queue_name) (kai_queue_allocated_gpus{namespace=~\"$namespace\", queue_name=~\"$queue\"}))",
+          "legendFormat": "gpu {{queue_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, max by (queue_name) (kai_queue_allocated_cpu_cores{namespace=~\"$namespace\", queue_name=~\"$queue\"}))",
+          "legendFormat": "cpu {{queue_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Top Queues by Allocation",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "kai",
+    "scale-test",
+    "queues"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "kai-scheduler",
+          "value": "kai-scheduler"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_queue_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_queue_info, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_queue_info{namespace=~\"$namespace\"}, queue_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Queue",
+        "multi": true,
+        "name": "queue",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_queue_info{namespace=~\"$namespace\"}, queue_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "KAI Queues and Allocation",
+  "uid": "kai-queues-allocation",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/metrics/grafana/kai-scheduler-internals.json
+++ b/docs/metrics/grafana/kai-scheduler-internals.json
@@ -513,6 +513,275 @@
       ],
       "title": "Preemption and Evictions",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (action) (kai_scenario_search_action_budget_configured_seconds{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"})",
+          "legendFormat": "action {{action}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (generator) (kai_scenario_search_generator_budget_configured_seconds{namespace=~\"$namespace\", pod=~\"$pod\", generator=~\"$generator\"})",
+          "legendFormat": "generator {{generator}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (kai_scenario_search_job_budget_configured_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "job {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Scenario Search Configured Budgets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action, result, reduced_budget) (rate(kai_scenario_search_jobs_total{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\", result=~\"$search_result\"}[$__rate_interval]))",
+          "legendFormat": "{{action}} {{result}} reduced={{reduced_budget}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scenario Search Job Results",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, action, generator, result) (rate(kai_scenario_search_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\", generator=~\"$generator\", result=~\"$search_result\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{action}} {{generator}} {{result}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le, action, generator, result) (rate(kai_scenario_search_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\", generator=~\"$generator\", result=~\"$search_result\"}[$__rate_interval])))",
+          "legendFormat": "p90 {{action}} {{generator}} {{result}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, action, generator, result) (rate(kai_scenario_search_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\", generator=~\"$generator\", result=~\"$search_result\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{action}} {{generator}} {{result}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Scenario Search Duration Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action, generator, state) (rate(kai_scenario_search_scenarios_total{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\", generator=~\"$generator\", state=~\"$scenario_state\"}[$__rate_interval]))",
+          "legendFormat": "{{action}} {{generator}} {{state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scenario Search Scenario States",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action) (rate(kai_scenario_search_action_budget_exhausted_total{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "{{action}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scenario Search Action Budget Exhaustion",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -641,6 +910,87 @@
         "options": [],
         "query": {
           "query": "label_values(kai_plugin_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, plugin)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_scenario_search_duration_seconds_count{namespace=~\"$namespace\"}, generator)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Scenario Generator",
+        "multi": true,
+        "name": "generator",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_scenario_search_duration_seconds_count{namespace=~\"$namespace\"}, generator)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_scenario_search_duration_seconds_count{namespace=~\"$namespace\"}, result)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Scenario Search Result",
+        "multi": true,
+        "name": "search_result",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_scenario_search_duration_seconds_count{namespace=~\"$namespace\"}, result)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_scenario_search_scenarios_total{namespace=~\"$namespace\"}, state)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Scenario State",
+        "multi": true,
+        "name": "scenario_state",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_scenario_search_scenarios_total{namespace=~\"$namespace\"}, state)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/docs/metrics/grafana/kai-scheduler-internals.json
+++ b/docs/metrics/grafana/kai-scheduler-internals.json
@@ -1,0 +1,663 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (kai_e2e_scheduling_latency_milliseconds{namespace=~\"$namespace\", pod=~\"$pod\"}) / 1000",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "End-to-End Scheduling Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (kai_open_session_latency_milliseconds{namespace=~\"$namespace\", pod=~\"$pod\"}) / 1000",
+          "legendFormat": "open {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (kai_close_session_latency_milliseconds{namespace=~\"$namespace\", pod=~\"$pod\"}) / 1000",
+          "legendFormat": "close {{pod}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Session Open/Close Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (action) (kai_action_scheduling_latency_milliseconds{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"}) / 1000",
+          "legendFormat": "{{action}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Action Scheduling Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (plugin, OnSession) (kai_plugin_scheduling_latency_milliseconds{namespace=~\"$namespace\", pod=~\"$pod\", plugin=~\"$plugin\"}) / 1000",
+          "legendFormat": "{{plugin}} {{OnSession}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Session Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action) (rate(kai_podgroups_acted_on_by_action{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "acted {{action}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action) (rate(kai_podgroups_scheduled_by_action{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "scheduled {{action}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "PodGroups Acted On vs Scheduled",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action) (rate(kai_scenarios_simulation_by_action{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "simulated {{action}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action) (rate(kai_scenarios_filtered_by_action{namespace=~\"$namespace\", pod=~\"$pod\", action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "filtered {{action}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Scenario Simulation and Filtering",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(kai_task_scheduling_latency_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(kai_task_scheduling_latency_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(kai_task_scheduling_latency_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Task Scheduling Latency Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(kai_task_bind_latency_milliseconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(kai_task_bind_latency_milliseconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(kai_task_bind_latency_milliseconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Binder Latency Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kai_total_preemption_attempts{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "preemption attempts",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (action, nodepool) (rate(kai_pod_group_evicted_pods_total{namespace=~\"$namespace\", action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "evicted {{action}} {{nodepool}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Preemption and Evictions",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "kai",
+    "scale-test",
+    "scheduler"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "kai-scheduler",
+          "value": "kai-scheduler"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_e2e_scheduling_latency_milliseconds, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_e2e_scheduling_latency_milliseconds, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_e2e_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Scheduler Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_e2e_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_action_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, action)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Action",
+        "multi": true,
+        "name": "action",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_action_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, action)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kai_plugin_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, plugin)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Plugin",
+        "multi": true,
+        "name": "plugin",
+        "options": [],
+        "query": {
+          "query": "label_values(kai_plugin_scheduling_latency_milliseconds{namespace=~\"$namespace\"}, plugin)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "KAI Scheduler Internals",
+  "uid": "kai-scheduler-internals",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/metrics/grafana/kai-service-resources.json
+++ b/docs/metrics/grafana/kai-service-resources.json
@@ -1,0 +1,525 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, container) (rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"\", image!=\"\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}} {{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, container) (container_memory_working_set_bytes{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"\", image!=\"\"})",
+          "legendFormat": "working set {{pod}} {{container}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, container) (container_memory_rss{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"\", image!=\"\"})",
+          "legendFormat": "rss {{pod}} {{container}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, container) (rate(container_cpu_cfs_throttled_periods_total{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"\", image!=\"\"}[$__rate_interval])) / clamp_min(sum by (pod, container) (rate(container_cpu_cfs_periods_total{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\", container!=\"\", image!=\"\"}[$__rate_interval])), 1)",
+          "legendFormat": "{{pod}} {{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Throttling Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, container) (increase(kube_pod_container_status_restarts_total{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}} {{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container Restarts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (kube_pod_status_ready{namespace=~\"$namespace\", pod=~\"$pod\", condition=\"true\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Ready",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "rx {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "tx {{pod}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pod Network I/O",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(process_cpu_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (process_resident_memory_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process Resident Memory",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "kai",
+    "scale-test",
+    "resources"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "kai-scheduler",
+          "value": "kai-scheduler"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info{namespace=~\"$namespace\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}, container)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Container",
+        "multi": true,
+        "name": "container",
+        "options": [],
+        "query": {
+          "query": "label_values(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}, container)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "KAI Service Resources",
+  "uid": "kai-service-resources",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/metrics/grafana/kubernetes-apiserver-scale.json
+++ b/docs/metrics/grafana/kubernetes-apiserver-scale.json
@@ -1,0 +1,665 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (verb, resource) (rate(apiserver_request_total{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\", resource=~\"$resource\"}[$__rate_interval]))",
+          "legendFormat": "{{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (code, verb, resource) (rate(apiserver_request_total{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\", resource=~\"$resource\", code=~\"4..|5..\"}[$__rate_interval]))",
+          "legendFormat": "{{code}} {{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (verb, resource, le) (rate(apiserver_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\", resource=~\"$resource\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (verb, resource, le) (rate(apiserver_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\", resource=~\"$resource\"}[$__rate_interval])))",
+          "legendFormat": "p90 {{verb}} {{resource}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (verb, resource, le) (rate(apiserver_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\", resource=~\"$resource\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{verb}} {{resource}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "API Request Duration Quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (request_kind) (apiserver_current_inflight_requests{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{request_kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current In-Flight Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (verb, resource) (apiserver_longrunning_requests{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\", resource=~\"$resource\"})",
+          "legendFormat": "{{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Long-Running Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (priority_level) (apiserver_flowcontrol_current_executing_requests{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "executing {{priority_level}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (priority_level) (apiserver_flowcontrol_current_inqueue_requests{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "queued {{priority_level}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "API Priority and Fairness Executing/Queued",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (priority_level, le) (rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "wait p90 {{priority_level}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (priority_level, le) (rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "wait p99 {{priority_level}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "APF Request Wait Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (priority_level, reason) (rate(apiserver_flowcontrol_rejected_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{priority_level}} {{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "APF Rejected Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (operation, type, le) (rate(etcd_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{operation}} {{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Etcd Request Duration p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, max by (resource) (apiserver_storage_objects{job=~\"$job\", instance=~\"$instance\"}))",
+          "legendFormat": "{{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top API Storage Objects",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "kubernetes",
+    "apiserver",
+    "scale-test"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(apiserver_request_total, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "API Server Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(apiserver_request_total, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(apiserver_request_total{job=~\"$job\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(apiserver_request_total{job=~\"$job\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(apiserver_request_total{job=~\"$job\", instance=~\"$instance\"}, verb)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Verb",
+        "multi": true,
+        "name": "verb",
+        "options": [],
+        "query": {
+          "query": "label_values(apiserver_request_total{job=~\"$job\", instance=~\"$instance\"}, verb)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(apiserver_request_total{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\"}, resource)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Resource",
+        "multi": true,
+        "name": "resource",
+        "options": [],
+        "query": {
+          "query": "label_values(apiserver_request_total{job=~\"$job\", instance=~\"$instance\", verb=~\"$verb\"}, resource)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kubernetes API Server - Scale Test",
+  "uid": "kubernetes-apiserver-scale",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/metrics/service-monitors.yaml
+++ b/docs/metrics/service-monitors.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     accounting: kai-scheduler
 spec:
-  jobLabel: binder
+  jobLabel: app
   namespaceSelector:
     matchNames:
       - kai-scheduler
@@ -23,18 +23,20 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: scheduler
+  name: scheduler-default
   namespace: kai-scheduler
   labels:
     accounting: kai-scheduler
 spec:
-  jobLabel: scheduler
+  jobLabel: app
   namespaceSelector:
     matchNames:
       - kai-scheduler
   selector:
     matchLabels:
-      app: scheduler
+      # The default SchedulingShard is named "default", and the scheduler
+      # service name is "<schedulerName>-<shardName>".
+      app: kai-scheduler-default
   endpoints:
     - port: http-metrics
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -47,7 +49,7 @@ metadata:
   labels:
     accounting: kai-scheduler
 spec:
-  jobLabel: queue-controller
+  jobLabel: app
   namespaceSelector:
     matchNames:
       - kai-scheduler
@@ -65,7 +67,7 @@ metadata:
   labels:
     accounting: kai-scheduler
 spec:
-  jobLabel: dcgm-exporter
+  jobLabel: app
   namespaceSelector:
     matchNames:
       - gpu-operator
@@ -83,7 +85,7 @@ metadata:
   labels:
     accounting: kai-scheduler
 spec:
-  jobLabel: kube-state-metrics
+  jobLabel: app.kubernetes.io/name
   namespaceSelector:
     matchNames:
       - monitoring

--- a/hack/add-grafana-dashboards.sh
+++ b/hack/add-grafana-dashboards.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+	echo "Run this script directly instead of sourcing it: hack/add-grafana-dashboards.sh" >&2
+	return 1
+fi
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+NAMESPACE="${NAMESPACE:-monitoring}"
+LOCAL_PORT="${LOCAL_PORT:-8383}"
+GRAFANA_SERVICE="${GRAFANA_SERVICE:-}"
+GRAFANA_SECRET="${GRAFANA_SECRET:-}"
+GRAFANA_SERVICE_PORT="${GRAFANA_SERVICE_PORT:-80}"
+DASHBOARD_DIR="${DASHBOARD_DIR:-${REPO_ROOT}/docs/metrics/grafana}"
+KEEP_PORT_FORWARD="${KEEP_PORT_FORWARD:-true}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-}"
+
+PF_PID=""
+PF_LOG=""
+SCRIPT_STATUS=0
+ERROR_REPORTED=0
+
+usage() {
+	cat <<EOF
+Usage: $0 [flags]
+
+Imports the repository Grafana dashboards into a Kubernetes Grafana instance.
+
+Flags:
+  -n, --namespace NAME          Grafana namespace (default: ${NAMESPACE})
+  -p, --port PORT               Local port-forward port (default: ${LOCAL_PORT})
+      --service NAME            Grafana service name (auto-detected by default)
+      --service-port PORT       Grafana service port (default: ${GRAFANA_SERVICE_PORT})
+      --secret NAME             Grafana admin secret name (auto-detected by default)
+      --dashboard-dir PATH      Directory containing dashboard JSON files
+      --context NAME            kubectl context to use
+      --no-wait                 Stop the port-forward after importing dashboards
+  -h, --help                    Show this help
+
+Environment variables with the same names are also supported:
+  NAMESPACE, LOCAL_PORT, GRAFANA_SERVICE, GRAFANA_SECRET,
+  GRAFANA_SERVICE_PORT, DASHBOARD_DIR, KEEP_PORT_FORWARD, KUBECTL_CONTEXT
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-n|--namespace)
+			NAMESPACE="$2"
+			shift 2
+			;;
+		-p|--port)
+			LOCAL_PORT="$2"
+			shift 2
+			;;
+		--service)
+			GRAFANA_SERVICE="$2"
+			shift 2
+			;;
+		--service-port)
+			GRAFANA_SERVICE_PORT="$2"
+			shift 2
+			;;
+		--secret)
+			GRAFANA_SECRET="$2"
+			shift 2
+			;;
+		--dashboard-dir)
+			DASHBOARD_DIR="$2"
+			shift 2
+			;;
+		--context)
+			KUBECTL_CONTEXT="$2"
+			shift 2
+			;;
+		--no-wait)
+			KEEP_PORT_FORWARD="false"
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown argument: $1" >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+done
+
+require_command() {
+	local command_name="$1"
+	if ! command -v "${command_name}" >/dev/null 2>&1; then
+		echo "Missing required command: ${command_name}" >&2
+		exit 1
+	fi
+}
+
+kubectl_cmd() {
+	local args=()
+	if [[ -n "${KUBECTL_CONTEXT}" ]]; then
+		args+=(--context "${KUBECTL_CONTEXT}")
+	fi
+	kubectl "${args[@]}" "$@"
+}
+
+resource_exists() {
+	local kind="$1"
+	local name="$2"
+	kubectl_cmd -n "${NAMESPACE}" get "${kind}" "${name}" >/dev/null 2>&1
+}
+
+discover_grafana_secret() {
+	if [[ -n "${GRAFANA_SECRET}" ]]; then
+		if ! resource_exists secret "${GRAFANA_SECRET}"; then
+			echo "Grafana secret ${GRAFANA_SECRET} was not found in namespace ${NAMESPACE}" >&2
+			exit 1
+		fi
+		return
+	fi
+
+	local candidate
+	candidate="$(kubectl_cmd -n "${NAMESPACE}" get secrets -o json | jq -r '
+		first(.items[]
+			| select(.data["admin-user"] and .data["admin-password"])
+			| .metadata.name) // empty
+	')"
+
+	if [[ -z "${candidate}" ]]; then
+		echo "Could not find a Grafana admin secret in namespace ${NAMESPACE}" >&2
+		echo "Pass one explicitly with --secret or GRAFANA_SECRET." >&2
+		exit 1
+	fi
+
+	GRAFANA_SECRET="${candidate}"
+}
+
+discover_grafana_service() {
+	if [[ -n "${GRAFANA_SERVICE}" ]]; then
+		if ! resource_exists service "${GRAFANA_SERVICE}"; then
+			echo "Grafana service ${GRAFANA_SERVICE} was not found in namespace ${NAMESPACE}" >&2
+			exit 1
+		fi
+		return
+	fi
+
+	if resource_exists service "${GRAFANA_SECRET}"; then
+		GRAFANA_SERVICE="${GRAFANA_SECRET}"
+		return
+	fi
+
+	local candidate
+	candidate="$(kubectl_cmd -n "${NAMESPACE}" get services -o json | jq -r '
+		first(.items[]
+			| select(.metadata.labels["app.kubernetes.io/name"] == "grafana")
+			| .metadata.name) // empty
+	')"
+
+	if [[ -z "${candidate}" ]]; then
+		echo "Could not find a Grafana service in namespace ${NAMESPACE}" >&2
+		echo "Pass one explicitly with --service or GRAFANA_SERVICE." >&2
+		exit 1
+	fi
+
+	GRAFANA_SERVICE="${candidate}"
+}
+
+decode_secret_key() {
+	local key="$1"
+	kubectl_cmd -n "${NAMESPACE}" get secret "${GRAFANA_SECRET}" -o json \
+		| jq -r --arg key "${key}" '.data[$key] // empty' \
+		| base64 --decode
+}
+
+cleanup() {
+	if [[ -n "${PF_PID}" ]] && kill -0 "${PF_PID}" >/dev/null 2>&1; then
+		kill "${PF_PID}" >/dev/null 2>&1 || true
+		wait "${PF_PID}" >/dev/null 2>&1 || true
+	fi
+	if [[ "${SCRIPT_STATUS}" -eq 0 && -n "${PF_LOG}" && -f "${PF_LOG}" ]]; then
+		rm -f "${PF_LOG}"
+	fi
+}
+
+on_error() {
+	local exit_code="$?"
+	local line_number="$1"
+
+	SCRIPT_STATUS="${exit_code}"
+	ERROR_REPORTED=1
+	echo "Failed on line ${line_number} with exit code ${exit_code}." >&2
+	if [[ -n "${PF_LOG}" && -f "${PF_LOG}" ]]; then
+		echo "Port-forward log preserved at: ${PF_LOG}" >&2
+		echo "Last port-forward log lines:" >&2
+		tail -50 "${PF_LOG}" >&2 || true
+	fi
+	exit "${exit_code}"
+}
+
+on_exit() {
+	local exit_code="$?"
+
+	SCRIPT_STATUS="${exit_code}"
+	if [[ "${exit_code}" -ne 0 && "${ERROR_REPORTED}" -eq 0 ]]; then
+		echo "Script exited with status ${exit_code}." >&2
+		if [[ -n "${PF_LOG}" && -f "${PF_LOG}" ]]; then
+			echo "Port-forward log preserved at: ${PF_LOG}" >&2
+		fi
+	fi
+	cleanup
+}
+
+on_interrupt() {
+	SCRIPT_STATUS=130
+	echo "Interrupted. Stopping port-forward." >&2
+	cleanup
+	exit 130
+}
+
+on_terminate() {
+	SCRIPT_STATUS=143
+	echo "Terminated. Stopping port-forward." >&2
+	cleanup
+	exit 143
+}
+
+trap 'on_error ${LINENO}' ERR
+trap on_exit EXIT
+trap on_interrupt INT
+trap on_terminate TERM
+
+wait_for_grafana() {
+	local url="$1"
+
+	for _ in $(seq 1 30); do
+		if curl -fsS "${url}/api/health" >/dev/null 2>&1; then
+			return 0
+		fi
+		if [[ -n "${PF_PID}" ]] && ! kill -0 "${PF_PID}" >/dev/null 2>&1; then
+			echo "Port-forward exited before Grafana became reachable." >&2
+			if [[ -f "${PF_LOG}" ]]; then
+				cat "${PF_LOG}" >&2
+			fi
+			exit 1
+		fi
+		sleep 1
+	done
+
+	echo "Timed out waiting for Grafana at ${url}" >&2
+	if [[ -f "${PF_LOG}" ]]; then
+		cat "${PF_LOG}" >&2
+	fi
+	exit 1
+}
+
+start_port_forward() {
+	local url="$1"
+
+	if curl -fsS "${url}/api/health" >/dev/null 2>&1; then
+		echo "Using existing Grafana endpoint at ${url}"
+		return
+	fi
+
+	PF_LOG="$(mktemp)"
+	echo "Starting port-forward: ${url} -> svc/${GRAFANA_SERVICE}:${GRAFANA_SERVICE_PORT}"
+	kubectl_cmd -n "${NAMESPACE}" port-forward "svc/${GRAFANA_SERVICE}" "${LOCAL_PORT}:${GRAFANA_SERVICE_PORT}" >"${PF_LOG}" 2>&1 &
+	PF_PID="$!"
+
+	wait_for_grafana "${url}"
+}
+
+import_dashboard() {
+	local dashboard_file="$1"
+	local url="$2"
+	local username="$3"
+	local password="$4"
+	local response_file
+	local status_code
+	local title
+
+	response_file="$(mktemp)"
+	title="$(jq -r '.title // input_filename' "${dashboard_file}")"
+
+	status_code="$(
+		jq -c '{dashboard: (. | .id = null), overwrite: true, folderId: 0}' "${dashboard_file}" \
+			| curl -sS \
+				-u "${username}:${password}" \
+				-H "Content-Type: application/json" \
+				-X POST \
+				-o "${response_file}" \
+				-w "%{http_code}" \
+				--data-binary @- \
+				"${url}/api/dashboards/db"
+	)"
+
+	if [[ "${status_code}" != "200" && "${status_code}" != "202" ]]; then
+		echo "Failed to import ${dashboard_file} (${status_code})" >&2
+		cat "${response_file}" >&2
+		rm -f "${response_file}"
+		exit 1
+	fi
+
+	local dashboard_url
+	dashboard_url="$(jq -r '.url // empty' "${response_file}")"
+	rm -f "${response_file}"
+
+	if [[ -n "${dashboard_url}" ]]; then
+		echo "Imported: ${title} (${url}${dashboard_url})"
+	else
+		echo "Imported: ${title}"
+	fi
+}
+
+require_command kubectl
+require_command curl
+require_command jq
+require_command base64
+
+if [[ ! -d "${DASHBOARD_DIR}" ]]; then
+	echo "Dashboard directory does not exist: ${DASHBOARD_DIR}" >&2
+	exit 1
+fi
+
+shopt -s nullglob
+dashboards=("${DASHBOARD_DIR}"/*.json)
+if [[ "${#dashboards[@]}" -eq 0 ]]; then
+	echo "No dashboard JSON files found in ${DASHBOARD_DIR}" >&2
+	exit 1
+fi
+
+discover_grafana_secret
+discover_grafana_service
+
+GRAFANA_USERNAME="$(decode_secret_key admin-user)"
+GRAFANA_PASSWORD="$(decode_secret_key admin-password)"
+
+if [[ -z "${GRAFANA_USERNAME}" || -z "${GRAFANA_PASSWORD}" ]]; then
+	echo "Secret ${GRAFANA_SECRET} does not contain admin-user/admin-password" >&2
+	exit 1
+fi
+
+GRAFANA_URL="http://localhost:${LOCAL_PORT}"
+
+start_port_forward "${GRAFANA_URL}"
+
+echo
+echo "Grafana URL: ${GRAFANA_URL}"
+echo "Grafana service: ${NAMESPACE}/${GRAFANA_SERVICE}"
+echo "Grafana secret: ${NAMESPACE}/${GRAFANA_SECRET}"
+echo "Username: ${GRAFANA_USERNAME}"
+echo "Password: ${GRAFANA_PASSWORD}"
+echo
+
+for dashboard in "${dashboards[@]}"; do
+	import_dashboard "${dashboard}" "${GRAFANA_URL}" "${GRAFANA_USERNAME}" "${GRAFANA_PASSWORD}"
+done
+
+echo
+echo "Imported ${#dashboards[@]} dashboard(s)."
+
+if [[ -n "${PF_PID}" && "${KEEP_PORT_FORWARD}" == "true" ]]; then
+	echo "Port-forward is running. Press Ctrl-C to stop it."
+	wait "${PF_PID}"
+else
+	cleanup
+fi

--- a/hack/setup-scale-test-env.sh
+++ b/hack/setup-scale-test-env.sh
@@ -27,6 +27,7 @@ helm -n monitoring upgrade -i pyroscope grafana/pyroscope
 kubectl patch nodepool managed-nodepool -p '{"spec":{"nodeCount": 0, "nodeTemplate": {"metadata": {"labels": {"run.ai/simulated-gpu-node-pool": "default"}}}}}' --type merge
 
 kubectl apply -f "${SCALE_DIR}/scheduler-service-monitor.yaml"
+kubectl apply -f "${SCALE_DIR}/queue-controller-service-monitor.yaml"
 kubectl apply -f "${SCALE_DIR}/binder.yaml"
 
 kubectl delete stage pod-complete --ignore-not-found

--- a/test/e2e/scale/queue-controller-service-monitor.yaml
+++ b/test/e2e/scale/queue-controller-service-monitor.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: queue-controller
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobLabel: queue-controller
+  namespaceSelector:
+    matchNames:
+      - kai-scheduler
+  selector:
+    matchLabels:
+      app: queue-controller
+  endpoints:
+    - port: metrics


### PR DESCRIPTION
## Description

Adds a focused Grafana dashboard set for scale-test investigation:

- **KAI Scheduler Internals**: scheduler-cycle, action/plugin, scenario-search, task scheduling, binder, preemption, and eviction metrics.
- **KAI Queues and Allocation**: queue allocation, quota, deserved GPU, fair-share, and UsageDB metrics.
- **KAI Service Resources**: KAI pod CPU, memory, throttling, restarts, readiness, network, and process metrics.
- **KAI Controller Runtime and Workqueues**: controller-runtime reconciliation and workqueue latency/backlog metrics.
- **Kubernetes API Server - Scale Test**: request rate, latency, errors, in-flight requests, API Priority and Fairness, and storage/etcd metrics.

Also:

- documents dashboard installation and Kubernetes API server scraping prerequisites;
- corrects the shared KAI ServiceMonitor job labels and default scheduler selector;
- installs a queue-controller ServiceMonitor during scale-test environment setup;
- adds `hack/add-grafana-dashboards.sh` to discover Grafana, retrieve its admin credentials, port-forward when needed, and import all repository dashboards.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (not applicable: dashboards, monitoring manifests, and installation script)
- [x] Updated documentation

## Breaking Changes

None.

## Additional Notes

Validated dashboard JSON with `jq` and ran `git diff --check`.
