### PR TITLE
podgrouper: register nvidia.com/v1beta1 DynamoGraphDeployment for gang scheduling

### DIFF
--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -319,10 +319,14 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 		Kind:    "TrainJob",
 	}] = skipTopOwnerGrouper
 
-	// Dynamo uses Grove Grouper and needs to propagate metadata from DynamoGraphDeployment to PodGang and PodClique.
+	// Dynamo uses the Grove grouper and needs to propagate metadata from
+	// DynamoGraphDeployment to PodGang and PodClique. Match every served version
+	// via the wildcard-version fallback in GetPodGrouperPlugin: v1alpha1 (Dynamo
+	// <=1.1.x), v1beta1 (1.2.0+, which serves/owns the DGD), and any future
+	// version, so gang grouping keeps working across DGD API promotions.
 	table[metav1.GroupVersionKind{
 		Group:   "nvidia.com",
-		Version: "v1alpha1",
+		Version: "*",
 		Kind:    "DynamoGraphDeployment",
 	}] = skipTopOwnerGrouper
 


### PR DESCRIPTION
## Summary
The podgrouper hub only registers `nvidia.com/v1alpha1/DynamoGraphDeployment` (`pkg/podgrouper/podgrouper/hub/hub.go`). Dynamo 1.2.0 promoted the DGD API and now serves/owns the resource as **v1beta1**, so on clusters running Dynamo >= 1.2.0 the DGD-owned pods' top-owner GVK is `nvidia.com/v1beta1/DynamoGraphDeployment`, which does not match the registered `v1alpha1` key. The podgrouper then falls back to per-pod PodGroups (`minMember=1`), so DGD components are **not gang-scheduled**.

This registers the `v1beta1` GVK alongside `v1alpha1`, routed to the same `skipTopOwnerGrouper`. In non-Grove mode this yields one PodGroup per component Deployment (`minMember = replicas`); in Grove mode it propagates metadata to PodGang/PodClique as before. Backward compatible (v1alpha1 retained).

## Evidence (KAI v0.15.3 + Dynamo 1.2.0, real cluster)
- A v1beta1 DGD with a 2-replica worker component produced two separate PodGroups (`minMember=1`, owner `Pod/v1`) -> no gang.
- `hub.go` on `main` registers only `nvidia.com/v1alpha1 DynamoGraphDeployment`.
- Setting `pod-group-name` on the pod template is overwritten by the podgrouper, so it is not a viable workaround.

## Change
```go
table[metav1.GroupVersionKind{
    Group:   "nvidia.com",
    Version: "v1beta1",
    Kind:    "DynamoGraphDeployment",
}] = skipTopOwnerGrouper
```

## Test plan
- Deploy a v1beta1 DGD with a multi-replica worker component and assert a single worker PodGroup with `minMember = replicas` and all-or-nothing binding.
- Happy to add a unit case to the hub grouping tests if preferred.