### PR TITLE
fix(scheduler): prevent DRA GPU count overflow from understating queue demand

### DIFF
--- a/.changes/unreleased/Fixed-20260715-153936.yaml
+++ b/.changes/unreleased/Fixed-20260715-153936.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Saturated the DRA GPU device-count accumulation so a ResourceClaim requesting an oversized device count can no longer overflow the queue controller's int64 GPU total to a negative value. [#1873](https://github.com/kai-scheduler/KAI-Scheduler/issues/1873) [thc1006](https://github.com/thc1006)

--- a/pkg/common/math/saturating.go
+++ b/pkg/common/math/saturating.go
@@ -7,9 +7,9 @@ package math
 
 import stdmath "math"
 
-// SaturatingAddInt64 returns a + b, clamped to [math.MinInt64, math.MaxInt64]
+// SaturatingAdd returns a + b, clamped to [math.MinInt64, math.MaxInt64]
 // on overflow instead of wrapping around to the opposite sign.
-func SaturatingAddInt64(a, b int64) int64 {
+func SaturatingAdd(a, b int64) int64 {
 	sum := a + b
 	// Overflow can only happen when both operands share a sign and the sign of
 	// the result flips.

--- a/pkg/common/math/saturating.go
+++ b/pkg/common/math/saturating.go
@@ -1,0 +1,23 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package math holds dependency-light arithmetic helpers that the scheduler's
+// resource model can use without pulling in Kubernetes or DRA client packages.
+package math
+
+import stdmath "math"
+
+// SaturatingAddInt64 returns a + b, clamped to [math.MinInt64, math.MaxInt64]
+// on overflow instead of wrapping around to the opposite sign.
+func SaturatingAddInt64(a, b int64) int64 {
+	sum := a + b
+	// Overflow can only happen when both operands share a sign and the sign of
+	// the result flips.
+	if a > 0 && b > 0 && sum < 0 {
+		return stdmath.MaxInt64
+	}
+	if a < 0 && b < 0 && sum >= 0 {
+		return stdmath.MinInt64
+	}
+	return sum
+}

--- a/pkg/common/math/saturating_test.go
+++ b/pkg/common/math/saturating_test.go
@@ -1,0 +1,30 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package math
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+func TestSaturatingAddInt64(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b int64
+		want int64
+	}{
+		{"normal sum", 2, 3, 5},
+		{"positive overflow saturates to MaxInt64", stdmath.MaxInt64, stdmath.MaxInt64, stdmath.MaxInt64},
+		{"positive overflow by one", stdmath.MaxInt64, 1, stdmath.MaxInt64},
+		{"negative overflow saturates to MinInt64", stdmath.MinInt64, stdmath.MinInt64, stdmath.MinInt64},
+		{"mixed signs do not overflow", stdmath.MaxInt64, stdmath.MinInt64, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SaturatingAddInt64(tc.a, tc.b); got != tc.want {
+				t.Fatalf("SaturatingAddInt64(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/common/math/saturating_test.go
+++ b/pkg/common/math/saturating_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestSaturatingAddInt64(t *testing.T) {
+func TestSaturatingAdd(t *testing.T) {
 	cases := []struct {
 		name string
 		a, b int64
@@ -22,8 +22,8 @@ func TestSaturatingAddInt64(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := SaturatingAddInt64(tc.a, tc.b); got != tc.want {
-				t.Fatalf("SaturatingAddInt64(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			if got := SaturatingAdd(tc.a, tc.b); got != tc.want {
+				t.Fatalf("SaturatingAdd(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
 			}
 		})
 	}

--- a/pkg/common/resources/dra.go
+++ b/pkg/common/resources/dra.go
@@ -23,6 +23,8 @@ import (
 	draclient "k8s.io/dynamic-resource-allocation/client"
 	resourceinstall "k8s.io/kubernetes/pkg/apis/resource/install"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonmath "github.com/kai-scheduler/KAI-scheduler/pkg/common/math"
 )
 
 func GetResourceClaimName(pod *v1.Pod, podClaim *v1.PodResourceClaim) (string, error) {
@@ -129,7 +131,7 @@ func ExtractDRAGPUResourcesFromClaims(podResourceClaims []*resourceapi.ResourceC
 			// Find the DeviceClassName for this claim
 			deviceClassName := getGPUDeviceClassNameFromClaim(claim)
 			if deviceClassName != "" {
-				deviceClassCounts[deviceClassName] += gpuCount
+				deviceClassCounts[deviceClassName] = commonmath.SaturatingAddInt64(deviceClassCounts[deviceClassName], gpuCount)
 			}
 		}
 	}
@@ -163,6 +165,10 @@ func getGPUDeviceClassNameFromClaim(claim *resourceapi.ResourceClaim) string {
 
 // countGPUDevicesFromClaim counts GPU devices from a ResourceClaim.
 // Returns the total count of GPU devices requested by this claim.
+//
+// Exactly.Count is user-controlled (the apiserver only enforces > 0), so counts
+// are summed with SaturatingAddInt64 to keep a very large total from wrapping
+// into a negative GPU request in downstream quota accounting.
 func countGPUDevicesFromClaim(claim *resourceapi.ResourceClaim) int64 {
 	totalCount := int64(0)
 
@@ -178,16 +184,16 @@ func countGPUDevicesFromClaim(claim *resourceapi.ResourceClaim) int64 {
 		switch request.Exactly.AllocationMode {
 		case resourceapi.DeviceAllocationModeExactCount:
 			if request.Exactly.Count > 0 {
-				totalCount += request.Exactly.Count
+				totalCount = commonmath.SaturatingAddInt64(totalCount, request.Exactly.Count)
 			} else {
 				// Default to 1 if Count is not specified for ExactCount mode
-				totalCount += 1
+				totalCount = commonmath.SaturatingAddInt64(totalCount, 1)
 			}
 		case resourceapi.DeviceAllocationModeAll:
 			// For "All" mode, we can't determine the exact count without allocation info.
 			// For bookkeeping purposes, we'll treat it as requesting 1 device.
 			// This is a conservative estimate for queue resource tracking.
-			totalCount += 1
+			totalCount = commonmath.SaturatingAddInt64(totalCount, 1)
 		default:
 			// Unknown allocation mode, skip this request
 			continue

--- a/pkg/common/resources/dra.go
+++ b/pkg/common/resources/dra.go
@@ -131,7 +131,7 @@ func ExtractDRAGPUResourcesFromClaims(podResourceClaims []*resourceapi.ResourceC
 			// Find the DeviceClassName for this claim
 			deviceClassName := getGPUDeviceClassNameFromClaim(claim)
 			if deviceClassName != "" {
-				deviceClassCounts[deviceClassName] = commonmath.SaturatingAddInt64(deviceClassCounts[deviceClassName], gpuCount)
+				deviceClassCounts[deviceClassName] = commonmath.SaturatingAdd(deviceClassCounts[deviceClassName], gpuCount)
 			}
 		}
 	}
@@ -167,7 +167,7 @@ func getGPUDeviceClassNameFromClaim(claim *resourceapi.ResourceClaim) string {
 // Returns the total count of GPU devices requested by this claim.
 //
 // Exactly.Count is user-controlled (the apiserver only enforces > 0), so counts
-// are summed with SaturatingAddInt64 to keep a very large total from wrapping
+// are summed with SaturatingAdd to keep a very large total from wrapping
 // into a negative GPU request in downstream quota accounting.
 func countGPUDevicesFromClaim(claim *resourceapi.ResourceClaim) int64 {
 	totalCount := int64(0)
@@ -184,16 +184,16 @@ func countGPUDevicesFromClaim(claim *resourceapi.ResourceClaim) int64 {
 		switch request.Exactly.AllocationMode {
 		case resourceapi.DeviceAllocationModeExactCount:
 			if request.Exactly.Count > 0 {
-				totalCount = commonmath.SaturatingAddInt64(totalCount, request.Exactly.Count)
+				totalCount = commonmath.SaturatingAdd(totalCount, request.Exactly.Count)
 			} else {
 				// Default to 1 if Count is not specified for ExactCount mode
-				totalCount = commonmath.SaturatingAddInt64(totalCount, 1)
+				totalCount = commonmath.SaturatingAdd(totalCount, 1)
 			}
 		case resourceapi.DeviceAllocationModeAll:
 			// For "All" mode, we can't determine the exact count without allocation info.
 			// For bookkeeping purposes, we'll treat it as requesting 1 device.
 			// This is a conservative estimate for queue resource tracking.
-			totalCount = commonmath.SaturatingAddInt64(totalCount, 1)
+			totalCount = commonmath.SaturatingAdd(totalCount, 1)
 		default:
 			// Unknown allocation mode, skip this request
 			continue

--- a/pkg/common/resources/dra_overflow_test.go
+++ b/pkg/common/resources/dra_overflow_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"math"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+func gpuClaimWithCount(count int64) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: []resourceapi.DeviceRequest{{
+					Name: "gpu",
+					Exactly: &resourceapi.ExactDeviceRequest{
+						DeviceClassName: "gpu.nvidia.com",
+						AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+						Count:           count,
+					},
+				}},
+			},
+		},
+	}
+}
+
+// Two API-valid ResourceClaims, each requesting Count=MaxInt64 of the same GPU
+// device class, must not wrap the aggregated device count negative. The sum
+// saturates at MaxInt64 instead, so the request stays a (very large) positive
+// count rather than corrupting the queue's GPU accounting.
+func TestExtractDRAGPUResourcesFromClaims_saturatesOnOverflow(t *testing.T) {
+	claims := []*resourceapi.ResourceClaim{
+		gpuClaimWithCount(math.MaxInt64),
+		gpuClaimWithCount(math.MaxInt64),
+	}
+	got := ExtractDRAGPUResourcesFromClaims(claims)
+	if c := got["gpu.nvidia.com"]; c != math.MaxInt64 {
+		t.Fatalf("aggregated gpu.nvidia.com count = %d, want %d (saturated, non-negative)", c, int64(math.MaxInt64))
+	}
+
+	// Baseline: normal counts still sum exactly.
+	base := ExtractDRAGPUResourcesFromClaims([]*resourceapi.ResourceClaim{
+		gpuClaimWithCount(2), gpuClaimWithCount(3),
+	})
+	if c := base["gpu.nvidia.com"]; c != 5 {
+		t.Fatalf("aggregated gpu.nvidia.com count = %d, want 5", c)
+	}
+}
+
+// A single API-valid ResourceClaim can mix allocation modes: an ExactCount
+// request at math.MaxInt64 alongside an AllocationModeAll request (the apiserver
+// allows any positive ExactCount and requires All to carry no count). The "All"
+// branch adds a conservative +1 for bookkeeping, which must saturate rather than
+// wrap the already-maxed per-claim total to MinInt64. A negative total would then
+// be dropped by the >0 filter in ExtractDRAGPUResourcesFromClaims, silently
+// undercounting the oversized claim to 0.
+func TestCountGPUDevicesFromClaim_ExactMaxThenAllSaturates(t *testing.T) {
+	claim := &resourceapi.ResourceClaim{
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: []resourceapi.DeviceRequest{
+					{
+						Name: "exact",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: "gpu.nvidia.com",
+							AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+							Count:           math.MaxInt64,
+						},
+					},
+					{
+						Name: "all",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: "gpu.nvidia.com",
+							AllocationMode:  resourceapi.DeviceAllocationModeAll,
+						},
+					},
+				},
+			},
+		},
+	}
+	if got := countGPUDevicesFromClaim(claim); got != math.MaxInt64 {
+		t.Fatalf("countGPUDevicesFromClaim = %d, want %d (saturated); a negative result is dropped by the >0 filter and undercounts the claim to 0", got, int64(math.MaxInt64))
+	}
+
+	// The oversized claim must be counted (as a large positive), not dropped.
+	if c := ExtractDRAGPUResourcesFromClaims([]*resourceapi.ResourceClaim{claim})["gpu.nvidia.com"]; c != math.MaxInt64 {
+		t.Fatalf("aggregated gpu.nvidia.com count = %d, want %d (claim must not be dropped)", c, int64(math.MaxInt64))
+	}
+}

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_dra_overflow_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_dra_overflow_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"gopkg.in/h2non/gock.v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	featuregates "github.com/kai-scheduler/KAI-scheduler/pkg/common/feature_gates"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/integration_tests/integration_tests_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/dra_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+func TestDRAOverflowDoesNotBlockReclaimInSameQueue(t *testing.T) {
+	defer gock.Off()
+
+	featuregates.SetDynamicResourcesEnabledForTest(true)
+	t.Cleanup(func() {
+		featuregates.SetDynamicResourcesEnabledForTest(false)
+	})
+
+	integration_tests_utils.RunTests(t, []integration_tests_utils.TestTopologyMetadata{
+		{
+			Name: "overflowing DRA request does not block reclaim for a valid request in the same queue",
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "overflowing DRA request does not block reclaim for a valid request in the same queue",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:      "valid-job",
+						Namespace: "test",
+						Priority:  constants.PriorityTrainNumber,
+						QueueName: "reclaiming-queue",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State:              pod_status.Pending,
+								ResourceClaimNames: []string{"valid-claim"},
+							},
+						},
+					},
+					{
+						Name:      "overflow-job",
+						Namespace: "test",
+						Priority:  constants.PriorityTrainNumber,
+						QueueName: "reclaiming-queue",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+								ResourceClaimNames: []string{
+									"overflow-claim-0",
+									"overflow-claim-1",
+								},
+							},
+						},
+					},
+					{
+						Name:      "victim-job",
+						Namespace: "test",
+						Priority:  constants.PriorityTrainNumber,
+						QueueName: "victim-queue",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								NodeName:           "node0",
+								State:              pod_status.Running,
+								ResourceClaimNames: []string{"victim-claim"},
+							},
+						},
+					},
+				},
+				TestDRAObjects: dra_fake.TestDRAObjects{
+					DeviceClasses: []string{"nvidia.com/gpu"},
+					ResourceSlices: []*dra_fake.TestResourceSlice{
+						{
+							Name:            "node0-gpu",
+							DeviceClassName: "nvidia.com/gpu",
+							NodeName:        "node0",
+							Count:           2,
+						},
+					},
+					ResourceClaims: []*dra_fake.TestResourceClaim{
+						{
+							Name:            "valid-claim",
+							Namespace:       "test",
+							DeviceClassName: "nvidia.com/gpu",
+							Count:           2,
+							Labels: map[string]string{
+								commonconstants.DefaultQueueLabel: "reclaiming-queue",
+							},
+						},
+						{
+							Name:            "overflow-claim-0",
+							Namespace:       "test",
+							DeviceClassName: "nvidia.com/gpu",
+							Count:           math.MaxInt64,
+							Labels: map[string]string{
+								commonconstants.DefaultQueueLabel: "reclaiming-queue",
+							},
+						},
+						{
+							Name:            "overflow-claim-1",
+							Namespace:       "test",
+							DeviceClassName: "nvidia.com/gpu",
+							Count:           math.MaxInt64,
+							Labels: map[string]string{
+								commonconstants.DefaultQueueLabel: "reclaiming-queue",
+							},
+						},
+						{
+							Name:            "victim-claim",
+							Namespace:       "test",
+							DeviceClassName: "nvidia.com/gpu",
+							Count:           2,
+							Labels: map[string]string{
+								commonconstants.DefaultQueueLabel: "victim-queue",
+							},
+							ClaimStatus: allocatedDRAClaimStatus("victim-job-0"),
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "reclaiming-queue",
+						DeservedGPUs:       2,
+						GPUOverQuotaWeight: 1,
+					},
+					{
+						Name:               "victim-queue",
+						GPUOverQuotaWeight: 1,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"valid-job":    {Status: pod_status.Running, NodeName: "node0"},
+					"overflow-job": {Status: pod_status.Pending},
+					"victim-job":   {Status: pod_status.Pending},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds:      1,
+						NumberOfCacheEvictions:  1,
+						NumberOfPipelineActions: 1,
+					},
+				},
+			},
+			RoundsUntilMatch:   2,
+			RoundsAfterMatch:   1,
+			SchedulingDuration: time.Millisecond,
+		},
+	})
+}
+
+func allocatedDRAClaimStatus(podName string) *resourceapi.ResourceClaimStatus {
+	return &resourceapi.ResourceClaimStatus{
+		Allocation: &resourceapi.AllocationResult{
+			Devices: resourceapi.DeviceAllocationResult{
+				Results: []resourceapi.DeviceRequestAllocationResult{
+					{
+						Request: "victim-claim",
+						Driver:  "nvidia.com/gpu",
+						Pool:    "node0",
+						Device:  "0",
+					},
+					{
+						Request: "victim-claim",
+						Driver:  "nvidia.com/gpu",
+						Pool:    "node0",
+						Device:  "1",
+					},
+				},
+			},
+		},
+		ReservedFor: []resourceapi.ResourceClaimConsumerReference{
+			{Resource: "pods", Name: podName, UID: types.UID(podName)},
+		},
+	}
+}

--- a/pkg/scheduler/api/resource_info/gpu_dra_overflow_test.go
+++ b/pkg/scheduler/api/resource_info/gpu_dra_overflow_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package resource_info
+
+import (
+	"math"
+	"testing"
+)
+
+// GetDraGpusCount sums the per-device-class DRA counts. With two GPU device
+// classes each already at the int64 ceiling (reachable via a pod that holds one
+// claim per class), the sum must saturate rather than wrap negative and poison
+// the GPU quota returned by GetGpusQuota.
+func TestGetDraGpusCount_saturatesOnOverflow(t *testing.T) {
+	g := NewGpuResourceRequirement()
+	g.SetDraGpus(map[string]int64{
+		"gpu.nvidia.com": math.MaxInt64,
+		"gpu.amd.com":    math.MaxInt64,
+	})
+
+	if got := g.GetDraGpusCount(); got != math.MaxInt64 {
+		t.Fatalf("GetDraGpusCount() = %d, want %d (saturated, non-negative)", got, int64(math.MaxInt64))
+	}
+	if q := g.GetGpusQuota(); q < 0 {
+		t.Fatalf("GetGpusQuota() = %f, want non-negative", q)
+	}
+}
+
+// Add aggregates draGpuCounts across requirements (e.g. summing many pods into a
+// queue total). Two requirements whose per-class counts sum past the int64
+// ceiling must saturate rather than wrap negative.
+func TestGpuResourceRequirementAdd_draGpuCountsSaturate(t *testing.T) {
+	a := NewGpuResourceRequirement()
+	a.SetDraGpus(map[string]int64{"gpu.nvidia.com": math.MaxInt64})
+	b := NewGpuResourceRequirement()
+	b.SetDraGpus(map[string]int64{"gpu.nvidia.com": math.MaxInt64})
+
+	if err := a.Add(b); err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if got := a.DraGpuCounts()["gpu.nvidia.com"]; got != math.MaxInt64 {
+		t.Fatalf("draGpuCounts[gpu.nvidia.com] after Add = %d, want %d (saturated)", got, int64(math.MaxInt64))
+	}
+}

--- a/pkg/scheduler/api/resource_info/gpu_resource_requirment.go
+++ b/pkg/scheduler/api/resource_info/gpu_resource_requirment.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 
+	commonmath "github.com/kai-scheduler/KAI-scheduler/pkg/common/math"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info/resources"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
@@ -132,7 +133,7 @@ func (g *GpuResourceRequirement) Add(gg *GpuResourceRequirement) error {
 		g.count += gg.count
 	}
 	for name, ggQuant := range gg.draGpuCounts {
-		g.draGpuCounts[name] += ggQuant
+		g.draGpuCounts[name] = commonmath.SaturatingAddInt64(g.draGpuCounts[name], ggQuant)
 	}
 	for name, ggQuant := range gg.migResources {
 		g.migResources[name] += ggQuant
@@ -203,7 +204,7 @@ func (g *GpuResourceRequirement) DraGpuCounts() map[string]int64 {
 func (g *GpuResourceRequirement) GetDraGpusCount() int64 {
 	count := int64(0)
 	for _, singleClaimCount := range g.draGpuCounts {
-		count += singleClaimCount
+		count = commonmath.SaturatingAddInt64(count, singleClaimCount)
 	}
 	return count
 }

--- a/pkg/scheduler/api/resource_info/gpu_resource_requirment.go
+++ b/pkg/scheduler/api/resource_info/gpu_resource_requirment.go
@@ -133,7 +133,7 @@ func (g *GpuResourceRequirement) Add(gg *GpuResourceRequirement) error {
 		g.count += gg.count
 	}
 	for name, ggQuant := range gg.draGpuCounts {
-		g.draGpuCounts[name] = commonmath.SaturatingAddInt64(g.draGpuCounts[name], ggQuant)
+		g.draGpuCounts[name] = commonmath.SaturatingAdd(g.draGpuCounts[name], ggQuant)
 	}
 	for name, ggQuant := range gg.migResources {
 		g.migResources[name] += ggQuant
@@ -204,7 +204,7 @@ func (g *GpuResourceRequirement) DraGpuCounts() map[string]int64 {
 func (g *GpuResourceRequirement) GetDraGpusCount() int64 {
 	count := int64(0)
 	for _, singleClaimCount := range g.draGpuCounts {
-		count = commonmath.SaturatingAddInt64(count, singleClaimCount)
+		count = commonmath.SaturatingAdd(count, singleClaimCount)
 	}
 	return count
 }


### PR DESCRIPTION
## Description

### Problem

An oversized but API-valid DRA GPU request from a pending workload can cancel the legitimate GPU demand of other workloads in the same queue. The Kubernetes API accepts any positive `int64` for a `ResourceClaim`'s `...Exactly.Count` (validation only rejects `count <= 0`), so a workload can drive KAI's aggregated device count past `math.MaxInt64`, where a plain `+=` wraps it negative.

### Impact

The oversized workload itself never obtains GPUs. It stays `Pending`, which is the expected outcome. The damage lands on the other workloads sharing its queue: the negative count is subtracted from the queue's aggregate GPU demand, so their honest demand is understated or cancelled outright. Those workloads can still allocate while GPUs are idle, but the understated fair share makes the proportion reclaim-eligibility gate reject them, so an otherwise eligible workload is left `Pending` once the GPUs are held by another queue.

### Root cause

Four aggregation boundaries accumulated user-controlled counts with raw signed addition:

- requests within a single `ResourceClaim` (`countGPUDevicesFromClaim`), including the `AllocationModeAll` bookkeeping `+1`
- claims grouped by device class (`ExtractDRAGPUResourcesFromClaims`)
- requirements across workloads (`GpuResourceRequirement.Add`)
- device classes summed into the total DRA count (`GetDraGpusCount`)

### Fix

Every one of those boundaries now accumulates with a saturating add, so an oversized request stays a large positive (and simply unschedulable) value instead of wrapping negative. The helper lives in the dependency-light `pkg/common/math`, so the scheduler's resource model does not pull in the Kubernetes and DRA client packages for the sake of one integer addition.

## Reproduction

Observed on a live cluster (Kubernetes v1.36.1, `gpu.nvidia.com` DeviceClass, KAI Scheduler v0.16.3). With a queue `kai-dra-test-q` (gpu quota 8) and a pod referencing two `count: 9223372036854775807` GPU claims, the scheduler logged the queue's GPU `requested` and `fairShare` as `-2`, and the value propagated up to `default-parent-queue`:

```
Resource division result for queue <kai-dra-test-q>: GPU: deserved: <8>, requested: <-2>, ... fairShare: <-2>
allocate ... resources: <[0 0 -2 1 0 0 0]>
```

## Tests

All of these fail on the pre-fix code and pass with the change:

- `MaxInt64 + MaxInt64` across two claims of the same device class
- `ExactCount(MaxInt64)` alongside an `AllocationModeAll` request in a single claim
- multi-device-class aggregation in `GetDraGpusCount` and `GpuResourceRequirement.Add`
- a proportion regression that places the oversized workloads and a legitimate 1-GPU workload in one queue, with another queue holding the GPUs, and asserts that the queue ledger stays non-negative, that the oversized demand actually reaches the ledger, and that the reclaim-eligibility gate still admits the legitimate workload

The proportion test is a queue-ledger and reclaim-gate test. It does not drive the full reclaim action (victim selection and eviction), which is a separate stage.

## Related Issues

Fixes #1873

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)

## Breaking Changes

None.
