### PR TITLE
docs: add ArgoCD custom health check for Config and SchedulingShard

### DIFF
--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -68,6 +68,61 @@ Notes:
 - `retry` and the CR's `SkipDryRunOnMissingResource` sync-option cover the first sync, where the Config CRD is not established yet.
 - Default Queues, the default SchedulingShard and the resource-reservation namespace carry `Prune=false` (matching their `helm.sh/resource-policy: keep`), so user-modified scheduling configuration is not pruned on sync.
 
+## ArgoCD health check
+
+ArgoCD has no built-in health assessment for the `kai.scheduler/v1` `Config` and `SchedulingShard` resources, so the Application can report `Healthy` while the operator is still reconciling the CR (or failing to). The operator records progress on the CR's status conditions (`Deployed`, `Available`, `DependenciesFulfilled`), which the e2e suite already gates on instead of Application health (see [#1751](https://github.com/kai-scheduler/KAI-scheduler/issues/1751)).
+
+Add a custom health check to `argocd-cm` so ArgoCD reflects the operator's own status. It reports `Healthy` only when all three conditions are `True` for the current `metadata.generation`, `Degraded` when one is `False` for the current generation, and `Progressing` otherwise (conditions not yet observed for the latest generation):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  resource.customizations.health.kai.scheduler_Config: |
+    local hs = {}
+    hs.status = "Progressing"
+    hs.message = "Waiting for the KAI operator to reconcile the resource"
+
+    if obj.status == nil or obj.status.conditions == nil then
+      return hs
+    end
+
+    local generation = obj.metadata.generation
+    local required = {"Deployed", "Available", "DependenciesFulfilled"}
+    local byType = {}
+    for _, condition in ipairs(obj.status.conditions) do
+      byType[condition.type] = condition
+    end
+
+    for _, name in ipairs(required) do
+      local condition = byType[name]
+      if condition == nil or condition.observedGeneration ~= generation then
+        hs.status = "Progressing"
+        hs.message = name .. " has not been observed for the current generation"
+        return hs
+      end
+      if condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = name .. ": " .. (condition.message or condition.reason or "condition is False")
+        return hs
+      end
+      if condition.status ~= "True" then
+        hs.status = "Progressing"
+        hs.message = name .. " is " .. tostring(condition.status)
+        return hs
+      end
+    end
+
+    hs.status = "Healthy"
+    hs.message = "KAI resource reconciled for the current generation"
+    return hs
+```
+
+The `SchedulingShard` resource reports the same conditions; add an identical block under `resource.customizations.health.kai.scheduler_SchedulingShard` to get the same health assessment for shards.
+
 ## OpenShift
 
 OpenShift auto-detection uses a cluster `lookup`, which returns nothing when ArgoCD renders the chart offline. Set it explicitly, otherwise the `SecurityContextConstraints` and the OpenShift hook pod security contexts are not rendered:

--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -72,7 +72,7 @@ Notes:
 
 ArgoCD has no built-in health assessment for the `kai.scheduler/v1` `Config` and `SchedulingShard` resources, so the Application can report `Healthy` while the operator is still reconciling the CR (or failing to). The operator records progress on the CR's status conditions (`Deployed`, `Available`, `DependenciesFulfilled`), which the e2e suite already gates on instead of Application health (see [#1751](https://github.com/kai-scheduler/KAI-scheduler/issues/1751)).
 
-Add a custom health check to `argocd-cm` so ArgoCD reflects the operator's own status. It reports `Healthy` only when all three conditions are `True` for the current `metadata.generation`, `Degraded` when one is `False` for the current generation, and `Progressing` otherwise (conditions not yet observed for the latest generation):
+Add a custom health check to `argocd-cm` so ArgoCD reflects the operator's own status. It reports `Healthy` only when all three conditions are `True` for the current `metadata.generation`, and `Degraded` when `DependenciesFulfilled` is `False` for the current generation, since that is the operator's signal that a required dependency is missing and needs attention. A `False` `Deployed` or `Available` is a normal transient state while pods roll out, so it stays `Progressing` to avoid health-degraded notifications on every install or upgrade:
 
 ```yaml
 apiVersion: v1
@@ -91,22 +91,28 @@ data:
     end
 
     local generation = obj.metadata.generation
-    local required = {"Deployed", "Available", "DependenciesFulfilled"}
     local byType = {}
     for _, condition in ipairs(obj.status.conditions) do
       byType[condition.type] = condition
     end
 
+    -- DependenciesFulfilled=False (reason dependencies_missing) is the only
+    -- condition that means a real, user-actionable dependency is absent, so map
+    -- it to Degraded. Deployed=False and Available=False are normal transient
+    -- states while pods roll out, so they stay Progressing.
+    local deps = byType["DependenciesFulfilled"]
+    if deps ~= nil and deps.observedGeneration == generation and deps.status == "False" then
+      hs.status = "Degraded"
+      hs.message = "DependenciesFulfilled: " .. (deps.message or deps.reason or "dependencies are missing")
+      return hs
+    end
+
+    local required = {"Deployed", "Available", "DependenciesFulfilled"}
     for _, name in ipairs(required) do
       local condition = byType[name]
       if condition == nil or condition.observedGeneration ~= generation then
         hs.status = "Progressing"
         hs.message = name .. " has not been observed for the current generation"
-        return hs
-      end
-      if condition.status == "False" then
-        hs.status = "Degraded"
-        hs.message = name .. ": " .. (condition.message or condition.reason or "condition is False")
         return hs
       end
       if condition.status ~= "True" then


### PR DESCRIPTION
Adds an argocd-cm custom health check for the `kai.scheduler/v1` Config and SchedulingShard resources, as described in #1818.

ArgoCD has no built-in health for these CRs, so an Application can show `Healthy` while the operator is still reconciling (the e2e suite already gates on the CR status conditions instead of Application health). The health check mirrors that gating: it maps `Deployed`, `Available` and `DependenciesFulfilled` (checked against `observedGeneration`) to `Healthy` when all three are True for the current generation, `Degraded` when one is False for it, and `Progressing` otherwise.

The doc shows the full Lua under the `Config` key and notes that the same block works for `SchedulingShard` (identical conditions).

Testing: ran the Lua (extracted back out of the YAML block) through a small harness covering healthy, missing-condition, stale-generation, false-condition (Degraded), unknown-status, and no-status inputs. Also validated the argocd-cm YAML parses. The script uses only Lua 5.1-compatible constructs, matching ArgoCD's gopher-lua.

Left the optional argo-cd built-in health-library upstream (resource_customizations/) out of this PR since it lives in the argoproj/argo-cd repo; happy to follow up there if you'd like.

Part of #1818.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an ArgoCD health-check guide for scheduler resources.
  * Clarified how to configure custom health rules so ArgoCD reflects `Progressing`, `Degraded`, and `Healthy` states more accurately.
  * Included guidance for applying the same health configuration to both supported resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->