### PR TITLE
fix(e2e): restore scale test job creation

### DIFF
--- a/test/e2e/modules/resources/rd/distributed_batch_job.go
+++ b/test/e2e/modules/resources/rd/distributed_batch_job.go
@@ -49,6 +49,8 @@ type DistributedBatchJobOptions struct {
 	PriorityClassName string
 	// Preemptibility is set as a Job label; the podgrouper reads it onto the PodGroup.
 	Preemptibility v2alpha2.Preemptibility
+	// JobLabels are merged into Job labels.
+	JobLabels map[string]string
 	// ExtraLabels are merged into pod template labels (e.g. for test filtering).
 	ExtraLabels map[string]string
 	// PodSpecMutator is applied to the pod template spec after defaults are set. Scale
@@ -56,34 +58,64 @@ type DistributedBatchJobOptions struct {
 	PodSpecMutator func(*v1.PodSpec)
 }
 
+// JobResult contains a distributed Job and resources created for it.
+type JobResult struct {
+	Job      *batchv1.Job
+	PodGroup *v2alpha2.PodGroup
+	Pods     []*v1.Pod
+}
+
 // CreateDistributedBatchJob submits a batch Job annotated with kai.scheduler/batch-min-member
-// so the podgrouper produces a single PodGroup with MinAvailable=opts.MinMember. Returns the
-// Job, the PodGroup (once the podgrouper has created it), and the pods the Job spawned.
+// so the podgrouper produces a single PodGroup with MinAvailable=opts.MinMember. Returns a
+// JobResult once the podgrouper creates the PodGroup and the Job spawns its pods.
 func CreateDistributedBatchJob(
 	ctx context.Context,
 	kubeClient runtimeClient.Client,
 	jobQueue *v2.Queue,
 	opts DistributedBatchJobOptions,
-) (*batchv1.Job, *v2alpha2.PodGroup, []*v1.Pod, error) {
+) (*JobResult, error) {
+	job, err := SubmitDistributedBatchJob(ctx, kubeClient, jobQueue, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return waitForDistributedBatchJob(ctx, kubeClient, job)
+}
+
+// SubmitDistributedBatchJob submits a batch Job annotated with kai.scheduler/batch-min-member.
+func SubmitDistributedBatchJob(
+	ctx context.Context,
+	kubeClient runtimeClient.Client,
+	jobQueue *v2.Queue,
+	opts DistributedBatchJobOptions,
+) (*batchv1.Job, error) {
 	parallelism := ptr.Deref(opts.Parallelism, 1)
 	minMember := ptr.Deref(opts.MinMember, parallelism)
 
 	job := buildDistributedBatchJob(jobQueue, opts, parallelism, minMember)
-	if err := kubeClient.Create(ctx, job); err != nil {
-		return nil, nil, nil, fmt.Errorf("create Job: %w", err)
+	if err := CreateObjectWithRetries(ctx, kubeClient, job); err != nil {
+		return nil, fmt.Errorf("create Job: %w", err)
 	}
 
+	return job, nil
+}
+
+func waitForDistributedBatchJob(
+	ctx context.Context,
+	kubeClient runtimeClient.Client,
+	job *batchv1.Job,
+) (*JobResult, error) {
 	podGroup, err := waitForPodGroup(ctx, kubeClient, job)
 	if err != nil {
-		return job, nil, nil, err
+		return &JobResult{Job: job}, err
 	}
 
-	pods, err := waitForJobPods(ctx, kubeClient, job, parallelism)
+	pods, err := waitForJobPods(ctx, kubeClient, job, ptr.Deref(job.Spec.Parallelism, 1))
 	if err != nil {
-		return job, podGroup, nil, err
+		return &JobResult{Job: job, PodGroup: podGroup}, err
 	}
 
-	return job, podGroup, pods, nil
+	return &JobResult{Job: job, PodGroup: podGroup, Pods: pods}, nil
 }
 
 func buildDistributedBatchJob(
@@ -114,6 +146,7 @@ func buildDistributedBatchJob(
 	if opts.Preemptibility != "" {
 		job.Labels[pgconstants.PreemptibilityLabelKey] = string(opts.Preemptibility)
 	}
+	maps.Copy(job.Labels, opts.JobLabels)
 
 	if opts.PriorityClassName != "" {
 		job.Spec.Template.Spec.PriorityClassName = opts.PriorityClassName
@@ -150,7 +183,10 @@ func waitForPodGroup(
 }
 
 func waitForJobPods(
-	ctx context.Context, kubeClient runtimeClient.Client, job *batchv1.Job, expected int32,
+	ctx context.Context,
+	kubeClient runtimeClient.Client,
+	job *batchv1.Job,
+	expected int32,
 ) ([]*v1.Pod, error) {
 	var pods []*v1.Pod
 	err := wait.PollUntilContextTimeout(ctx, podGroupFetchPoll, podGroupFetchTimeout, true,
@@ -163,13 +199,18 @@ func waitForJobPods(
 			if err != nil {
 				return false, err
 			}
-			if int32(len(list.Items)) < expected {
+			livePods := make([]*v1.Pod, 0, len(list.Items))
+			for i := range list.Items {
+				pod := &list.Items[i]
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+				livePods = append(livePods, pod)
+			}
+			if int32(len(livePods)) < expected {
 				return false, nil
 			}
-			pods = make([]*v1.Pod, 0, len(list.Items))
-			for i := range list.Items {
-				pods = append(pods, &list.Items[i])
-			}
+			pods = livePods
 			return true, nil
 		})
 	if err != nil {

--- a/test/e2e/modules/resources/rd/object.go
+++ b/test/e2e/modules/resources/rd/object.go
@@ -1,0 +1,38 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package rd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	operationAttemptsRetries = 10
+	retryInterval            = 100 * time.Microsecond
+)
+
+// CreateObjectWithRetries creates an object using the scale-test retry behavior.
+func CreateObjectWithRetries(
+	ctx context.Context, kubeClient runtimeClient.Client, obj runtimeClient.Object,
+) error {
+	key := runtimeClient.ObjectKeyFromObject(obj)
+	err := kubeClient.Get(ctx, key, obj)
+	if err == nil {
+		return fmt.Errorf("object %v already exists in the cluster", key)
+	}
+
+	for i := 0; i < operationAttemptsRetries; i++ {
+		err = kubeClient.Create(ctx, obj)
+		if err == nil || errors.IsAlreadyExists(err) {
+			return nil
+		}
+		time.Sleep(retryInterval)
+	}
+	return err
+}

--- a/test/e2e/modules/resources/rd/object.go
+++ b/test/e2e/modules/resources/rd/object.go
@@ -5,7 +5,6 @@ package rd
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -21,13 +20,8 @@ const (
 func CreateObjectWithRetries(
 	ctx context.Context, kubeClient runtimeClient.Client, obj runtimeClient.Object,
 ) error {
-	key := runtimeClient.ObjectKeyFromObject(obj)
-	err := kubeClient.Get(ctx, key, obj)
-	if err == nil {
-		return fmt.Errorf("object %v already exists in the cluster", key)
-	}
-
-	for i := 0; i < operationAttemptsRetries; i++ {
+	var err error
+	for range operationAttemptsRetries {
 		err = kubeClient.Create(ctx, obj)
 		if err == nil || errors.IsAlreadyExists(err) {
 			return nil

--- a/test/e2e/scale/kwok_job_creation.go
+++ b/test/e2e/scale/kwok_job_creation.go
@@ -5,8 +5,8 @@ package scale
 
 import (
 	"context"
+	"maps"
 
-	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -22,23 +22,20 @@ func createJobObjectForKwok(
 	jobQueue *v2.Queue,
 	resources v1.ResourceRequirements,
 	extraLabels map[string]string,
-) *batchv1.Job {
-	job, _, _, err := rd.CreateDistributedBatchJob(ctx, testCtx.ControllerClient, jobQueue,
-		rd.DistributedBatchJobOptions{
-			Resources:      resources,
-			ExtraLabels:    extraLabels,
-			PodSpecMutator: addKWOKTaintsAndAffinity,
-		})
-	Expect(err).To(Succeed())
-	return job
+) (*batchv1.Job, error) {
+	job := rd.CreateBatchJobObject(jobQueue, resources)
+	addKWOKTaintsAndAffinity(&job.Spec.Template.Spec)
+	maps.Copy(job.Spec.Template.ObjectMeta.Labels, extraLabels)
+
+	return job, rd.CreateObjectWithRetries(ctx, testCtx.ControllerClient, job)
 }
 
 func createDistributedJobForKwok(
 	ctx context.Context, testCtx *testcontext.TestContext,
 	jobQueue *v2.Queue, resourcesPerPod v1.ResourceRequirements, numberOfTasks int,
 	extraLabels map[string]string, topologyConstraint *v2alpha2.TopologyConstraint,
-) (*v2alpha2.PodGroup, []*v1.Pod, error) {
-	_, pg, pods, err := rd.CreateDistributedBatchJob(ctx, testCtx.ControllerClient, jobQueue,
+) (*rd.JobResult, error) {
+	return rd.CreateDistributedBatchJob(ctx, testCtx.ControllerClient, jobQueue,
 		rd.DistributedBatchJobOptions{
 			Parallelism:        ptr.To(int32(numberOfTasks)),
 			Resources:          resourcesPerPod,
@@ -46,5 +43,20 @@ func createDistributedJobForKwok(
 			TopologyConstraint: topologyConstraint,
 			PodSpecMutator:     addKWOKTaintsAndAffinity,
 		})
-	return pg, pods, err
+}
+
+func submitDistributedJobForKwok(
+	ctx context.Context, testCtx *testcontext.TestContext,
+	jobQueue *v2.Queue, resourcesPerPod v1.ResourceRequirements, numberOfTasks int,
+	extraLabels, jobLabels map[string]string, topologyConstraint *v2alpha2.TopologyConstraint,
+) (*batchv1.Job, error) {
+	return rd.SubmitDistributedBatchJob(ctx, testCtx.ControllerClient, jobQueue,
+		rd.DistributedBatchJobOptions{
+			Parallelism:        ptr.To(int32(numberOfTasks)),
+			Resources:          resourcesPerPod,
+			ExtraLabels:        extraLabels,
+			JobLabels:          jobLabels,
+			TopologyConstraint: topologyConstraint,
+			PodSpecMutator:     addKWOKTaintsAndAffinity,
+		})
 }

--- a/test/e2e/scale/kwok_test.go
+++ b/test/e2e/scale/kwok_test.go
@@ -5,6 +5,7 @@ package scale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -329,18 +330,29 @@ var _ = Describe("Kwok scale test", Ordered, Label(labels.Scale), func() {
 			})
 
 			It("schedules jobs with pending tasks in background", func(ctx context.Context) {
+				creationErrors := make(chan error, pendingBackgroundTasks)
 				var wg sync.WaitGroup
 				for range pendingBackgroundTasks {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						createJobObjectForKwok(
+						_, err := createJobObjectForKwok(
 							ctx, testCtx, noGPUQuotaQueue,
 							SingleGPURequirement, map[string]string{},
 						)
+						if err != nil {
+							creationErrors <- err
+						}
 					}()
 				}
 				wg.Wait()
+				close(creationErrors)
+
+				var creationError error
+				for err := range creationErrors {
+					creationError = errors.Join(creationError, err)
+				}
+				Expect(creationError).NotTo(HaveOccurred(), "Failed to create some pending background jobs")
 
 				wait.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -393,7 +405,7 @@ var _ = Describe("Kwok scale test", Ordered, Label(labels.Scale), func() {
 						It("measure time for reclaim to fail on distributed job last pod", func(ctx context.Context) {
 							averageTimeToUnschedulable := measureUnschedulableDelayInSeconds(
 								ctx, testCtx, reclaimSingleGPUJobsQueue,
-								func(ctx context.Context, testCtx *testcontext.TestContext, queue *v2.Queue) (*v2alpha2.PodGroup, []*v1.Pod, error) {
+								func(ctx context.Context, testCtx *testcontext.TestContext, queue *v2.Queue) (*rd.JobResult, error) {
 									return createDistributedJobForKwok(
 										ctx, testCtx, queue,
 										v1.ResourceRequirements{

--- a/test/e2e/scale/kwok_test_functions.go
+++ b/test/e2e/scale/kwok_test_functions.go
@@ -212,9 +212,9 @@ func distributedJobsScaleTestInternal(
 
 func waitForDistributedJobsForKwok(
 	ctx context.Context, testCtx *testcontext.TestContext, jobs []*batchv1.Job,
-) {
+) []*v1.Pod {
 	if len(jobs) == 0 {
-		return
+		return nil
 	}
 
 	expectedPods := 0
@@ -239,6 +239,18 @@ func waitForDistributedJobsForKwok(
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(len(podGroups.Items)).To(Equal(len(jobs)))
 	}, maxFlowTimeoutMinutes*time.Minute, podsPollIntervalSeconds*time.Second).Should(Succeed())
+
+	pods := &v1.PodList{}
+	Expect(testCtx.ControllerClient.List(ctx, pods,
+		runtimeClient.InNamespace(jobs[0].Namespace),
+		runtimeClient.MatchingLabels{distributedJobBatchLabel: batchID},
+	)).To(Succeed())
+
+	result := make([]*v1.Pod, 0, len(pods.Items))
+	for i := range pods.Items {
+		result = append(result, &pods.Items[i])
+	}
+	return result
 }
 
 func consolidateScaleTest(
@@ -371,23 +383,32 @@ func runNCCLSimulation(
 ) (testSucceeded bool, totalPods int, completedPods int, pendingPods int, startTime time.Time) {
 	jobSizes := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
 	startTime = time.Now()
-	var testPods []*v1.Pod
+	batchID := utils.GenerateRandomK8sName(10)
+	podLabels := map[string]string{
+		"burst-test":             "true",
+		distributedJobBatchLabel: batchID,
+	}
+	jobLabels := map[string]string{distributedJobBatchLabel: batchID}
+	var jobs []*batchv1.Job
+	var creationError error
 	for _, jobSize := range jobSizes {
 		if jobSize > numberOfNodes {
 			break
 		}
 		for range numberOfNCCLJobsPerSize {
-			result, err := createDistributedJobForKwok(
+			job, err := submitDistributedJobForKwok(
 				ctx, testCtx, testQueue, FullNodeGPURequirement, jobSize,
-				map[string]string{
-					"burst-test": "true",
-				},
-				nil,
+				podLabels, jobLabels, nil,
 			)
-			Expect(err).NotTo(HaveOccurred())
-			testPods = append(testPods, result.Pods...)
+			if err != nil {
+				creationError = errors.Join(creationError, err)
+				continue
+			}
+			jobs = append(jobs, job)
 		}
 	}
+	Expect(creationError).NotTo(HaveOccurred(), "Failed to create some NCCL jobs")
+	testPods := waitForDistributedJobsForKwok(ctx, testCtx, jobs)
 
 	totalPods = len(testPods)
 	completedPods = 0

--- a/test/e2e/scale/kwok_test_functions.go
+++ b/test/e2e/scale/kwok_test_functions.go
@@ -5,6 +5,7 @@ package scale
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"time"
@@ -12,7 +13,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/multierr"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +27,8 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/testconfig"
-	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+	waitutils "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
 )
 
 const (
@@ -34,6 +36,7 @@ const (
 	KWOKOperatorNodePoolName = "managed-nodepool"
 	podsPollIntervalSeconds  = 10
 	testLabelKey             = "scale-test"
+	distributedJobBatchLabel = "scale-test-batch"
 
 	defaultNumberOfNodes         = 500
 	gpusPerNode                  = 8
@@ -101,17 +104,25 @@ func fillClusterWithJobs(
 	totalNumberOfJobs = (numberOfNodes * gpusPerNode) / gpusPerJob
 
 	var wg sync.WaitGroup
+	var creationError error
+	var lock sync.Mutex
 	for range totalNumberOfJobs {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			createJobObjectForKwok(ctx, testCtx, testQueue, resourceRequirements, map[string]string{})
+			_, err := createJobObjectForKwok(ctx, testCtx, testQueue, resourceRequirements, map[string]string{})
+			if err != nil {
+				lock.Lock()
+				creationError = errors.Join(creationError, err)
+				lock.Unlock()
+			}
 		}()
 	}
 	wg.Wait()
+	Expect(creationError).NotTo(HaveOccurred(), "Failed to create some jobs")
 
 	GinkgoLogr.Info("Waiting for pods creation")
-	wait.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, metav1.LabelSelector{
+	waitutils.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			testconfig.GetConfig().QueueLabelKey: testQueue.Name,
 		},
@@ -150,29 +161,35 @@ func distributedJobsScaleTestInternal(
 	var wg sync.WaitGroup
 	var creationError error
 	var lock sync.Mutex
+	var jobs []*batchv1.Job
+	batchID := utils.GenerateRandomK8sName(10)
+	batchLabels := map[string]string{distributedJobBatchLabel: batchID}
 
 	for range numberOfDistributedJobs {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _, err := createDistributedJobForKwok(
+			job, err := submitDistributedJobForKwok(
 				ctx, testCtx, testQueue,
 				v1.ResourceRequirements{
 					Limits: map[v1.ResourceName]resource.Quantity{
 						constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpuPerPod), resource.DecimalSI),
 					},
 				}, podsPerDistributedJob,
-				map[string]string{}, topologyConstraint,
+				batchLabels, batchLabels, topologyConstraint,
 			)
+			lock.Lock()
+			defer lock.Unlock()
 			if err != nil {
-				lock.Lock()
-				creationError = multierr.Append(creationError, err)
-				lock.Unlock()
+				creationError = errors.Join(creationError, err)
+				return
 			}
+			jobs = append(jobs, job)
 		}()
 	}
 	wg.Wait()
 	Expect(creationError).NotTo(HaveOccurred(), "Failed to create some distributed jobs")
+	waitForDistributedJobsForKwok(ctx, testCtx, jobs)
 
 	startTime := time.Now()
 	schedulerconfig.EnableScheduler(ctx, testCtx)
@@ -191,6 +208,37 @@ func distributedJobsScaleTestInternal(
 			"distributed jobs": numberOfDistributedJobs,
 			"time":             endTime.Sub(startTime).String(),
 		})).To(Succeed())
+}
+
+func waitForDistributedJobsForKwok(
+	ctx context.Context, testCtx *testcontext.TestContext, jobs []*batchv1.Job,
+) {
+	if len(jobs) == 0 {
+		return
+	}
+
+	expectedPods := 0
+	for _, job := range jobs {
+		if job.Spec.Parallelism == nil {
+			expectedPods++
+		} else {
+			expectedPods += int(*job.Spec.Parallelism)
+		}
+	}
+
+	batchID := jobs[0].Labels[distributedJobBatchLabel]
+	selector := metav1.LabelSelector{MatchLabels: map[string]string{distributedJobBatchLabel: batchID}}
+	waitutils.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, selector, expectedPods)
+
+	Eventually(func(g Gomega) {
+		podGroups := &v2alpha2.PodGroupList{}
+		err := testCtx.ControllerClient.List(ctx, podGroups,
+			runtimeClient.InNamespace(jobs[0].Namespace),
+			runtimeClient.MatchingLabels{distributedJobBatchLabel: batchID},
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(podGroups.Items)).To(Equal(len(jobs)))
+	}, maxFlowTimeoutMinutes*time.Minute, podsPollIntervalSeconds*time.Second).Should(Succeed())
 }
 
 func consolidateScaleTest(
@@ -219,10 +267,11 @@ func measureReclaimSingleGPUJob(
 	totalTime := time.Duration(0)
 	for i := 0; i < statusMeasuringSamples; i++ {
 		startTime := time.Now()
-		createJobObjectForKwok(
+		_, err := createJobObjectForKwok(
 			ctx, testCtx, testQueue, SingleGPURequirement,
 			map[string]string{},
 		)
+		Expect(err).NotTo(HaveOccurred())
 		scheduledTime := waitForAllJobsToSchedule(ctx, testCtx, testQueue, i+1)
 		totalTime += scheduledTime.Sub(startTime)
 	}
@@ -237,12 +286,13 @@ func measureReclaimSingleGPUJob(
 
 func measureUnschedulableDelayInSeconds(
 	ctx context.Context, testCtx *testcontext.TestContext, testQueue *v2.Queue,
-	createJob func(context.Context, *testcontext.TestContext, *v2.Queue) (*v2alpha2.PodGroup, []*v1.Pod, error),
+	createJob func(context.Context, *testcontext.TestContext, *v2.Queue) (*rd.JobResult, error),
 ) float64 {
 	totalTime := time.Duration(0)
 	for i := 0; i < statusMeasuringSamples; i++ {
-		pg, pods, err := createJob(ctx, testCtx, testQueue)
+		result, err := createJob(ctx, testCtx, testQueue)
 		Expect(err).NotTo(HaveOccurred())
+		pg := result.PodGroup
 		Eventually(func(g Gomega) bool {
 			updatedPodGroup := &v2alpha2.PodGroup{}
 			err := testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKeyFromObject(pg), updatedPodGroup)
@@ -257,10 +307,7 @@ func measureUnschedulableDelayInSeconds(
 			return false
 		}, maxFlowTimeoutMinutes*time.Minute, podsPollIntervalSeconds*time.Second).Should(BeTrue())
 
-		for _, pod := range pods {
-			Expect(deleteObjectWithRetries(ctx, testCtx.ControllerClient, pod)).To(Succeed())
-		}
-		Expect(deleteObjectWithRetries(ctx, testCtx.ControllerClient, pg)).To(Succeed())
+		Expect(deleteObjectWithRetries(ctx, testCtx.ControllerClient, result.Job)).To(Succeed())
 	}
 
 	return totalTime.Seconds() / float64(statusMeasuringSamples)
@@ -268,7 +315,7 @@ func measureUnschedulableDelayInSeconds(
 
 // reclaimForOneLargeJob creates a distributed job with the specified number of pods, each requesting gpusPerNode GPUs
 func reclaimForOneLargeJob(ctx context.Context, testCtx *testcontext.TestContext, reclaimSingleGPUJobsQueue *v2.Queue, numberOfPods int) {
-	podGroup, _, err := createDistributedJobForKwok(
+	result, err := createDistributedJobForKwok(
 		ctx, testCtx, reclaimSingleGPUJobsQueue,
 		v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
@@ -279,6 +326,7 @@ func reclaimForOneLargeJob(ctx context.Context, testCtx *testcontext.TestContext
 		nil,
 	)
 	Expect(err).NotTo(HaveOccurred())
+	podGroup := result.PodGroup
 
 	podsList := &v1.PodList{}
 	Eventually(func(g Gomega) bool {
@@ -329,15 +377,15 @@ func runNCCLSimulation(
 			break
 		}
 		for range numberOfNCCLJobsPerSize {
-			_, createdPods, err := createDistributedJobForKwok(
+			result, err := createDistributedJobForKwok(
 				ctx, testCtx, testQueue, FullNodeGPURequirement, jobSize,
 				map[string]string{
 					"burst-test": "true",
 				},
 				nil,
 			)
-			testPods = append(testPods, createdPods...)
 			Expect(err).NotTo(HaveOccurred())
+			testPods = append(testPods, result.Pods...)
 		}
 	}
 

--- a/test/e2e/suites/allocate/topology/topology_test.go
+++ b/test/e2e/suites/allocate/topology/topology_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Topology", Ordered, func() {
 
 func createDistributedWorkload(ctx context.Context, testCtx *testcontext.TestContext,
 	podCount int, podResource v1.ResourceList, topologyConstraint v2alpha2.TopologyConstraint) []*v1.Pod {
-	_, _, pods, err := rd.CreateDistributedBatchJob(ctx, testCtx.ControllerClient, testCtx.Queues[0],
+	result, err := rd.CreateDistributedBatchJob(ctx, testCtx.ControllerClient, testCtx.Queues[0],
 		rd.DistributedBatchJobOptions{
 			Parallelism:        ptr.To(int32(podCount)),
 			NamePrefix:         "distributed-" + utils.GenerateRandomK8sName(5) + "-",
@@ -315,5 +315,5 @@ func createDistributedWorkload(ctx context.Context, testCtx *testcontext.TestCon
 			TopologyConstraint: &topologyConstraint,
 		})
 	Expect(err).To(Succeed())
-	return pods
+	return result.Pods
 }


### PR DESCRIPTION
## Description

Restore scalable Job creation in the KWOK scale tests after the distributed Job refactor.

- keep bulk one-pod Job creation asynchronous and preserve the existing retry behavior
- split distributed Job submission from controller-generated resource readiness
- wait once for the expected Pod and PodGroup counts in distributed scale batches
- return Job, PodGroup, and Pods through `JobResult`
- propagate concurrent creation failures through the parent Ginkgo goroutine
- delete the owning Job between unschedulable-delay samples

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None. Changes affect test infrastructure helpers and their in-repository callers.

## Additional Notes

Validated with compile-only checks for the resource helpers, scale suite, and topology suite, focused `go vet`, and `git diff --check`.

The KWOK scale suite was not run locally because it requires the dedicated scale-test environment. `make validate` reached a pre-existing generation-order failure where generated clients are removed before `controller-gen` imports them; its working-tree side effects were restored.
