### PR TITLE
fix(scheduler): scheduler snapshot writes config:null between scheduling cycles - v0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Scheduler snapshot now correctly captures the plugin configuration even when `/get-snapshot` is requested between scheduling cycles (previously the `config` field was written as `null`, causing snapshot-tool to panic on replay). [#1885](https://github.com/kai-scheduler/KAI-Scheduler/issues/1885)
+
 ## [v0.16.4] - 2026-07-12
 
 ### Added

--- a/pkg/scheduler/plugins/snapshot/snapshot.go
+++ b/pkg/scheduler/plugins/snapshot/snapshot.go
@@ -69,6 +69,7 @@ type Snapshot struct {
 
 type snapshotPlugin struct {
 	session *framework.Session
+	config  *conf.SchedulerConfiguration
 }
 
 type jsonStream struct {
@@ -89,6 +90,7 @@ func (sp *snapshotPlugin) Name() string {
 
 func (sp *snapshotPlugin) OnSessionOpen(ssn *framework.Session) {
 	sp.session = ssn
+	sp.config = ssn.Config
 	log.InfraLogger.V(3).Info("Snapshot plugin registering get-snapshot")
 	ssn.AddHttpHandler("/get-snapshot", sp.serveSnapshot)
 }
@@ -123,7 +125,7 @@ func (sp *snapshotPlugin) writeSnapshot(ctx context.Context, writer io.Writer) e
 	return stream.writeObject(func(object *jsonObjectWriter) error {
 		return writeFields(
 			object,
-			valueField("config", sp.session.Config),
+			valueField("config", sp.config),
 			valueField("schedulerParams", &sp.session.SchedulerParams),
 			streamedField("rawObjects", sp.writeRawObjects),
 			streamedField("discovery", func(stream *jsonStream) error {


### PR DESCRIPTION
## Description

Backport of the snapshot-plugin config-caching fix from #1843 to v0.16.

`closeSession` sets `ssn.Config = nil` at the end of every scheduling cycle. The snapshot plugin stored only a reference to the live session and read `sp.session.Config` at HTTP request time. Any `/get-snapshot` request that arrived between two scheduling cycles therefore serialised `"config":null` into the archive.

`snapshot-tool` dereferences `snapshot.Config` unconditionally, so replaying such an archive panics with a nil pointer dereference in `framework.OpenSession`.

**Fix:** cache the config pointer in the plugin struct at `OnSessionOpen` time (`sp.config = ssn.Config`) and use that cached copy when writing the snapshot, making the serialised value immune to later session teardown.

## Related Issues

Fixes #1885

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Additional Notes

Minimal two-liner change; identical to the diff already merged to `main` via #1843.