### PR TITLE
fix(binder): sanitize configmap volume names for dotted pod names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
 - In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
 
 ## [v0.9.20] - 2026-06-22
 

--- a/pkg/binder/common/gpusharingconfigmap/config_map.go
+++ b/pkg/binder/common/gpusharingconfigmap/config_map.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -140,6 +141,7 @@ func generateConfigMapNamePrefix(pod *v1.Pod, containerIndex int) string {
 	if len(baseName) > maxBaseNameLength {
 		baseName = baseName[:maxBaseNameLength]
 	}
+	baseName = strings.TrimRight(baseName, ".-")
 	return fmt.Sprintf("%v-%v-%v", baseName,
 		utilrand.String(configMapNameNumRandomChars), gpuSharingConfigMap)
 }

--- a/pkg/binder/common/gpusharingconfigmap/config_map_name_test.go
+++ b/pkg/binder/common/gpusharingconfigmap/config_map_name_test.go
@@ -6,8 +6,10 @@ package gpusharingconfigmap
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 type configMapNameTest struct {
@@ -27,9 +29,7 @@ func TestGetDesiredConfigMapName(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{},
-					},
+					Containers: []v1.Container{{}},
 				},
 			},
 			containerIndex:       0,
@@ -44,22 +44,18 @@ func TestGetDesiredConfigMapName(t *testing.T) {
 					},
 				},
 				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{},
-						{},
-					},
-					Volumes: []v1.Volume{
-						{
-							Name: "config-map-vol",
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: "config-map-name-1",
-									},
+					Containers: []v1.Container{{}, {}},
+					Volumes: []v1.Volume{{
+						Name: "config-map-vol",
+						VolumeSource: v1.VolumeSource{
+							ConfigMap: &v1.ConfigMapVolumeSource{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "config-map-name-1",
 								},
 							},
 						},
 					}},
+				},
 			},
 			containerIndex:       1,
 			desiredConfigMapName: "config-map-name-1",
@@ -84,4 +80,53 @@ func TestGetDesiredConfigMapName(t *testing.T) {
 			t.Errorf("Expected config map name %v but got %v", test.desiredConfigMapName, configMapName)
 		}
 	}
+}
+
+func TestSetGpuCapabilitiesConfigMapNameTrimsTrailingDotAfterTruncation(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.b",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{}},
+		},
+	}
+
+	containerRef := &PodContainerRef{
+		Container: &pod.Spec.Containers[0],
+		Index:     0,
+		Type:      RegularContainer,
+	}
+
+	configMapName := SetGpuCapabilitiesConfigMapName(pod, containerRef)
+
+	assert.Empty(t, validation.IsDNS1123Subdomain(configMapName))
+	assert.NotContains(t, configMapName, ".-")
+	assert.Equal(t, pod.Annotations[gpuSharingConfigMapAnnotation]+"-0", configMapName)
+}
+
+func TestSetGpuCapabilitiesConfigMapNameUsesOwnerRefAndTrimsTrailingHyphenAfterTruncation(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fallback-name",
+			OwnerReferences: []metav1.OwnerReference{{
+				Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b",
+			}},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{}},
+		},
+	}
+
+	containerRef := &PodContainerRef{
+		Container: &pod.Spec.Containers[0],
+		Index:     0,
+		Type:      RegularContainer,
+	}
+
+	configMapName := SetGpuCapabilitiesConfigMapName(pod, containerRef)
+
+	assert.Empty(t, validation.IsDNS1123Subdomain(configMapName))
+	assert.NotContains(t, configMapName, "--")
+	assert.Equal(t, pod.Annotations[gpuSharingConfigMapAnnotation]+"-0", configMapName)
 }

--- a/pkg/binder/common/volumes.go
+++ b/pkg/binder/common/volumes.go
@@ -4,7 +4,8 @@
 package common
 
 import (
-	"fmt"
+	"regexp"
+	"strings"
 
 	"k8s.io/api/core/v1"
 )
@@ -40,6 +41,11 @@ func addConfigMapVolume(podSpec *v1.PodSpec, volumeName string, configMapName st
 	podSpec.Volumes = append(podSpec.Volumes, volume)
 }
 
+var invalidDNSLabelChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
 func GetConfigVolumeName(configMapName string) string {
-	return fmt.Sprintf("%v-vol", configMapName)
+	// ConfigMap names may be DNS subdomains, but volume names must be DNS labels.
+	volumeName := strings.ToLower(configMapName + "-vol")
+	volumeName = invalidDNSLabelChars.ReplaceAllString(volumeName, "-")
+	return strings.Trim(volumeName, "-")
 }

--- a/pkg/binder/common/volumes_test.go
+++ b/pkg/binder/common/volumes_test.go
@@ -4,10 +4,12 @@
 package common
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func TestAddConfigMapVolume(t *testing.T) {
@@ -38,4 +40,34 @@ func TestOverrideConfigMapVolume(t *testing.T) {
 	assert.Equal(t, len(podSpec.Volumes), 1)
 	assert.Equal(t, podSpec.Volumes[0].Name, "name")
 	assert.Equal(t, podSpec.Volumes[0].ConfigMap.LocalObjectReference.Name, "conf2")
+}
+
+func TestGetConfigVolumeName(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMapName string
+		expected      string
+	}{
+		{
+			name:          "replaces dots and keeps suffix",
+			configMapName: "test.pod-abc1234-shared-gpu-0",
+			expected:      "test-pod-abc1234-shared-gpu-0-vol",
+		},
+		{
+			name:          "normalizes unsupported characters",
+			configMapName: "test_pod.config@1",
+			expected:      "test-pod-config-1-vol",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := GetConfigVolumeName(tt.configMapName)
+
+			assert.Equal(t, tt.expected, actual)
+			assert.True(t, strings.HasSuffix(actual, "-vol"))
+			assert.NotContains(t, actual, ".")
+			assert.Empty(t, validation.IsDNS1123Label(actual))
+		})
+	}
 }


### PR DESCRIPTION
## Description

Backports #1728 to `v0.9`.

## Related Issues

Backport of #1728.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Validated with `go test ./pkg/binder/common/gpusharingconfigmap ./pkg/binder/common`.

