### PR TITLE
fix(scheduler): Track extended resources present on only a subset of nodes in MaxNodeResourcesPredicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Fixed extended resources present on only a subset of nodes being reported as unavailable cluster-wide: `ResourceVector.SetMax` now grows the accumulator to the longer vector's length instead of silently dropping resource indices discovered after the first-iterated node, which caused pods requesting such resources to be rejected as unschedulable ("No node in the node-pool has X resources") depending on node map iteration order. [#1851](https://github.com/kai-scheduler/KAI-Scheduler/issues/1851)
 - Scheduler snapshot now correctly captures the plugin configuration even when `/get-snapshot` is requested between scheduling cycles (previously the `config` field was written as `null`, causing snapshot-tool to panic on replay). [#1885](https://github.com/kai-scheduler/KAI-Scheduler/issues/1885)
 
 ## [v0.16.4] - 2026-07-12

--- a/pkg/scheduler/api/resource_info/resource_vector.go
+++ b/pkg/scheduler/api/resource_info/resource_vector.go
@@ -258,10 +258,15 @@ func (r *ResourceRequirements) FromVector(vec ResourceVector, indexMap *Resource
 	}
 }
 
-func (v ResourceVector) SetMax(other ResourceVector) {
-	for i := range min(len(v), len(other)) {
-		if other[i] > v[i] {
-			v[i] = other[i]
+func (v *ResourceVector) SetMax(other ResourceVector) {
+	if len(*v) < len(other) {
+		extended := make(ResourceVector, len(other))
+		copy(extended, *v)
+		*v = extended
+	}
+	for i := range other {
+		if other[i] > (*v)[i] {
+			(*v)[i] = other[i]
 		}
 	}
 }

--- a/pkg/scheduler/api/resource_info/resource_vector_test.go
+++ b/pkg/scheduler/api/resource_info/resource_vector_test.go
@@ -102,6 +102,56 @@ var _ = Describe("ResourceVector", func() {
 		})
 	})
 
+	Describe("SetMax", func() {
+		It("should take element-wise maximum for vectors of equal length", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemSmall, gpuTwo}
+			vec2 := ResourceVector{vecValSmall, vecValMemMedium, gpuOne}
+
+			vec1.SetMax(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}))
+		})
+
+		It("should extend shorter receiver and pick up values at extended indices", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall, gpuOne}
+
+			vec1.SetMax(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, gpuOne}))
+		})
+
+		It("should preserve receiver values beyond the other vector's length", func() {
+			vec1 := ResourceVector{vecValSmall, vecValMemSmall, gpuTwo}
+			vec2 := ResourceVector{vecValMedium, vecValMemMedium}
+
+			vec1.SetMax(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}))
+		})
+
+		It("should leave receiver unchanged when other values are smaller", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall, gpuOne}
+
+			vec1.SetMax(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}))
+		})
+
+		It("should adopt the other vector when receiver is empty", func() {
+			vec1 := ResourceVector{}
+			vec2 := ResourceVector{vecValSmall, vecValMemSmall}
+
+			vec1.SetMax(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValSmall, vecValMemSmall}))
+		})
+
+		It("should leave receiver unchanged when other vector is empty", func() {
+			vec1 := ResourceVector{vecValMedium, vecValMemMedium}
+			vec2 := ResourceVector{}
+
+			vec1.SetMax(vec2)
+			Expect(vec1).To(Equal(ResourceVector{vecValMedium, vecValMemMedium}))
+		})
+	})
+
 	Describe("Clone", func() {
 		It("should create a deep copy of the vector", func() {
 			original := ResourceVector{vecValMedium, vecValMemMedium, gpuTwo}

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -561,6 +561,142 @@ func TestMaxNodeResourcesPredicateDRA(t *testing.T) {
 	}
 }
 
+func buildTestNodesIncremental(scanOrder []string, nodesResourceLists map[string]v1.ResourceList) (
+	map[string]*node_info.NodeInfo, *resource_info.ResourceVectorMap) {
+	vm := resource_info.NewResourceVectorMap()
+	result := make(map[string]*node_info.NodeInfo, len(nodesResourceLists))
+	for _, name := range scanOrder {
+		rl := nodesResourceLists[name]
+		vm.AddResourceList(rl)
+		result[name] = &node_info.NodeInfo{
+			Name:              name,
+			AllocatableVector: resource_info.ResourceFromResourceList(rl).ToVector(vm),
+			VectorMap:         vm,
+		}
+	}
+	return result, vm
+}
+
+func buildPodRequestingResources(requests v1.ResourceList) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name1",
+			Namespace: "n1",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: requests,
+					},
+				},
+			},
+		},
+	}
+}
+
+const extendedResourceTestIterations = 20
+
+func Test_maxNodeResourcesExtendedResourceOnSubsetOfNodes(t *testing.T) {
+	fooResource := v1.ResourceName("example.com/foo")
+	coreOnly := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("4"),
+		v1.ResourceMemory: resource.MustParse("16Gi"),
+		v1.ResourcePods:   resource.MustParse("110"),
+	}
+	nodesResourceLists := map[string]v1.ResourceList{
+		"n1": coreOnly,
+		"n2": coreOnly,
+		"n3": coreOnly,
+		"n4": coreOnly,
+		"n5": {
+			v1.ResourceCPU:    resource.MustParse("4"),
+			v1.ResourceMemory: resource.MustParse("16Gi"),
+			v1.ResourcePods:   resource.MustParse("110"),
+			fooResource:       resource.MustParse("5"),
+		},
+	}
+	scanOrder := []string{"n1", "n2", "n3", "n4", "n5"}
+
+	t.Run("pod requesting the resource within capacity fits", func(t *testing.T) {
+		for i := 0; i < extendedResourceTestIterations; i++ {
+			nodesMap, _ := buildTestNodesIncremental(scanOrder, nodesResourceLists)
+			mnr := NewMaxNodeResourcesPredicate(nodesMap, nil, "")
+			pod := buildPodRequestingResources(v1.ResourceList{fooResource: resource.MustParse("1")})
+			_, status := mnr.PreFilter(context.TODO(), nil, pod, nil)
+			if status != nil {
+				t.Fatalf("iteration %d: PreFilter() = %v, want nil", i, status)
+			}
+		}
+	})
+
+	t.Run("pod requesting more than any node has is rejected", func(t *testing.T) {
+		for i := 0; i < extendedResourceTestIterations; i++ {
+			nodesMap, _ := buildTestNodesIncremental(scanOrder, nodesResourceLists)
+			mnr := NewMaxNodeResourcesPredicate(nodesMap, nil, "")
+			pod := buildPodRequestingResources(v1.ResourceList{fooResource: resource.MustParse("10")})
+			_, status := mnr.PreFilter(context.TODO(), nil, pod, nil)
+			if status == nil {
+				t.Fatalf("iteration %d: PreFilter() = nil, want rejection", i)
+			}
+			if status.Code() != ksf.UnschedulableAndUnresolvable {
+				t.Fatalf("iteration %d: PreFilter() code = %v, want UnschedulableAndUnresolvable", i, status.Code())
+			}
+			if !strings.Contains(status.Message(), string(fooResource)) {
+				t.Fatalf("iteration %d: PreFilter() = %v, message should mention %s", i, status, fooResource)
+			}
+		}
+	})
+
+	t.Run("max resources track the highest capacity across all nodes", func(t *testing.T) {
+		for i := 0; i < extendedResourceTestIterations; i++ {
+			nodesMap, vm := buildTestNodesIncremental(scanOrder, nodesResourceLists)
+			mnr := NewMaxNodeResourcesPredicate(nodesMap, nil, "")
+			fooIdx := vm.GetIndex(fooResource)
+			if fooIdx < 0 {
+				t.Fatalf("iteration %d: %s not registered in vector map", i, fooResource)
+			}
+			if got := mnr.maxResources.Get(fooIdx); got != 5000 {
+				t.Fatalf("iteration %d: maxResources[%s] = %v, want 5000", i, fooResource, got)
+			}
+		}
+	})
+}
+
+func Test_maxNodeResourcesExtendedResourceOnNoNode(t *testing.T) {
+	missingResource := v1.ResourceName("example.com/bar")
+	nodesResourceLists := map[string]v1.ResourceList{
+		"n1": {
+			v1.ResourceCPU:    resource.MustParse("4"),
+			v1.ResourceMemory: resource.MustParse("16Gi"),
+			v1.ResourcePods:   resource.MustParse("110"),
+		},
+		"n2": {
+			v1.ResourceCPU:    resource.MustParse("4"),
+			v1.ResourceMemory: resource.MustParse("16Gi"),
+			v1.ResourcePods:   resource.MustParse("110"),
+		},
+	}
+	pod := buildPodRequestingResources(v1.ResourceList{missingResource: resource.MustParse("1")})
+
+	nodesMap, vm := buildTestNodesIncremental([]string{"n1", "n2"}, nodesResourceLists)
+	vm.AddResourceList(pod.Spec.Containers[0].Resources.Requests)
+
+	mnr := NewMaxNodeResourcesPredicate(nodesMap, nil, "")
+	_, status := mnr.PreFilter(context.TODO(), nil, pod, nil)
+	if status == nil {
+		t.Fatal("PreFilter() = nil, want rejection")
+	}
+	if status.Code() != ksf.UnschedulableAndUnresolvable {
+		t.Fatalf("PreFilter() code = %v, want UnschedulableAndUnresolvable", status.Code())
+	}
+	expectedMessage := "No node in the default node-pool has example.com/bar resources"
+	if !strings.Contains(status.Message(), expectedMessage) {
+		t.Fatalf("PreFilter() = %v, message should contain %q", status, expectedMessage)
+	}
+}
+
 func statusEqual(a, b *ksf.Status) bool {
 	if a == nil && b == nil {
 		return true


### PR DESCRIPTION
## Description

Backports #1852 to `v0.16`.

## Related Issues

Backport of #1852.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Validated with `go test ./pkg/scheduler/api/resource_info ./pkg/scheduler/k8s_internal/predicates`.

