### PR TITLE
fix(scheduler): guard reclaim eviction messages for root queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
 - Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)
 - Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
+- Fixed scheduler panic during reclaim when building eviction messages for jobs in root-level queues (`ParentQueue` empty) that reclaim across hierarchy branches. [#1863](https://github.com/kai-scheduler/KAI-Scheduler/issues/1863)
 
 ## [v0.14.6] - 2026-06-22
 

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_cross_hierarchy_root_leaf_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_cross_hierarchy_root_leaf_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package reclaim
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+const (
+	rootLeafQueueName       = "non-gpu"
+	inferenceChildQueueName = "inference-default"
+	defaultDepartmentName   = "default"
+)
+
+// TestReclaimCrossHierarchyRootLeafVictimDoesNotPanic reproduces the #1863 panic path:
+// a pending job under a named parent reclaims from a running job in a root-level leaf queue
+// (ParentQueue == ""). Reclaim's JobSolver probes evictions via EvictAllPreemptees, which
+// calls GetMessageOfEviction with Queues[""] on unfixed code.
+func TestReclaimCrossHierarchyRootLeafVictimDoesNotPanic(t *testing.T) {
+	defer gock.Off()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	topology := buildCrossHierarchyRootLeafReclaimTopology()
+	ssn := test_utils.BuildSession(topology, ctrl)
+
+	rootLeafQueue := ssn.ClusterInfo.Queues[common_info.QueueID(rootLeafQueueName)]
+	inferenceChildQueue := ssn.ClusterInfo.Queues[common_info.QueueID(inferenceChildQueueName)]
+	if rootLeafQueue == nil || inferenceChildQueue == nil {
+		t.Fatal("expected cross-hierarchy queues to exist in session")
+	}
+	if rootLeafQueue.ParentQueue != "" {
+		t.Fatalf("expected %q to be a root leaf queue, got parent %q", rootLeafQueueName, rootLeafQueue.ParentQueue)
+	}
+	if inferenceChildQueue.ParentQueue != common_info.QueueID(defaultDepartmentName) {
+		t.Fatalf("expected %q parent %q, got %q", inferenceChildQueueName, defaultDepartmentName, inferenceChildQueue.ParentQueue)
+	}
+
+	reclaim.New().Execute(ssn)
+
+	victimJob := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID("root-leaf-victim")]
+	pendingJob := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID("inference-pending")]
+	if victimJob == nil || pendingJob == nil {
+		t.Fatal("expected victim and pending jobs in session")
+	}
+	if len(victimJob.PodStatusIndex[pod_status.Releasing]) != 1 {
+		t.Fatalf("expected root-leaf victim to be releasing, got statuses %#v", victimJob.PodStatusIndex)
+	}
+	if len(pendingJob.PodStatusIndex[pod_status.Pipelined]) != 1 {
+		t.Fatalf("expected inference pending job to be pipelined, got statuses %#v", pendingJob.PodStatusIndex)
+	}
+}
+
+func buildCrossHierarchyRootLeafReclaimTopology() test_utils.TestTopologyBasic {
+	return test_utils.TestTopologyBasic{
+		Name:                     "cross-hierarchy reclaim from root leaf victim",
+		DisableDefaultDepartment: true,
+		Departments: []test_utils.TestDepartmentBasic{{
+			Name:         defaultDepartmentName,
+			DeservedGPUs: 1,
+		}},
+		Nodes: map[string]nodes_fake.TestNodeBasic{
+			"node0": {GPUs: 1},
+		},
+		Jobs: []*jobs_fake.TestJobBasic{
+			{
+				Name:                "root-leaf-victim",
+				RequiredGPUsPerTask: 1,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           rootLeafQueueName,
+				Tasks: []*tasks_fake.TestTaskBasic{{
+					NodeName: "node0",
+					State:    pod_status.Running,
+				}},
+			},
+			{
+				Name:                "inference-pending",
+				RequiredGPUsPerTask: 1,
+				Priority:            constants.PriorityTrainNumber,
+				QueueName:           inferenceChildQueueName,
+				Tasks: []*tasks_fake.TestTaskBasic{{
+					State: pod_status.Pending,
+				}},
+			},
+		},
+		Queues: []test_utils.TestQueueBasic{
+			{
+				Name:               inferenceChildQueueName,
+				ParentQueue:        defaultDepartmentName,
+				DeservedGPUs:       1,
+				GPUOverQuotaWeight: 1,
+			},
+			{
+				Name:               rootLeafQueueName,
+				ParentQueue:        "",
+				DeservedGPUs:       0,
+				GPUOverQuotaWeight: 1,
+			},
+		},
+		Mocks: &test_utils.TestMock{
+			CacheRequirements: &test_utils.CacheMocking{
+				NumberOfCacheBinds:      1,
+				NumberOfCacheEvictions:  1,
+				NumberOfPipelineActions: 1,
+			},
+		},
+	}
+}

--- a/pkg/scheduler/actions/utils/action.go
+++ b/pkg/scheduler/actions/utils/action.go
@@ -62,21 +62,29 @@ func GetMessageOfEviction(ssn *framework.Session, actionType framework.ActionTyp
 				"Failed to get preemptee job for task: <%s/%s>", preempteeTask.Namespace, preempteeTask.Name)
 			return ""
 		}
-		reclaimerQueue := ssn.ClusterInfo.Queues[preemptorJob.Queue]
-		reclaimerParentQueue := ssn.ClusterInfo.Queues[reclaimerQueue.ParentQueue]
-		reclaimeeQueue := ssn.ClusterInfo.Queues[preempteeJob.Queue]
-		reclaimeeParentQueue := ssn.ClusterInfo.Queues[reclaimeeQueue.ParentQueue]
+		reclaimerQueue, reclaimerFound := ssn.ClusterInfo.Queues[preemptorJob.Queue]
+		reclaimeeQueue, reclaimeeFound := ssn.ClusterInfo.Queues[preempteeJob.Queue]
 
 		msg := api.GetReclaimMessage(preempteeTask, preemptorJob)
 
-		var queueDetails string
-		if reclaimeeQueue.ParentQueue == reclaimerQueue.ParentQueue {
-			queueDetails = getReclaimMessageQueuesDetails(ssn, preempteeTask, preemptorJob,
-				reclaimerQueue, reclaimeeQueue)
-		} else {
-			queueDetails = getReclaimMessageQueuesDetails(ssn, preempteeTask, preemptorJob,
-				reclaimerParentQueue, reclaimeeParentQueue)
+		if !reclaimerFound || reclaimerQueue == nil || !reclaimeeFound || reclaimeeQueue == nil {
+			log.InfraLogger.Errorf(
+				"Failed to get reclaimer or reclaimee queue for task: <%s/%s>, reclaimer queue: <%v>, reclaimee queue: <%v>",
+				preempteeTask.Namespace, preempteeTask.Name, preemptorJob.Queue, preempteeJob.Queue)
+			return msg
 		}
+
+		var reclaimerDetailsQueue, reclaimeeDetailsQueue *queue_info.QueueInfo
+		if reclaimeeQueue.ParentQueue == reclaimerQueue.ParentQueue {
+			reclaimerDetailsQueue = reclaimerQueue
+			reclaimeeDetailsQueue = reclaimeeQueue
+		} else {
+			reclaimerDetailsQueue = queueForReclaimDetails(ssn, reclaimerQueue)
+			reclaimeeDetailsQueue = queueForReclaimDetails(ssn, reclaimeeQueue)
+		}
+
+		queueDetails := getReclaimMessageQueuesDetails(ssn, preempteeTask, preemptorJob,
+			reclaimerDetailsQueue, reclaimeeDetailsQueue)
 
 		msg += "\n" + queueDetails
 		return msg
@@ -85,6 +93,19 @@ func GetMessageOfEviction(ssn *framework.Session, actionType framework.ActionTyp
 	log.InfraLogger.Errorf("Unexpected action type: <%v>, task: <%v/%v>", actionType, preempteeTask.Namespace,
 		preempteeTask.Name)
 	return ""
+}
+
+func queueForReclaimDetails(ssn *framework.Session, q *queue_info.QueueInfo) *queue_info.QueueInfo {
+	if q == nil {
+		return nil
+	}
+	if q.ParentQueue == "" {
+		return q
+	}
+	if parent, found := ssn.ClusterInfo.Queues[q.ParentQueue]; found && parent != nil {
+		return parent
+	}
+	return q
 }
 
 func getReclaimMessageQueuesDetails(ssn *framework.Session, reclaimeeTask *pod_info.PodInfo,

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -508,16 +508,37 @@ func (pp *proportionPlugin) queueOrder(lQ, rQ *queue_info.QueueInfo, lJob, rJob 
 }
 
 func (pp *proportionPlugin) getQueueDeservedResourcesFn(queue *queue_info.QueueInfo) *resource_info.ResourceRequirements {
-	queueAttributes := pp.queues[queue.UID]
+	if queue == nil {
+		return nil
+	}
+	queueAttributes, found := pp.queues[queue.UID]
+	if !found {
+		log.InfraLogger.Errorf("Failed to find queue attributes for queue: <%v>", queue.Name)
+		return nil
+	}
 	return utils.ResourceRequirementsFromQuantities(queueAttributes.GetDeservedShare())
 }
 
 func (pp *proportionPlugin) getQueueFairShareFn(queue *queue_info.QueueInfo) *resource_info.ResourceRequirements {
-	queueAttributes := pp.queues[queue.UID]
+	if queue == nil {
+		return nil
+	}
+	queueAttributes, found := pp.queues[queue.UID]
+	if !found {
+		log.InfraLogger.Errorf("Failed to find queue attributes for queue: <%v>", queue.Name)
+		return nil
+	}
 	return utils.ResourceRequirementsFromQuantities(queueAttributes.GetFairShare())
 }
 
 func (pp *proportionPlugin) getQueueAllocatedResourceFn(queue *queue_info.QueueInfo) *resource_info.ResourceRequirements {
-	queueAttributes := pp.queues[queue.UID]
+	if queue == nil {
+		return nil
+	}
+	queueAttributes, found := pp.queues[queue.UID]
+	if !found {
+		log.InfraLogger.Errorf("Failed to find queue attributes for queue: <%v>", queue.Name)
+		return nil
+	}
 	return utils.ResourceRequirementsFromQuantities(queueAttributes.GetAllocatedShare())
 }


### PR DESCRIPTION
## Description

Backports #1866 to `v0.14`.

## Related Issues

Backport of #1866.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Validated with `go test ./pkg/scheduler/actions/utils ./pkg/scheduler/plugins/proportion ./pkg/scheduler/actions/integration_tests/reclaim`.

