### PR TITLE
test: make scale job submission robust

### DIFF
--- a/test/e2e/scale/kwok_job_batch.go
+++ b/test/e2e/scale/kwok_job_batch.go
@@ -1,0 +1,120 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package scale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/panjf2000/ants/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/client-go/rest"
+
+	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
+	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
+)
+
+const defaultScaleSubmissionWorkers = 32
+
+type jobSubmission struct {
+	ExpectedPods int
+	Submit       func(context.Context, map[string]string) (*batchv1.Job, error)
+}
+
+// JobResult is one scale Job creation result.
+type JobResult struct {
+	Job *batchv1.Job
+	Err error
+}
+
+func scaleSubmissionWorkerCount(config *rest.Config, jobs int) int {
+	if jobs <= 0 {
+		return 0
+	}
+	workers := defaultScaleSubmissionWorkers
+	if config != nil && config.Burst > 0 {
+		workers = config.Burst
+	} else if config != nil && config.QPS > 0 {
+		workers = int(math.Ceil(float64(config.QPS)))
+	}
+	return min(workers, jobs)
+}
+
+func submitJobBatch(
+	ctx context.Context,
+	testCtx *testcontext.TestContext,
+	namespace string,
+	submissions []jobSubmission,
+) (*jobBatchTracker, error) {
+	if len(submissions) == 0 {
+		return nil, fmt.Errorf("cannot submit an empty Job batch")
+	}
+	expectedPods := 0
+	for _, submission := range submissions {
+		if submission.ExpectedPods <= 0 {
+			return nil, fmt.Errorf("Job submission must expect at least one Pod")
+		}
+		expectedPods += submission.ExpectedPods
+	}
+
+	batchID := utils.GenerateRandomK8sName(10)
+	batchLabels := map[string]string{distributedJobBatchLabel: batchID}
+	tracker, err := newJobBatchTracker(ctx, testCtx.ControllerClient, namespace, batchID, batchLabels, expectedPods, len(submissions))
+	if err != nil {
+		return nil, err
+	}
+
+	pool, err := ants.NewPool(scaleSubmissionWorkerCount(testCtx.KubeConfig, len(submissions)))
+	if err != nil {
+		tracker.Close()
+		return nil, fmt.Errorf("create Job submission pool: %w", err)
+	}
+	defer pool.Release()
+
+	results := make(chan JobResult, len(submissions))
+	var submitted sync.WaitGroup
+	for _, submission := range submissions {
+		submission := submission
+		submitted.Add(1)
+		if err := pool.Submit(func() {
+			defer submitted.Done()
+			job, err := submission.Submit(ctx, cloneStringMap(batchLabels))
+			results <- JobResult{Job: job, Err: err}
+		}); err != nil {
+			submitted.Done()
+			results <- JobResult{Err: fmt.Errorf("submit Job creation task: %w", err)}
+		}
+	}
+	submitted.Wait()
+	close(results)
+
+	var submissionError error
+	for result := range results {
+		if result.Err != nil {
+			submissionError = errors.Join(submissionError, result.Err)
+			continue
+		}
+		tracker.AddJob(result.Job)
+	}
+	if submissionError != nil {
+		tracker.Close()
+		return nil, fmt.Errorf("submit Job batch %s: %w", batchID, submissionError)
+	}
+	if err := tracker.WaitForReady(ctx); err != nil {
+		tracker.Close()
+		return nil, err
+	}
+	return tracker, nil
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	copy := make(map[string]string, len(values))
+	for key, value := range values {
+		copy[key] = value
+	}
+	return copy
+}

--- a/test/e2e/scale/kwok_job_batch_tracker.go
+++ b/test/e2e/scale/kwok_job_batch_tracker.go
@@ -13,6 +13,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -22,6 +23,11 @@ import (
 )
 
 const batchProgressLogInterval = 30 * time.Second
+
+const (
+	watchRestartInitialBackoff = time.Second
+	watchRestartMaxBackoff     = 30 * time.Second
+)
 
 // BatchStatus is the aggregate state of one scale-test Job batch.
 type BatchStatus struct {
@@ -241,13 +247,8 @@ func (t *jobBatchTracker) Close() {
 }
 
 func (t *jobBatchTracker) watchAndListPods() (watch.Interface, error) {
-	podWatch, err := t.client.Watch(t.ctx, &v1.PodList{}, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels))
-	if err != nil {
-		return nil, err
-	}
 	pods := &v1.PodList{}
 	if err := t.client.List(t.ctx, pods, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels)); err != nil {
-		podWatch.Stop()
 		return nil, err
 	}
 
@@ -260,17 +261,13 @@ func (t *jobBatchTracker) watchAndListPods() (watch.Interface, error) {
 	}
 	t.notifyLocked()
 	t.mu.Unlock()
-	return podWatch, nil
+
+	return t.client.Watch(t.ctx, &v1.PodList{}, t.watchOptions(pods.ResourceVersion)...)
 }
 
 func (t *jobBatchTracker) watchAndListPodGroups() (watch.Interface, error) {
-	podGroupWatch, err := t.client.Watch(t.ctx, &v2alpha2.PodGroupList{}, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels))
-	if err != nil {
-		return nil, err
-	}
 	podGroups := &v2alpha2.PodGroupList{}
 	if err := t.client.List(t.ctx, podGroups, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels)); err != nil {
-		podGroupWatch.Stop()
 		return nil, err
 	}
 
@@ -281,7 +278,16 @@ func (t *jobBatchTracker) watchAndListPodGroups() (watch.Interface, error) {
 	}
 	t.notifyLocked()
 	t.mu.Unlock()
-	return podGroupWatch, nil
+
+	return t.client.Watch(t.ctx, &v2alpha2.PodGroupList{}, t.watchOptions(podGroups.ResourceVersion)...)
+}
+
+func (t *jobBatchTracker) watchOptions(resourceVersion string) []runtimeClient.ListOption {
+	return []runtimeClient.ListOption{
+		runtimeClient.InNamespace(t.namespace),
+		runtimeClient.MatchingLabels(t.batchLabels),
+		&runtimeClient.ListOptions{Raw: &metav1.ListOptions{ResourceVersion: resourceVersion}},
+	}
 }
 
 func (t *jobBatchTracker) runWatch(
@@ -291,21 +297,50 @@ func (t *jobBatchTracker) runWatch(
 	update func(runtime.Object, watch.EventType) error,
 ) {
 	defer t.wg.Done()
+	backoff := watchRestartInitialBackoff
 	for {
 		err := t.consumeWatch(resourceWatch, update)
 		resourceWatch.Stop()
 		if t.ctx.Err() != nil {
 			return
 		}
-		if err != nil {
+		if err != nil && !isRecoverableWatchError(err) {
 			t.setTerminalError(fmt.Errorf("watch %s: %w", resource, err))
 			return
 		}
-		resourceWatch, err = restart()
 		if err != nil {
+			GinkgoLogr.Error(err, "Restarting scale Job batch watch", "batchID", t.batchID, "resource", resource)
+			if !t.waitForWatchRestart(backoff) {
+				return
+			}
+			backoff = min(backoff*2, watchRestartMaxBackoff)
+		}
+
+		resourceWatch, err = restart()
+		if err == nil {
+			backoff = watchRestartInitialBackoff
+			continue
+		}
+		if !isRecoverableWatchError(err) {
 			t.setTerminalError(fmt.Errorf("restart %s watch: %w", resource, err))
 			return
 		}
+		GinkgoLogr.Error(err, "Retrying scale Job batch watch restart", "batchID", t.batchID, "resource", resource)
+		if !t.waitForWatchRestart(backoff) {
+			return
+		}
+		backoff = min(backoff*2, watchRestartMaxBackoff)
+	}
+}
+
+func (t *jobBatchTracker) waitForWatchRestart(backoff time.Duration) bool {
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-t.ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -465,4 +500,11 @@ func watchEventError(obj runtime.Object) error {
 		return err
 	}
 	return fmt.Errorf("Kubernetes watch returned an error event")
+}
+
+func isRecoverableWatchError(err error) bool {
+	return apierrors.IsResourceExpired(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err)
 }

--- a/test/e2e/scale/kwok_job_batch_tracker.go
+++ b/test/e2e/scale/kwok_job_batch_tracker.go
@@ -140,26 +140,33 @@ func (t *jobBatchTracker) Jobs() []*batchv1.Job {
 }
 
 func (t *jobBatchTracker) WaitForReady(ctx context.Context) error {
-	_, err := t.WaitForStatus(ctx, "batch resources to be created", func(status BatchStatus) bool {
-		return status.ObservedPods == status.ExpectedPods &&
-			status.ObservedPodGroups == status.ExpectedPodGroups
+	_, err := t.waitForLocked(ctx, "batch resources to be created", func(status BatchStatus) bool {
+		return status.ObservedPods >= status.ExpectedPods &&
+			status.ObservedPodGroups >= status.ExpectedPodGroups
 	})
 	return err
 }
 
 func (t *jobBatchTracker) WaitForScheduled(ctx context.Context) (BatchStatus, error) {
-	return t.WaitForStatus(ctx, "batch Pods to be scheduled", func(status BatchStatus) bool {
-		return status.ObservedPods == status.ExpectedPods && status.ScheduledPods == status.ExpectedPods
+	return t.waitForLocked(ctx, "batch Pods to be scheduled", func(status BatchStatus) bool {
+		return status.ObservedPods >= status.ExpectedPods && status.ScheduledPods >= status.ExpectedPods
 	})
 }
 
 func (t *jobBatchTracker) WaitForRunning(ctx context.Context) (BatchStatus, error) {
-	return t.WaitForStatus(ctx, "batch Pods to be running", func(status BatchStatus) bool {
-		return status.ObservedPods == status.ExpectedPods && status.RunningPods == status.ExpectedPods
+	return t.waitForLocked(ctx, "batch Pods to be running", func(status BatchStatus) bool {
+		return status.ObservedPods >= status.ExpectedPods && status.RunningPods >= status.ExpectedPods
 	})
 }
 
 func (t *jobBatchTracker) WaitForStatus(
+	ctx context.Context, description string, condition func(BatchStatus) bool,
+) (BatchStatus, error) {
+	return t.waitForLocked(ctx, description, condition)
+}
+
+// waitForLocked calls condition while t.mu is held.
+func (t *jobBatchTracker) waitForLocked(
 	ctx context.Context, description string, condition func(BatchStatus) bool,
 ) (BatchStatus, error) {
 	ticker := time.NewTicker(batchProgressLogInterval)
@@ -201,9 +208,7 @@ func (t *jobBatchTracker) WaitForPodGroupCondition(
 	ctx context.Context, conditionType v2alpha2.SchedulingConditionType,
 ) (PodGroupConditionTiming, error) {
 	var timing PodGroupConditionTiming
-	_, err := t.WaitForStatus(ctx, fmt.Sprintf("PodGroup condition %s", conditionType), func(BatchStatus) bool {
-		t.mu.Lock()
-		defer t.mu.Unlock()
+	_, err := t.waitForLocked(ctx, fmt.Sprintf("PodGroup condition %s", conditionType), func(BatchStatus) bool {
 		for _, podGroup := range t.podGroups {
 			if transitionAt, found := podGroup.conditions[conditionType]; found {
 				timing = PodGroupConditionTiming{CreatedAt: podGroup.createdAt, TransitionAt: transitionAt}
@@ -217,12 +222,10 @@ func (t *jobBatchTracker) WaitForPodGroupCondition(
 
 func (t *jobBatchTracker) WaitForSinglePodGroupCreation(ctx context.Context) (time.Time, error) {
 	var createdAt time.Time
-	_, err := t.WaitForStatus(ctx, "single PodGroup to be created", func(status BatchStatus) bool {
-		if status.ExpectedPodGroups != 1 || status.ObservedPodGroups != 1 {
+	_, err := t.waitForLocked(ctx, "single PodGroup to be created", func(status BatchStatus) bool {
+		if status.ExpectedPodGroups != 1 || status.ObservedPodGroups < 1 {
 			return false
 		}
-		t.mu.Lock()
-		defer t.mu.Unlock()
 		for _, podGroup := range t.podGroups {
 			createdAt = podGroup.createdAt
 			return true

--- a/test/e2e/scale/kwok_job_batch_tracker.go
+++ b/test/e2e/scale/kwok_job_batch_tracker.go
@@ -1,0 +1,465 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package scale
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+)
+
+const batchProgressLogInterval = 30 * time.Second
+
+// BatchStatus is the aggregate state of one scale-test Job batch.
+type BatchStatus struct {
+	ExpectedPods      int
+	ExpectedPodGroups int
+	ObservedPods      int
+	ObservedPodGroups int
+	ScheduledPods     int
+	RunningPods       int
+	SucceededPods     int
+	PendingPods       int
+	LastScheduledAt   time.Time
+}
+
+// PodGroupConditionTiming identifies when a PodGroup and one of its conditions appeared.
+type PodGroupConditionTiming struct {
+	CreatedAt    time.Time
+	TransitionAt time.Time
+}
+
+type podState struct {
+	scheduled   bool
+	running     bool
+	succeeded   bool
+	pending     bool
+	scheduledAt time.Time
+}
+
+type podGroupState struct {
+	createdAt  time.Time
+	conditions map[v2alpha2.SchedulingConditionType]time.Time
+}
+
+type jobBatchTracker struct {
+	client            runtimeClient.WithWatch
+	namespace         string
+	batchID           string
+	batchLabels       map[string]string
+	expectedPods      int
+	expectedPodGroups int
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu            sync.Mutex
+	pods          map[types.UID]podState
+	podGroups     map[types.UID]podGroupState
+	jobs          map[runtimeClient.ObjectKey]*batchv1.Job
+	scheduledPods int
+	runningPods   int
+	succeededPods int
+	pendingPods   int
+	lastScheduled time.Time
+	changed       chan struct{}
+	terminalError error
+}
+
+func newJobBatchTracker(
+	ctx context.Context,
+	client runtimeClient.WithWatch,
+	namespace string,
+	batchID string,
+	batchLabels map[string]string,
+	expectedPods, expectedPodGroups int,
+) (*jobBatchTracker, error) {
+	trackerCtx, cancel := context.WithCancel(ctx)
+	t := &jobBatchTracker{
+		client:            client,
+		namespace:         namespace,
+		batchID:           batchID,
+		batchLabels:       batchLabels,
+		expectedPods:      expectedPods,
+		expectedPodGroups: expectedPodGroups,
+		ctx:               trackerCtx,
+		cancel:            cancel,
+		pods:              make(map[types.UID]podState),
+		podGroups:         make(map[types.UID]podGroupState),
+		jobs:              make(map[runtimeClient.ObjectKey]*batchv1.Job),
+		changed:           make(chan struct{}),
+	}
+
+	podWatch, err := t.watchAndListPods()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("watch batch Pods: %w", err)
+	}
+	podGroupWatch, err := t.watchAndListPodGroups()
+	if err != nil {
+		podWatch.Stop()
+		cancel()
+		return nil, fmt.Errorf("watch batch PodGroups: %w", err)
+	}
+
+	t.wg.Add(2)
+	go t.runWatch("Pods", podWatch, t.watchAndListPods, t.updatePod)
+	go t.runWatch("PodGroups", podGroupWatch, t.watchAndListPodGroups, t.updatePodGroup)
+	return t, nil
+}
+
+func (t *jobBatchTracker) AddJob(job *batchv1.Job) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.jobs[runtimeClient.ObjectKeyFromObject(job)] = job.DeepCopy()
+	t.notifyLocked()
+}
+
+func (t *jobBatchTracker) Jobs() []*batchv1.Job {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	jobs := make([]*batchv1.Job, 0, len(t.jobs))
+	for _, job := range t.jobs {
+		jobs = append(jobs, job.DeepCopy())
+	}
+	return jobs
+}
+
+func (t *jobBatchTracker) WaitForReady(ctx context.Context) error {
+	_, err := t.WaitForStatus(ctx, "batch resources to be created", func(status BatchStatus) bool {
+		return status.ObservedPods == status.ExpectedPods &&
+			status.ObservedPodGroups == status.ExpectedPodGroups
+	})
+	return err
+}
+
+func (t *jobBatchTracker) WaitForScheduled(ctx context.Context) (BatchStatus, error) {
+	return t.WaitForStatus(ctx, "batch Pods to be scheduled", func(status BatchStatus) bool {
+		return status.ObservedPods == status.ExpectedPods && status.ScheduledPods == status.ExpectedPods
+	})
+}
+
+func (t *jobBatchTracker) WaitForRunning(ctx context.Context) (BatchStatus, error) {
+	return t.WaitForStatus(ctx, "batch Pods to be running", func(status BatchStatus) bool {
+		return status.ObservedPods == status.ExpectedPods && status.RunningPods == status.ExpectedPods
+	})
+}
+
+func (t *jobBatchTracker) WaitForStatus(
+	ctx context.Context, description string, condition func(BatchStatus) bool,
+) (BatchStatus, error) {
+	ticker := time.NewTicker(batchProgressLogInterval)
+	defer ticker.Stop()
+
+	for {
+		t.mu.Lock()
+		status := t.statusLocked()
+		if t.terminalError != nil {
+			err := t.terminalError
+			t.mu.Unlock()
+			return status, fmt.Errorf("wait for %s in batch %s: %w", description, t.batchID, err)
+		}
+		if condition(status) {
+			t.mu.Unlock()
+			return status, nil
+		}
+		changed := t.changed
+		t.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			t.mu.Lock()
+			status = t.statusLocked()
+			t.mu.Unlock()
+			return status, fmt.Errorf("wait for %s in batch %s: %w", description, t.batchID, ctx.Err())
+		case <-changed:
+		case <-ticker.C:
+			GinkgoLogr.Info("Waiting for scale Job batch", "batchID", t.batchID, "condition", description,
+				"expectedPods", status.ExpectedPods, "observedPods", status.ObservedPods,
+				"scheduledPods", status.ScheduledPods, "runningPods", status.RunningPods,
+				"succeededPods", status.SucceededPods, "pendingPods", status.PendingPods,
+				"podGroups", status.ObservedPodGroups)
+		}
+	}
+}
+
+func (t *jobBatchTracker) WaitForPodGroupCondition(
+	ctx context.Context, conditionType v2alpha2.SchedulingConditionType,
+) (PodGroupConditionTiming, error) {
+	var timing PodGroupConditionTiming
+	_, err := t.WaitForStatus(ctx, fmt.Sprintf("PodGroup condition %s", conditionType), func(BatchStatus) bool {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		for _, podGroup := range t.podGroups {
+			if transitionAt, found := podGroup.conditions[conditionType]; found {
+				timing = PodGroupConditionTiming{CreatedAt: podGroup.createdAt, TransitionAt: transitionAt}
+				return true
+			}
+		}
+		return false
+	})
+	return timing, err
+}
+
+func (t *jobBatchTracker) WaitForSinglePodGroupCreation(ctx context.Context) (time.Time, error) {
+	var createdAt time.Time
+	_, err := t.WaitForStatus(ctx, "single PodGroup to be created", func(status BatchStatus) bool {
+		if status.ExpectedPodGroups != 1 || status.ObservedPodGroups != 1 {
+			return false
+		}
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		for _, podGroup := range t.podGroups {
+			createdAt = podGroup.createdAt
+			return true
+		}
+		return false
+	})
+	return createdAt, err
+}
+
+func (t *jobBatchTracker) Close() {
+	t.cancel()
+	t.wg.Wait()
+}
+
+func (t *jobBatchTracker) watchAndListPods() (watch.Interface, error) {
+	podWatch, err := t.client.Watch(t.ctx, &v1.PodList{}, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels))
+	if err != nil {
+		return nil, err
+	}
+	pods := &v1.PodList{}
+	if err := t.client.List(t.ctx, pods, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels)); err != nil {
+		podWatch.Stop()
+		return nil, err
+	}
+
+	t.mu.Lock()
+	t.pods = make(map[types.UID]podState, len(pods.Items))
+	t.scheduledPods, t.runningPods, t.succeededPods, t.pendingPods = 0, 0, 0, 0
+	t.lastScheduled = time.Time{}
+	for i := range pods.Items {
+		t.upsertPodLocked(&pods.Items[i])
+	}
+	t.notifyLocked()
+	t.mu.Unlock()
+	return podWatch, nil
+}
+
+func (t *jobBatchTracker) watchAndListPodGroups() (watch.Interface, error) {
+	podGroupWatch, err := t.client.Watch(t.ctx, &v2alpha2.PodGroupList{}, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels))
+	if err != nil {
+		return nil, err
+	}
+	podGroups := &v2alpha2.PodGroupList{}
+	if err := t.client.List(t.ctx, podGroups, runtimeClient.InNamespace(t.namespace), runtimeClient.MatchingLabels(t.batchLabels)); err != nil {
+		podGroupWatch.Stop()
+		return nil, err
+	}
+
+	t.mu.Lock()
+	t.podGroups = make(map[types.UID]podGroupState, len(podGroups.Items))
+	for i := range podGroups.Items {
+		t.podGroups[podGroups.Items[i].UID] = podGroupStateFromPodGroup(&podGroups.Items[i])
+	}
+	t.notifyLocked()
+	t.mu.Unlock()
+	return podGroupWatch, nil
+}
+
+func (t *jobBatchTracker) runWatch(
+	resource string,
+	resourceWatch watch.Interface,
+	restart func() (watch.Interface, error),
+	update func(runtime.Object, watch.EventType) error,
+) {
+	defer t.wg.Done()
+	for {
+		err := t.consumeWatch(resourceWatch, update)
+		resourceWatch.Stop()
+		if t.ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			t.setTerminalError(fmt.Errorf("watch %s: %w", resource, err))
+			return
+		}
+		resourceWatch, err = restart()
+		if err != nil {
+			t.setTerminalError(fmt.Errorf("restart %s watch: %w", resource, err))
+			return
+		}
+	}
+}
+
+func (t *jobBatchTracker) consumeWatch(resourceWatch watch.Interface, update func(runtime.Object, watch.EventType) error) error {
+	for {
+		select {
+		case <-t.ctx.Done():
+			return nil
+		case event, open := <-resourceWatch.ResultChan():
+			if !open {
+				return nil
+			}
+			if event.Type == watch.Error {
+				return watchEventError(event.Object)
+			}
+			if err := update(event.Object, event.Type); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (t *jobBatchTracker) updatePod(obj runtime.Object, eventType watch.EventType) error {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		return fmt.Errorf("unexpected Pod watch object %T", obj)
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if eventType == watch.Deleted {
+		t.deletePodLocked(pod.UID)
+	} else {
+		t.upsertPodLocked(pod)
+	}
+	t.notifyLocked()
+	return nil
+}
+
+func (t *jobBatchTracker) updatePodGroup(obj runtime.Object, eventType watch.EventType) error {
+	podGroup, ok := obj.(*v2alpha2.PodGroup)
+	if !ok {
+		return fmt.Errorf("unexpected PodGroup watch object %T", obj)
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if eventType == watch.Deleted {
+		delete(t.podGroups, podGroup.UID)
+	} else {
+		t.podGroups[podGroup.UID] = podGroupStateFromPodGroup(podGroup)
+	}
+	t.notifyLocked()
+	return nil
+}
+
+func (t *jobBatchTracker) upsertPodLocked(pod *v1.Pod) {
+	if existing, found := t.pods[pod.UID]; found {
+		t.removePodCountersLocked(existing)
+	}
+	state := podStateFromPod(pod)
+	t.pods[pod.UID] = state
+	t.addPodCountersLocked(state)
+}
+
+func (t *jobBatchTracker) deletePodLocked(uid types.UID) {
+	state, found := t.pods[uid]
+	if !found {
+		return
+	}
+	t.removePodCountersLocked(state)
+	delete(t.pods, uid)
+}
+
+func (t *jobBatchTracker) addPodCountersLocked(state podState) {
+	if state.scheduled {
+		t.scheduledPods++
+		if state.scheduledAt.After(t.lastScheduled) {
+			t.lastScheduled = state.scheduledAt
+		}
+	}
+	if state.running {
+		t.runningPods++
+	}
+	if state.succeeded {
+		t.succeededPods++
+	}
+	if state.pending {
+		t.pendingPods++
+	}
+}
+
+func (t *jobBatchTracker) removePodCountersLocked(state podState) {
+	if state.scheduled {
+		t.scheduledPods--
+	}
+	if state.running {
+		t.runningPods--
+	}
+	if state.succeeded {
+		t.succeededPods--
+	}
+	if state.pending {
+		t.pendingPods--
+	}
+}
+
+func (t *jobBatchTracker) statusLocked() BatchStatus {
+	return BatchStatus{
+		ExpectedPods:      t.expectedPods,
+		ExpectedPodGroups: t.expectedPodGroups,
+		ObservedPods:      len(t.pods),
+		ObservedPodGroups: len(t.podGroups),
+		ScheduledPods:     t.scheduledPods,
+		RunningPods:       t.runningPods,
+		SucceededPods:     t.succeededPods,
+		PendingPods:       t.pendingPods,
+		LastScheduledAt:   t.lastScheduled,
+	}
+}
+
+func (t *jobBatchTracker) setTerminalError(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.terminalError == nil {
+		t.terminalError = err
+		t.notifyLocked()
+	}
+}
+
+func (t *jobBatchTracker) notifyLocked() {
+	close(t.changed)
+	t.changed = make(chan struct{})
+}
+
+func podStateFromPod(pod *v1.Pod) podState {
+	state := podState{
+		running:   pod.Status.Phase == v1.PodRunning,
+		succeeded: pod.Status.Phase == v1.PodSucceeded,
+		pending:   pod.Status.Phase == v1.PodPending,
+	}
+	if scheduledAt, err := getPodScheduledTime(pod); err == nil {
+		state.scheduled = true
+		state.scheduledAt = scheduledAt
+	}
+	return state
+}
+
+func podGroupStateFromPodGroup(podGroup *v2alpha2.PodGroup) podGroupState {
+	state := podGroupState{createdAt: podGroup.CreationTimestamp.Time, conditions: make(map[v2alpha2.SchedulingConditionType]time.Time)}
+	for _, condition := range podGroup.Status.SchedulingConditions {
+		state.conditions[condition.Type] = condition.LastTransitionTime.Time
+	}
+	return state
+}
+
+func watchEventError(obj runtime.Object) error {
+	if err := apierrors.FromObject(obj); err != nil {
+		return err
+	}
+	return fmt.Errorf("Kubernetes watch returned an error event")
+}

--- a/test/e2e/scale/kwok_job_creation.go
+++ b/test/e2e/scale/kwok_job_creation.go
@@ -30,19 +30,20 @@ func createJobObjectForKwok(
 	return job, rd.CreateObjectWithRetries(ctx, testCtx.ControllerClient, job)
 }
 
-func createDistributedJobForKwok(
-	ctx context.Context, testCtx *testcontext.TestContext,
-	jobQueue *v2.Queue, resourcesPerPod v1.ResourceRequirements, numberOfTasks int,
-	extraLabels map[string]string, topologyConstraint *v2alpha2.TopologyConstraint,
-) (*rd.JobResult, error) {
-	return rd.CreateDistributedBatchJob(ctx, testCtx.ControllerClient, jobQueue,
-		rd.DistributedBatchJobOptions{
-			Parallelism:        ptr.To(int32(numberOfTasks)),
-			Resources:          resourcesPerPod,
-			ExtraLabels:        extraLabels,
-			TopologyConstraint: topologyConstraint,
-			PodSpecMutator:     addKWOKTaintsAndAffinity,
-		})
+func singleJobSubmissionForKwok(
+	testCtx *testcontext.TestContext,
+	jobQueue *v2.Queue,
+	resources v1.ResourceRequirements,
+	extraLabels map[string]string,
+) jobSubmission {
+	return jobSubmission{
+		ExpectedPods: 1,
+		Submit: func(ctx context.Context, batchLabels map[string]string) (*batchv1.Job, error) {
+			labels := cloneStringMap(extraLabels)
+			maps.Copy(labels, batchLabels)
+			return createJobObjectForKwok(ctx, testCtx, jobQueue, resources, labels)
+		},
+	}
 }
 
 func submitDistributedJobForKwok(
@@ -59,4 +60,25 @@ func submitDistributedJobForKwok(
 			TopologyConstraint: topologyConstraint,
 			PodSpecMutator:     addKWOKTaintsAndAffinity,
 		})
+}
+
+func distributedJobSubmissionForKwok(
+	testCtx *testcontext.TestContext,
+	jobQueue *v2.Queue,
+	resourcesPerPod v1.ResourceRequirements,
+	numberOfTasks int,
+	extraPodLabels map[string]string,
+	topologyConstraint *v2alpha2.TopologyConstraint,
+) jobSubmission {
+	return jobSubmission{
+		ExpectedPods: numberOfTasks,
+		Submit: func(ctx context.Context, batchLabels map[string]string) (*batchv1.Job, error) {
+			podLabels := cloneStringMap(extraPodLabels)
+			maps.Copy(podLabels, batchLabels)
+			return submitDistributedJobForKwok(
+				ctx, testCtx, jobQueue, resourcesPerPod, numberOfTasks,
+				podLabels, batchLabels, topologyConstraint,
+			)
+		},
+	}
 }

--- a/test/e2e/scale/kwok_job_creation.go
+++ b/test/e2e/scale/kwok_job_creation.go
@@ -25,6 +25,7 @@ func createJobObjectForKwok(
 ) (*batchv1.Job, error) {
 	job := rd.CreateBatchJobObject(jobQueue, resources)
 	addKWOKTaintsAndAffinity(&job.Spec.Template.Spec)
+	maps.Copy(job.ObjectMeta.Labels, extraLabels)
 	maps.Copy(job.Spec.Template.ObjectMeta.Labels, extraLabels)
 
 	return job, rd.CreateObjectWithRetries(ctx, testCtx.ControllerClient, job)

--- a/test/e2e/scale/kwok_test.go
+++ b/test/e2e/scale/kwok_test.go
@@ -5,7 +5,6 @@ package scale
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -32,7 +31,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/crd"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
-	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait/watcher"
@@ -330,35 +328,17 @@ var _ = Describe("Kwok scale test", Ordered, Label(labels.Scale), func() {
 			})
 
 			It("schedules jobs with pending tasks in background", func(ctx context.Context) {
-				creationErrors := make(chan error, pendingBackgroundTasks)
-				var wg sync.WaitGroup
-				for range pendingBackgroundTasks {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						_, err := createJobObjectForKwok(
-							ctx, testCtx, noGPUQuotaQueue,
-							SingleGPURequirement, map[string]string{},
-						)
-						if err != nil {
-							creationErrors <- err
-						}
-					}()
+				submissions := make([]jobSubmission, pendingBackgroundTasks)
+				for i := range submissions {
+					submissions[i] = singleJobSubmissionForKwok(
+						testCtx, noGPUQuotaQueue, SingleGPURequirement, nil,
+					)
 				}
-				wg.Wait()
-				close(creationErrors)
-
-				var creationError error
-				for err := range creationErrors {
-					creationError = errors.Join(creationError, err)
-				}
-				Expect(creationError).NotTo(HaveOccurred(), "Failed to create some pending background jobs")
-
-				wait.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						testconfig.GetConfig().QueueLabelKey: noGPUQuotaQueue.Name,
-					},
-				}, pendingBackgroundTasks)
+				tracker, err := submitJobBatch(
+					ctx, testCtx, queue.GetConnectedNamespaceToQueue(noGPUQuotaQueue), submissions,
+				)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create pending background Job batch")
+				defer tracker.Close()
 
 				basicScaleTest(
 					ctx, testCtx, fmt.Sprintf(
@@ -405,17 +385,9 @@ var _ = Describe("Kwok scale test", Ordered, Label(labels.Scale), func() {
 						It("measure time for reclaim to fail on distributed job last pod", func(ctx context.Context) {
 							averageTimeToUnschedulable := measureUnschedulableDelayInSeconds(
 								ctx, testCtx, reclaimSingleGPUJobsQueue,
-								func(ctx context.Context, testCtx *testcontext.TestContext, queue *v2.Queue) (*rd.JobResult, error) {
-									return createDistributedJobForKwok(
-										ctx, testCtx, queue,
-										v1.ResourceRequirements{
-											Limits: map[v1.ResourceName]resource.Quantity{
-												constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
-											},
-										}, defaultPodsPerDistributedJob,
-										map[string]string{}, nil,
-									)
-								},
+								v1.ResourceRequirements{Limits: map[v1.ResourceName]resource.Quantity{
+									constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
+								}}, defaultPodsPerDistributedJob,
 							)
 							Expect(writeTestResults(
 								"Average time to unschedulable for distributed job", true,

--- a/test/e2e/scale/kwok_test_functions.go
+++ b/test/e2e/scale/kwok_test_functions.go
@@ -5,18 +5,14 @@ package scale
 
 import (
 	"context"
-	"errors"
 	"math"
 	"time"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
@@ -24,8 +20,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
 	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
-	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
-	waitutils "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
 )
 
 const (
@@ -173,49 +167,6 @@ func distributedJobsScaleTestInternal(
 		})).To(Succeed())
 }
 
-func waitForDistributedJobsForKwok(
-	ctx context.Context, testCtx *testcontext.TestContext, jobs []*batchv1.Job,
-) []*v1.Pod {
-	if len(jobs) == 0 {
-		return nil
-	}
-
-	expectedPods := 0
-	for _, job := range jobs {
-		if job.Spec.Parallelism == nil {
-			expectedPods++
-		} else {
-			expectedPods += int(*job.Spec.Parallelism)
-		}
-	}
-
-	batchID := jobs[0].Labels[distributedJobBatchLabel]
-	selector := metav1.LabelSelector{MatchLabels: map[string]string{distributedJobBatchLabel: batchID}}
-	waitutils.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, selector, expectedPods)
-
-	Eventually(func(g Gomega) {
-		podGroups := &v2alpha2.PodGroupList{}
-		err := testCtx.ControllerClient.List(ctx, podGroups,
-			runtimeClient.InNamespace(jobs[0].Namespace),
-			runtimeClient.MatchingLabels{distributedJobBatchLabel: batchID},
-		)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(len(podGroups.Items)).To(Equal(len(jobs)))
-	}, maxFlowTimeoutMinutes*time.Minute, podsPollIntervalSeconds*time.Second).Should(Succeed())
-
-	pods := &v1.PodList{}
-	Expect(testCtx.ControllerClient.List(ctx, pods,
-		runtimeClient.InNamespace(jobs[0].Namespace),
-		runtimeClient.MatchingLabels{distributedJobBatchLabel: batchID},
-	)).To(Succeed())
-
-	result := make([]*v1.Pod, 0, len(pods.Items))
-	for i := range pods.Items {
-		result = append(result, &pods.Items[i])
-	}
-	return result
-}
-
 func consolidateScaleTest(
 	ctx context.Context, testCtx *testcontext.TestContext, testQueue *v2.Queue, numberOfNodes int,
 ) {
@@ -314,70 +265,39 @@ func runNCCLSimulation(
 ) (testSucceeded bool, totalPods int, completedPods int, pendingPods int, startTime time.Time) {
 	jobSizes := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
 	startTime = time.Now()
-	batchID := utils.GenerateRandomK8sName(10)
-	podLabels := map[string]string{
-		"burst-test":             "true",
-		distributedJobBatchLabel: batchID,
-	}
-	jobLabels := map[string]string{distributedJobBatchLabel: batchID}
-	var jobs []*batchv1.Job
-	var creationError error
+	podLabels := map[string]string{"burst-test": "true"}
+	var submissions []jobSubmission
 	for _, jobSize := range jobSizes {
 		if jobSize > numberOfNodes {
 			break
 		}
 		for range numberOfNCCLJobsPerSize {
-			job, err := submitDistributedJobForKwok(
-				ctx, testCtx, testQueue, FullNodeGPURequirement, jobSize,
-				podLabels, jobLabels, nil,
-			)
-			if err != nil {
-				creationError = errors.Join(creationError, err)
-				continue
-			}
-			jobs = append(jobs, job)
+			submissions = append(submissions, distributedJobSubmissionForKwok(
+				testCtx, testQueue, FullNodeGPURequirement, jobSize, podLabels, nil,
+			))
 		}
 	}
-	Expect(creationError).NotTo(HaveOccurred(), "Failed to create some NCCL jobs")
-	testPods := waitForDistributedJobsForKwok(ctx, testCtx, jobs)
+	tracker, err := submitJobBatch(ctx, testCtx, queue.GetConnectedNamespaceToQueue(testQueue), submissions)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create NCCL Job batch")
+	defer tracker.Close()
+	completionCtx, cancelCompletion := context.WithTimeout(ctx, time.Duration(ncclTimeoutMinutes)*time.Minute)
+	defer cancelCompletion()
+	status, err := waitForNCCLCompletion(completionCtx, tracker)
+	Expect(err).NotTo(HaveOccurred())
 
-	totalPods = len(testPods)
-	completedPods = 0
-	pendingPods = 0
-
-	Eventually(func(g Gomega) bool {
-		queuePods := &v1.PodList{}
-		g.Expect(testCtx.ControllerClient.List(ctx, queuePods,
-			runtimeClient.InNamespace(queue.GetConnectedNamespaceToQueue(testQueue)),
-		)).To(Succeed())
-
-		currentCompletedPods := 0
-		currentPendingPods := 0
-
-		queuePodsByName := map[string]*v1.Pod{}
-		for i := range queuePods.Items {
-			pod := &queuePods.Items[i]
-			queuePodsByName[pod.Name] = pod
-			if pod.Status.Phase == v1.PodPending {
-				currentPendingPods++
-			}
-		}
-
-		for _, pod := range testPods {
-			queuePod, exists := queuePodsByName[pod.Name]
-			if exists && queuePod.Status.Phase == v1.PodSucceeded {
-				currentCompletedPods++
-			}
-		}
-		completedPods = currentCompletedPods
-		pendingPods = currentPendingPods
-
-		return len(testPods) == completedPods || currentPendingPods == 0
-	}, time.Duration(ncclTimeoutMinutes)*time.Minute, podsPollIntervalSeconds*time.Second).Should(BeTrue())
-
-	GinkgoLogr.Info("Finished NCCL test", "completedPods", completedPods, "len(testPods)", len(testPods), "pendingPods", pendingPods)
+	totalPods = status.ExpectedPods
+	completedPods = status.SucceededPods
+	pendingPods = status.PendingPods
+	GinkgoLogr.Info("Finished NCCL test", "completedPods", completedPods, "totalPods", totalPods, "pendingPods", pendingPods)
 
 	testSucceeded = true
 
 	return testSucceeded, totalPods, completedPods, pendingPods, startTime
+}
+
+func waitForNCCLCompletion(ctx context.Context, tracker *jobBatchTracker) (BatchStatus, error) {
+	return tracker.WaitForStatus(ctx, "NCCL batch completion", func(status BatchStatus) bool {
+		return status.SucceededPods == status.ExpectedPods ||
+			(status.ObservedPods == status.ExpectedPods && status.PendingPods == 0)
+	})
 }

--- a/test/e2e/scale/kwok_test_functions.go
+++ b/test/e2e/scale/kwok_test_functions.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"math"
-	"sync"
 	"time"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
@@ -24,9 +23,7 @@ import (
 	schedulerconfig "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/configurations/feature_flags"
 	testcontext "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/context"
-	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd/queue"
-	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/testconfig"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/utils"
 	waitutils "github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/wait"
 )
@@ -103,30 +100,13 @@ func fillClusterWithJobs(
 	gpusPerJob := int(gpuQuantity.Value())
 	totalNumberOfJobs = (numberOfNodes * gpusPerNode) / gpusPerJob
 
-	var wg sync.WaitGroup
-	var creationError error
-	var lock sync.Mutex
-	for range totalNumberOfJobs {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, err := createJobObjectForKwok(ctx, testCtx, testQueue, resourceRequirements, map[string]string{})
-			if err != nil {
-				lock.Lock()
-				creationError = errors.Join(creationError, err)
-				lock.Unlock()
-			}
-		}()
+	submissions := make([]jobSubmission, totalNumberOfJobs)
+	for i := range submissions {
+		submissions[i] = singleJobSubmissionForKwok(testCtx, testQueue, resourceRequirements, nil)
 	}
-	wg.Wait()
-	Expect(creationError).NotTo(HaveOccurred(), "Failed to create some jobs")
-
-	GinkgoLogr.Info("Waiting for pods creation")
-	waitutils.ForAtLeastNPodCreation(ctx, testCtx.ControllerClient, metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			testconfig.GetConfig().QueueLabelKey: testQueue.Name,
-		},
-	}, totalNumberOfJobs)
+	tracker, err := submitJobBatch(ctx, testCtx, queue.GetConnectedNamespaceToQueue(testQueue), submissions)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create Job batch")
+	defer tracker.Close()
 
 	if disableSchedulerForPodCreation {
 		startTime = time.Now()
@@ -134,7 +114,9 @@ func fillClusterWithJobs(
 	}
 
 	GinkgoLogr.Info("Waiting for pods scheduling")
-	return startTime, waitForAllJobsToSchedule(ctx, testCtx, testQueue, totalNumberOfJobs), totalNumberOfJobs
+	status, err := tracker.WaitForScheduled(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	return startTime, status.LastScheduledAt, totalNumberOfJobs
 }
 
 func distributedJobsScaleTest(
@@ -157,44 +139,25 @@ func distributedJobsScaleTestInternal(
 	schedulerconfig.DisableScheduler(ctx, testCtx)
 	defer schedulerconfig.EnableScheduler(ctx, testCtx)
 
-	expectedNumberOfPods := numberOfDistributedJobs * podsPerDistributedJob
-	var wg sync.WaitGroup
-	var creationError error
-	var lock sync.Mutex
-	var jobs []*batchv1.Job
-	batchID := utils.GenerateRandomK8sName(10)
-	batchLabels := map[string]string{distributedJobBatchLabel: batchID}
-
-	for range numberOfDistributedJobs {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			job, err := submitDistributedJobForKwok(
-				ctx, testCtx, testQueue,
-				v1.ResourceRequirements{
-					Limits: map[v1.ResourceName]resource.Quantity{
-						constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpuPerPod), resource.DecimalSI),
-					},
-				}, podsPerDistributedJob,
-				batchLabels, batchLabels, topologyConstraint,
-			)
-			lock.Lock()
-			defer lock.Unlock()
-			if err != nil {
-				creationError = errors.Join(creationError, err)
-				return
-			}
-			jobs = append(jobs, job)
-		}()
+	resources := v1.ResourceRequirements{Limits: map[v1.ResourceName]resource.Quantity{
+		constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpuPerPod), resource.DecimalSI),
+	}}
+	submissions := make([]jobSubmission, numberOfDistributedJobs)
+	for i := range submissions {
+		submissions[i] = distributedJobSubmissionForKwok(
+			testCtx, testQueue, resources, podsPerDistributedJob, nil, topologyConstraint,
+		)
 	}
-	wg.Wait()
-	Expect(creationError).NotTo(HaveOccurred(), "Failed to create some distributed jobs")
-	waitForDistributedJobsForKwok(ctx, testCtx, jobs)
+	tracker, err := submitJobBatch(ctx, testCtx, queue.GetConnectedNamespaceToQueue(testQueue), submissions)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create distributed Job batch")
+	defer tracker.Close()
 
 	startTime := time.Now()
 	schedulerconfig.EnableScheduler(ctx, testCtx)
 
-	endTime := waitForAllJobsToSchedule(ctx, testCtx, testQueue, expectedNumberOfPods)
+	status, err := tracker.WaitForScheduled(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	endTime := status.LastScheduledAt
 
 	GinkgoLogr.Info(
 		"Scheduled pods", "Total time", endTime.Sub(startTime),
@@ -298,28 +261,22 @@ func measureReclaimSingleGPUJob(
 
 func measureUnschedulableDelayInSeconds(
 	ctx context.Context, testCtx *testcontext.TestContext, testQueue *v2.Queue,
-	createJob func(context.Context, *testcontext.TestContext, *v2.Queue) (*rd.JobResult, error),
+	resources v1.ResourceRequirements, numberOfPods int,
 ) float64 {
 	totalTime := time.Duration(0)
-	for i := 0; i < statusMeasuringSamples; i++ {
-		result, err := createJob(ctx, testCtx, testQueue)
+	for range statusMeasuringSamples {
+		tracker, err := submitJobBatch(ctx, testCtx, queue.GetConnectedNamespaceToQueue(testQueue), []jobSubmission{
+			distributedJobSubmissionForKwok(testCtx, testQueue, resources, numberOfPods, nil, nil),
+		})
 		Expect(err).NotTo(HaveOccurred())
-		pg := result.PodGroup
-		Eventually(func(g Gomega) bool {
-			updatedPodGroup := &v2alpha2.PodGroup{}
-			err := testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKeyFromObject(pg), updatedPodGroup)
-			g.Expect(err).NotTo(HaveOccurred())
+		timing, err := tracker.WaitForPodGroupCondition(ctx, v2alpha2.UnschedulableOnNodePool)
+		Expect(err).NotTo(HaveOccurred())
+		totalTime += timing.TransitionAt.Sub(timing.CreatedAt)
 
-			for _, condition := range updatedPodGroup.Status.SchedulingConditions {
-				if condition.Type == v2alpha2.UnschedulableOnNodePool {
-					totalTime += condition.LastTransitionTime.Time.Sub(pg.CreationTimestamp.Time)
-					return true
-				}
-			}
-			return false
-		}, maxFlowTimeoutMinutes*time.Minute, podsPollIntervalSeconds*time.Second).Should(BeTrue())
-
-		Expect(deleteObjectWithRetries(ctx, testCtx.ControllerClient, result.Job)).To(Succeed())
+		jobs := tracker.Jobs()
+		Expect(jobs).To(HaveLen(1))
+		Expect(deleteObjectWithRetries(ctx, testCtx.ControllerClient, jobs[0])).To(Succeed())
+		tracker.Close()
 	}
 
 	return totalTime.Seconds() / float64(statusMeasuringSamples)
@@ -327,52 +284,26 @@ func measureUnschedulableDelayInSeconds(
 
 // reclaimForOneLargeJob creates a distributed job with the specified number of pods, each requesting gpusPerNode GPUs
 func reclaimForOneLargeJob(ctx context.Context, testCtx *testcontext.TestContext, reclaimSingleGPUJobsQueue *v2.Queue, numberOfPods int) {
-	result, err := createDistributedJobForKwok(
-		ctx, testCtx, reclaimSingleGPUJobsQueue,
-		v1.ResourceRequirements{
-			Limits: map[v1.ResourceName]resource.Quantity{
-				constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
-			},
-		},
-		numberOfPods, map[string]string{},
-		nil,
-	)
+	resources := v1.ResourceRequirements{Limits: map[v1.ResourceName]resource.Quantity{
+		constants.NvidiaGpuResource: *resource.NewQuantity(int64(gpusPerNode), resource.DecimalSI),
+	}}
+	tracker, err := submitJobBatch(ctx, testCtx, queue.GetConnectedNamespaceToQueue(reclaimSingleGPUJobsQueue), []jobSubmission{
+		distributedJobSubmissionForKwok(testCtx, reclaimSingleGPUJobsQueue, resources, numberOfPods, nil, nil),
+	})
 	Expect(err).NotTo(HaveOccurred())
-	podGroup := result.PodGroup
-
-	podsList := &v1.PodList{}
-	Eventually(func(g Gomega) bool {
-		err := testCtx.ControllerClient.List(
-			ctx, podsList,
-			runtimeClient.InNamespace(queue.GetConnectedNamespaceToQueue(reclaimSingleGPUJobsQueue)),
-		)
-		g.Expect(err).To(Succeed())
-		g.Expect(len(podsList.Items)).To(Equal(numberOfPods))
-		for _, pod := range podsList.Items {
-			g.Expect(rd.IsPodRunning(&pod)).To(BeTrue())
-		}
-		return true
-	}, maxFlowTimeoutMinutes*time.Minute, podsPollIntervalSeconds*time.Second).Should(BeTrue())
-
-	Expect(testCtx.ControllerClient.Get(ctx, runtimeClient.ObjectKeyFromObject(podGroup), podGroup)).To(Succeed())
-	startTime := podGroup.CreationTimestamp.Time
-	endTime := startTime
-	for _, pod := range podsList.Items {
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == v1.PodScheduled && condition.Status == v1.ConditionTrue {
-				if condition.LastTransitionTime.After(endTime) {
-					endTime = condition.LastTransitionTime.Time
-				}
-			}
-		}
-	}
+	defer tracker.Close()
+	status, err := tracker.WaitForRunning(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	startTime, err := tracker.WaitForSinglePodGroupCreation(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	endTime := status.LastScheduledAt
 
 	Expect(writeTestResults(
 		"Reclaim time for one very large job", true,
 		map[string]interface{}{
 			"total requested gpus":      float64((numberOfPods) * gpusPerNode),
 			"time to reclaim (seconds)": endTime.Sub(startTime).Seconds(),
-			"number of pods":            float64(len(podsList.Items)),
+			"number of pods":            float64(status.ObservedPods),
 		},
 	))
 }

--- a/test/e2e/scale/kwok_test_functions.go
+++ b/test/e2e/scale/kwok_test_functions.go
@@ -216,18 +216,24 @@ func measureUnschedulableDelayInSeconds(
 ) float64 {
 	totalTime := time.Duration(0)
 	for range statusMeasuringSamples {
-		tracker, err := submitJobBatch(ctx, testCtx, queue.GetConnectedNamespaceToQueue(testQueue), []jobSubmission{
-			distributedJobSubmissionForKwok(testCtx, testQueue, resources, numberOfPods, nil, nil),
-		})
-		Expect(err).NotTo(HaveOccurred())
-		timing, err := tracker.WaitForPodGroupCondition(ctx, v2alpha2.UnschedulableOnNodePool)
-		Expect(err).NotTo(HaveOccurred())
-		totalTime += timing.TransitionAt.Sub(timing.CreatedAt)
+		func() {
+			measurementCtx, cancel := context.WithTimeout(ctx, maxFlowTimeoutMinutes*time.Minute)
+			defer cancel()
 
-		jobs := tracker.Jobs()
-		Expect(jobs).To(HaveLen(1))
-		Expect(deleteObjectWithRetries(ctx, testCtx.ControllerClient, jobs[0])).To(Succeed())
-		tracker.Close()
+			tracker, err := submitJobBatch(measurementCtx, testCtx, queue.GetConnectedNamespaceToQueue(testQueue), []jobSubmission{
+				distributedJobSubmissionForKwok(testCtx, testQueue, resources, numberOfPods, nil, nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer tracker.Close()
+
+			timing, err := tracker.WaitForPodGroupCondition(measurementCtx, v2alpha2.UnschedulableOnNodePool)
+			Expect(err).NotTo(HaveOccurred())
+			totalTime += timing.TransitionAt.Sub(timing.CreatedAt)
+
+			jobs := tracker.Jobs()
+			Expect(jobs).To(HaveLen(1))
+			Expect(deleteObjectWithRetries(measurementCtx, testCtx.ControllerClient, jobs[0])).To(Succeed())
+		}()
 	}
 
 	return totalTime.Seconds() / float64(statusMeasuringSamples)


### PR DESCRIPTION
## Description

Makes scale-test Job submission and readiness tracking robust for larger clusters.

- submits Jobs through an `ants` pool sized to the configured Kubernetes client Burst, reaching the API limit without one goroutine per Job
- tracks Pods and PodGroups incrementally with batch-scoped watches, avoiding repeated full resource lists
- replaces full-list polling in scheduling, reclaim, background-pending, distributed, and NCCL flows, removing API work that grows with cluster size
- keeps NCCL completion accounting scoped to the submitted batch, avoiding scans of unrelated namespace Pods

This follows #1879, which restored the stable aggregate Job creation behavior. The separate `CreateObjectWithRetries` retry-policy refactor is intentionally not included here.

## Related Issues

Related to #1879

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

None.

## Additional Notes

Validation:

- `go test ./test/e2e/scale/... -run '^$'`
- `go vet ./test/e2e/scale/...`
- `make validate`
- `git diff --check origin/main...HEAD`

The environment-dependent KWOK scale suite was not run locally.
