### PR TITLE
feat(scheduler): Improve NUMA plugin performance

### DIFF
--- a/.changes/unreleased/Changed-20260716-101157.yaml
+++ b/.changes/unreleased/Changed-20260716-101157.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: |-
+  Reduced scheduler memory allocations and improved performance on clusters using NUMA topology alignment.

--- a/pkg/scheduler/api/node_info/numa_topology.go
+++ b/pkg/scheduler/api/node_info/numa_topology.go
@@ -10,8 +10,9 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 // TopologyManagerPolicy mirrors the kubelet Topology Manager policy reported per node via NRT.
@@ -59,12 +60,32 @@ type NumaTopology struct {
 	Scope     TopologyManagerScope
 	Zones     []*NumaZone
 	Resources sets.Set[v1.ResourceName]
+
+	VectorMap *resource_info.ResourceVectorMap
+	// AwareIndices holds the VectorMap indices of the zone-reported resources — the only ones the
+	// kubelet aligns. Sorted ascending.
+	AwareIndices []int
+	// AwareNames maps each aware index to the NRT-reported resource name, so placement amounts
+	// materialize under the durable name (e.g. nvidia.com/gpu) rather than the map's normalized "gpu".
+	AwareNames map[int]v1.ResourceName
+	// AllocatablePrefix holds, per aware index, the descending-sorted prefix sums of the zones'
+	// Allocatable: [idx][k] is the sum of the k+1 largest zone allocatables. Precomputed (Allocatable
+	// is static) so the restricted policy's preferred-width lookup is a prefix scan, no per-call sort.
+	AllocatablePrefix map[int][]float64
 }
 
+// NumaZone describes a single NUMA zone's per-resource Available and Allocatable amounts in a ResourceVector format.
 type NumaZone struct {
 	ID          string
-	Available   map[v1.ResourceName]resource.Quantity
-	Allocatable map[v1.ResourceName]resource.Quantity
+	Available   resource_info.ResourceVector
+	Allocatable resource_info.ResourceVector
+}
+
+// NumaZoneSpec describes a single NUMA zone's per-resource Available and Allocatable amounts in a non-vector (ResourceList) format.
+type NumaZoneSpec struct {
+	ID          string
+	Available   v1.ResourceList
+	Allocatable v1.ResourceList
 }
 
 // ZoneIndexByID returns the index of the zone with the given durable id, or false if no zone has
@@ -93,55 +114,127 @@ func (t *NumaTopology) Clone() *NumaTopology {
 	}
 	zones := make([]*NumaZone, len(t.Zones))
 	for i, zone := range t.Zones {
-		available := make(map[v1.ResourceName]resource.Quantity, len(zone.Available))
-		for r, qty := range zone.Available {
-			available[r] = qty.DeepCopy()
+		zones[i] = &NumaZone{
+			ID:          zone.ID,
+			Available:   zone.Available.Clone(),
+			Allocatable: zone.Allocatable.Clone(),
 		}
-		allocatable := make(map[v1.ResourceName]resource.Quantity, len(zone.Allocatable))
-		for r, qty := range zone.Allocatable {
-			allocatable[r] = qty.DeepCopy()
-		}
-		zones[i] = &NumaZone{ID: zone.ID, Available: available, Allocatable: allocatable}
 	}
 	return &NumaTopology{
-		Policy:    t.Policy,
-		Scope:     t.Scope,
-		Zones:     zones,
-		Resources: t.Resources.Clone(),
+		Policy:            t.Policy,
+		Scope:             t.Scope,
+		Zones:             zones,
+		Resources:         t.Resources.Clone(),
+		VectorMap:         t.VectorMap,         // shared, read-only during scoring
+		AwareIndices:      t.AwareIndices,      // shared, read-only
+		AwareNames:        t.AwareNames,        // shared, read-only
+		AllocatablePrefix: t.AllocatablePrefix, // shared, read-only (Allocatable is static)
 	}
 }
 
 // BuildNumaTopology derives a node's NumaTopology from its NodeResourceTopology object, or
-// returns nil when the object is absent or reports no NUMA-node zones.
-func BuildNumaTopology(nrt *nrtv1alpha2.NodeResourceTopology) *NumaTopology {
+// returns nil when the object is absent or reports no NUMA-node zones. The zone vectors and the
+// aware-index projection are built against vectorMap, the cluster-shared resource index map;
+// zone-reported resources absent from the map are ignored (see newNumaTopology).
+func BuildNumaTopology(nrt *nrtv1alpha2.NodeResourceTopology, vectorMap *resource_info.ResourceVectorMap) *NumaTopology {
 	if nrt == nil {
 		return nil
 	}
 
-	zones := buildZones(nrt.Zones)
-	if len(zones) == 0 {
+	specs := zoneSpecs(nrt.Zones)
+	if len(specs) == 0 {
 		return nil
 	}
 
 	policy, scope := parsePolicyAndScope(nrt)
+	return newNumaTopology(policy, scope, vectorMap, specs)
+}
 
+// newNumaTopology vectorizes the zone specs against the shared map and records the aware-resource
+// indices. A zone-reported resource absent from the shared map is ignored: the map is seeded from
+// the cluster's node resources, so its absence means the node does not actually expose that resource.
+// Zones are ordered by ascending NUMA-node id (see sortZones).
+func newNumaTopology(
+	policy TopologyManagerPolicy, scope TopologyManagerScope,
+	vectorMap *resource_info.ResourceVectorMap, specs []NumaZoneSpec,
+) *NumaTopology {
 	resources := sets.New[v1.ResourceName]()
-	for _, zone := range zones {
-		for name := range zone.Available {
-			resources.Insert(name)
+	for _, spec := range specs {
+		for name := range spec.Allocatable {
+			if vectorMap.GetIndex(name) >= 0 {
+				resources.Insert(name)
+			}
+		}
+		for name := range spec.Available {
+			if vectorMap.GetIndex(name) >= 0 {
+				resources.Insert(name)
+			}
 		}
 	}
 
+	zones := make([]*NumaZone, len(specs))
+	for i, spec := range specs {
+		zones[i] = &NumaZone{
+			ID:          spec.ID,
+			Available:   resource_info.NewResourceVectorFromResourceList(spec.Available, vectorMap),
+			Allocatable: resource_info.NewResourceVectorFromResourceList(spec.Allocatable, vectorMap),
+		}
+	}
+	sortZones(zones)
+
+	indices, names := awareIndices(resources, vectorMap)
 	return &NumaTopology{
-		Policy:    policy,
-		Scope:     scope,
-		Zones:     zones,
-		Resources: resources,
+		Policy:            policy,
+		Scope:             scope,
+		Zones:             zones,
+		Resources:         resources,
+		VectorMap:         vectorMap,
+		AwareIndices:      indices,
+		AwareNames:        names,
+		AllocatablePrefix: allocatablePrefixSums(zones, indices),
 	}
 }
 
-// buildZones keeps only NUMA-node zones (NRT Zone.Type == "Node") and their
-// per-resource Available and Allocatable quantities.
+// allocatablePrefixSums computes, per aware index, the descending-sorted prefix sums of the zones'
+// Allocatable for that resource (see NumaTopology.AllocatablePrefix).
+func allocatablePrefixSums(zones []*NumaZone, indices []int) map[int][]float64 {
+	prefix := make(map[int][]float64, len(indices))
+	for _, idx := range indices {
+		vals := make([]float64, len(zones))
+		for z, zone := range zones {
+			vals[z] = zone.Allocatable.Get(idx)
+		}
+		sort.Sort(sort.Reverse(sort.Float64Slice(vals)))
+		acc := 0.0
+		for k := range vals {
+			acc += vals[k]
+			vals[k] = acc
+		}
+		prefix[idx] = vals
+	}
+	return prefix
+}
+
+// awareIndices returns the sorted, deduplicated VectorMap indices of the given resource names, and
+// the reported name for each index. Distinct names that normalize to the same index (e.g. GPU
+// vendor variants) collapse to one entry; the reported name preserved is the last seen.
+func awareIndices(resources sets.Set[v1.ResourceName], vectorMap *resource_info.ResourceVectorMap) ([]int, map[int]v1.ResourceName) {
+	names := map[int]v1.ResourceName{}
+	for name := range resources {
+		if idx := vectorMap.GetIndex(name); idx >= 0 {
+			names[idx] = name
+		}
+	}
+	out := make([]int, 0, len(names))
+	for idx := range names {
+		out = append(out, idx)
+	}
+	sort.Ints(out)
+	return out, names
+}
+
+// zoneSpecs keeps only NUMA-node zones (NRT Zone.Type == "Node") and their per-resource Available
+// and Allocatable quantities.
 //
 // We deliberately model only the NUMA-node level and drop every other zone type
 // the NRT API can express (sockets, dies, ...). This is because the kubelet
@@ -153,30 +246,28 @@ func BuildNumaTopology(nrt *nrtv1alpha2.NodeResourceTopology) *NumaTopology {
 //   - upstream plugin skips zone.Type != "Node":
 //     sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/pluginhelpers.go (createNUMANodeList)
 //   - rationale and history: docs/developer/designs/numa-topology/README.md
-func buildZones(nrtZones nrtv1alpha2.ZoneList) []*NumaZone {
-	var zones []*NumaZone
+func zoneSpecs(nrtZones nrtv1alpha2.ZoneList) []NumaZoneSpec {
+	var specs []NumaZoneSpec
 	for i := range nrtZones {
 		nrtZone := &nrtZones[i]
 		if nrtZone.Type != zoneTypeNode {
 			continue
 		}
 
-		available := make(map[v1.ResourceName]resource.Quantity, len(nrtZone.Resources))
-		allocatable := make(map[v1.ResourceName]resource.Quantity, len(nrtZone.Resources))
+		available := make(v1.ResourceList, len(nrtZone.Resources))
+		allocatable := make(v1.ResourceList, len(nrtZone.Resources))
 		for _, ri := range nrtZone.Resources {
-			available[v1.ResourceName(ri.Name)] = ri.Available.DeepCopy()
-			allocatable[v1.ResourceName(ri.Name)] = ri.Allocatable.DeepCopy()
+			available[v1.ResourceName(ri.Name)] = ri.Available
+			allocatable[v1.ResourceName(ri.Name)] = ri.Allocatable
 		}
 
-		zones = append(zones, &NumaZone{
+		specs = append(specs, NumaZoneSpec{
 			ID:          nrtZone.Name,
 			Available:   available,
 			Allocatable: allocatable,
 		})
 	}
-
-	sortZones(zones)
-	return zones
+	return specs
 }
 
 // sortZones orders the zones by ascending NUMA-node id so the evaluators' zone/mask selection

--- a/pkg/scheduler/api/node_info/numa_topology.go
+++ b/pkg/scheduler/api/node_info/numa_topology.go
@@ -4,6 +4,7 @@
 package node_info
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -220,7 +221,9 @@ func allocatablePrefixSums(zones []*NumaZone, indices []int) map[int][]float64 {
 // vendor variants) collapse to one entry; the reported name preserved is the last seen.
 func awareIndices(resources sets.Set[v1.ResourceName], vectorMap *resource_info.ResourceVectorMap) ([]int, map[int]v1.ResourceName) {
 	names := map[int]v1.ResourceName{}
-	for name := range resources {
+	resourceNames := sets.List(resources)
+	slices.Sort(resourceNames)
+	for _, name := range resourceNames {
 		if idx := vectorMap.GetIndex(name); idx >= 0 {
 			names[idx] = name
 		}

--- a/pkg/scheduler/api/node_info/numa_topology_test.go
+++ b/pkg/scheduler/api/node_info/numa_topology_test.go
@@ -8,8 +8,22 @@ import (
 
 	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
+
+// zoneAmount reads a zone vector's amount for a resource in its natural unit (cpu in cores, others
+// by count), translating from the vector's milli-cpu storage.
+func zoneAmount(vec resource_info.ResourceVector, vm *resource_info.ResourceVectorMap, name v1.ResourceName) int64 {
+	idx := vm.GetIndex(name)
+	val := vec.Get(idx)
+	if idx == resource_info.CPUIndex {
+		return int64(val) / 1000
+	}
+	return int64(val)
+}
 
 func numaNodeZone(name string, available map[string]string) nrtv1alpha2.Zone {
 	return numaNodeZoneWithAllocatable(name, available, available)
@@ -122,14 +136,14 @@ func TestParsePolicyAndScope(t *testing.T) {
 
 func TestBuildNumaTopology(t *testing.T) {
 	t.Run("nil NRT returns nil", func(t *testing.T) {
-		assert.Nil(t, BuildNumaTopology(nil))
+		assert.Nil(t, BuildNumaTopology(nil, resource_info.NewResourceVectorMap()))
 	})
 
 	t.Run("no NUMA-node zones returns nil", func(t *testing.T) {
 		nrt := &nrtv1alpha2.NodeResourceTopology{
 			Zones: nrtv1alpha2.ZoneList{{Name: "socket-0", Type: "Socket"}},
 		}
-		assert.Nil(t, BuildNumaTopology(nrt))
+		assert.Nil(t, BuildNumaTopology(nrt, resource_info.NewResourceVectorMap()))
 	})
 
 	t.Run("zones, availability and reported resources are populated", func(t *testing.T) {
@@ -139,17 +153,14 @@ func TestBuildNumaTopology(t *testing.T) {
 			nrtv1alpha2.Zone{Name: "socket-0", Type: "Socket"}, // ignored
 		)
 
-		nt := BuildNumaTopology(nrt)
+		nt := BuildNumaTopology(nrt, resource_info.NewResourceVectorMap())
 
 		assert.NotNil(t, nt)
 		assert.Equal(t, TopologyPolicySingleNUMANode, nt.Policy)
 		assert.Len(t, nt.Zones, 2, "only NUMA-node zones are kept")
 
-		gpu := nt.Zones[0].Available["nvidia.com/gpu"]
-		assert.Equal(t, int64(2), gpu.Value())
-
-		gpuAlloc := nt.Zones[0].Allocatable["nvidia.com/gpu"]
-		assert.Equal(t, int64(2), gpuAlloc.Value(), "allocatable is populated")
+		assert.Equal(t, int64(2), zoneAmount(nt.Zones[0].Available, nt.VectorMap, "nvidia.com/gpu"))
+		assert.Equal(t, int64(2), zoneAmount(nt.Zones[0].Allocatable, nt.VectorMap, "nvidia.com/gpu"), "allocatable is populated")
 
 		assert.True(t, nt.Resources.HasAll("cpu", "memory", "nvidia.com/gpu"))
 		assert.Equal(t, 3, nt.Resources.Len())
@@ -165,12 +176,10 @@ func TestBuildNumaTopology(t *testing.T) {
 			),
 		)
 
-		nt := BuildNumaTopology(nrt)
+		nt := BuildNumaTopology(nrt, resource_info.NewResourceVectorMap())
 
-		avail := nt.Zones[0].Available["cpu"]
-		alloc := nt.Zones[0].Allocatable["cpu"]
-		assert.Equal(t, int64(4), avail.Value(), "available reflects free capacity")
-		assert.Equal(t, int64(8), alloc.Value(), "allocatable reflects total capacity")
+		assert.Equal(t, int64(4), zoneAmount(nt.Zones[0].Available, nt.VectorMap, "cpu"), "available reflects free capacity")
+		assert.Equal(t, int64(8), zoneAmount(nt.Zones[0].Allocatable, nt.VectorMap, "cpu"), "allocatable reflects total capacity")
 	})
 }
 
@@ -183,7 +192,7 @@ func TestBuildNumaTopologyOrdersZones(t *testing.T) {
 		numaNodeZone("node-0", map[string]string{"cpu": "1"}),
 	)
 
-	nt := BuildNumaTopology(nrt)
+	nt := BuildNumaTopology(nrt, resource_info.NewResourceVectorMap())
 
 	ids := []string{nt.Zones[0].ID, nt.Zones[1].ID, nt.Zones[2].ID}
 	assert.Equal(t, []string{"node-0", "node-2", "node-10"}, ids)
@@ -193,22 +202,16 @@ func TestNumaTopologyClone(t *testing.T) {
 	nrt := nrtWithAttributes(policyValueSingleNUMANode, scopeValueContainer,
 		numaNodeZone("node-0", map[string]string{"cpu": "4"}),
 	)
-	orig := BuildNumaTopology(nrt)
+	orig := BuildNumaTopology(nrt, resource_info.NewResourceVectorMap())
 	clone := orig.Clone()
 
 	// Mutating the clone's ledgers must not affect the original (deep copy).
-	cpu := clone.Zones[0].Available["cpu"]
-	cpu.Sub(resource.MustParse("1"))
-	clone.Zones[0].Available["cpu"] = cpu
+	cpuIdx := clone.VectorMap.GetIndex("cpu")
+	clone.Zones[0].Available[cpuIdx] -= 1000
+	clone.Zones[0].Allocatable[cpuIdx] -= 2000
 
-	allocCPU := clone.Zones[0].Allocatable["cpu"]
-	allocCPU.Sub(resource.MustParse("2"))
-	clone.Zones[0].Allocatable["cpu"] = allocCPU
-
-	origCPU := orig.Zones[0].Available["cpu"]
-	assert.Equal(t, int64(4), origCPU.Value(), "original available ledger unchanged")
-	origAllocCPU := orig.Zones[0].Allocatable["cpu"]
-	assert.Equal(t, int64(4), origAllocCPU.Value(), "original allocatable ledger unchanged")
+	assert.Equal(t, int64(4), zoneAmount(orig.Zones[0].Available, orig.VectorMap, "cpu"), "original available ledger unchanged")
+	assert.Equal(t, int64(4), zoneAmount(orig.Zones[0].Allocatable, orig.VectorMap, "cpu"), "original allocatable ledger unchanged")
 	assert.Nil(t, (*NumaTopology)(nil).Clone())
 }
 

--- a/pkg/scheduler/api/node_info/numa_topology_test.go
+++ b/pkg/scheduler/api/node_info/numa_topology_test.go
@@ -16,13 +16,13 @@ import (
 
 // zoneAmount reads a zone vector's amount for a resource in its natural unit (cpu in cores, others
 // by count), translating from the vector's milli-cpu storage.
-func zoneAmount(vec resource_info.ResourceVector, vm *resource_info.ResourceVectorMap, name v1.ResourceName) int64 {
+func zoneAmount(vec resource_info.ResourceVector, vm *resource_info.ResourceVectorMap, name v1.ResourceName) float64 {
 	idx := vm.GetIndex(name)
 	val := vec.Get(idx)
 	if idx == resource_info.CPUIndex {
-		return int64(val) / 1000
+		return val / 1000
 	}
-	return int64(val)
+	return val
 }
 
 func numaNodeZone(name string, available map[string]string) nrtv1alpha2.Zone {
@@ -159,8 +159,8 @@ func TestBuildNumaTopology(t *testing.T) {
 		assert.Equal(t, TopologyPolicySingleNUMANode, nt.Policy)
 		assert.Len(t, nt.Zones, 2, "only NUMA-node zones are kept")
 
-		assert.Equal(t, int64(2), zoneAmount(nt.Zones[0].Available, nt.VectorMap, "nvidia.com/gpu"))
-		assert.Equal(t, int64(2), zoneAmount(nt.Zones[0].Allocatable, nt.VectorMap, "nvidia.com/gpu"), "allocatable is populated")
+		assert.Equal(t, float64(2), zoneAmount(nt.Zones[0].Available, nt.VectorMap, "nvidia.com/gpu"))
+		assert.Equal(t, float64(2), zoneAmount(nt.Zones[0].Allocatable, nt.VectorMap, "nvidia.com/gpu"), "allocatable is populated")
 
 		assert.True(t, nt.Resources.HasAll("cpu", "memory", "nvidia.com/gpu"))
 		assert.Equal(t, 3, nt.Resources.Len())
@@ -178,8 +178,8 @@ func TestBuildNumaTopology(t *testing.T) {
 
 		nt := BuildNumaTopology(nrt, resource_info.NewResourceVectorMap())
 
-		assert.Equal(t, int64(4), zoneAmount(nt.Zones[0].Available, nt.VectorMap, "cpu"), "available reflects free capacity")
-		assert.Equal(t, int64(8), zoneAmount(nt.Zones[0].Allocatable, nt.VectorMap, "cpu"), "allocatable reflects total capacity")
+		assert.Equal(t, float64(4), zoneAmount(nt.Zones[0].Available, nt.VectorMap, "cpu"), "available reflects free capacity")
+		assert.Equal(t, float64(8), zoneAmount(nt.Zones[0].Allocatable, nt.VectorMap, "cpu"), "allocatable reflects total capacity")
 	})
 }
 
@@ -210,8 +210,8 @@ func TestNumaTopologyClone(t *testing.T) {
 	clone.Zones[0].Available[cpuIdx] -= 1000
 	clone.Zones[0].Allocatable[cpuIdx] -= 2000
 
-	assert.Equal(t, int64(4), zoneAmount(orig.Zones[0].Available, orig.VectorMap, "cpu"), "original available ledger unchanged")
-	assert.Equal(t, int64(4), zoneAmount(orig.Zones[0].Allocatable, orig.VectorMap, "cpu"), "original allocatable ledger unchanged")
+	assert.Equal(t, float64(4), zoneAmount(orig.Zones[0].Available, orig.VectorMap, "cpu"), "original available ledger unchanged")
+	assert.Equal(t, float64(4), zoneAmount(orig.Zones[0].Allocatable, orig.VectorMap, "cpu"), "original allocatable ledger unchanged")
 	assert.Nil(t, (*NumaTopology)(nil).Clone())
 }
 

--- a/pkg/scheduler/cache/cluster_info/cluster_info.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info.go
@@ -304,7 +304,7 @@ func (c *ClusterInfo) populateNodeResourceTopologies(nodes map[string]*node_info
 			continue
 		}
 		nodeInfo.NodeResourceTopology = nrt
-		nodeInfo.NumaTopology = node_info.BuildNumaTopology(nrt)
+		nodeInfo.NumaTopology = node_info.BuildNumaTopology(nrt, nodeInfo.VectorMap)
 	}
 }
 

--- a/pkg/scheduler/plugins/numa/consolidation_discard_test.go
+++ b/pkg/scheduler/plugins/numa/consolidation_discard_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common"
 	schedapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
@@ -60,12 +59,10 @@ func newScenarioFixture(t *testing.T) *scenarioFixture {
 		tasksToNodeMap, nil, vectorMap)
 	node := nodesInfoMap["node0"]
 
-	node.NumaTopology = &node_info.NumaTopology{
-		Policy:    node_info.TopologyPolicySingleNUMANode,
-		Scope:     node_info.TopologyScopePod,
-		Zones:     []*node_info.NumaZone{cpuZone("node-0", "4", "1"), cpuZone("node-1", "4", "1")},
-		Resources: sets.New[v1.ResourceName]("cpu"),
-	}
+	node.NumaTopology = nodes_fake.NewNumaTopologyWithMap(
+		node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod, vectorMap,
+		cpuZone("node-0", "4", "1"), cpuZone("node-1", "4", "1"),
+	)
 
 	victim0 := singleTask(jobsInfoMap["victim0"])
 	victim1 := singleTask(jobsInfoMap["victim1"])
@@ -100,8 +97,8 @@ func newScenarioFixture(t *testing.T) *scenarioFixture {
 }
 
 func (f *scenarioFixture) zone(i int) int64 {
-	q := f.node.NumaTopology.Zones[i].Available["cpu"]
-	return q.Value()
+	idx := f.node.NumaTopology.VectorMap.GetIndex("cpu")
+	return int64(f.node.NumaTopology.Zones[i].Available.Get(idx)) / 1000
 }
 
 // runScenario simulates the scenario by evicting the victims and allocating the preemptor.

--- a/pkg/scheduler/plugins/numa/evaluator.go
+++ b/pkg/scheduler/plugins/numa/evaluator.go
@@ -12,156 +12,164 @@ import (
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
-// numaEvaluator decides whether a set of requests can be NUMA-aligned on a node and returns the
-// expected per-zone placement. Each request is one alignment unit — the whole pod under pod scope,
-// one container under container scope.
-type numaEvaluator interface {
-	evaluate(topo *node_info.NumaTopology, ignoreList sets.Set[v1.ResourceName], requests []v1.ResourceList) (placement pod_info.NUMAPlacement, admit bool)
-}
+// stackZones bounds the mask/scratch stack buffers; nodes with more NUMA zones fall back to heap.
+const stackZones = 16
 
-func evaluatorFor(policy node_info.TopologyManagerPolicy) numaEvaluator {
-	switch policy {
-	case node_info.TopologyPolicySingleNUMANode:
-		return singleNUMAEvaluator{}
-	case node_info.TopologyPolicyRestricted:
-		return restrictedEvaluator{}
-	default:
-		return nil
+// zoneAllocation accumulates, per zone index, the amounts to place there (as a ResourceVector delta).
+// placementFromAllocation materializes it into a pod_info.NUMAPlacement.
+type zoneAllocation = map[int]resource_info.ResourceVector
+
+// effectiveAware returns the node's aware indices minus the ignored ones. When nothing is ignored
+// (the default) this is the topology's own AwareIndices.
+func (pp *numaPlugin) effectiveAware(node *node_info.NodeInfo) []int {
+	aware := node.NumaTopology.AwareIndices
+	if len(pp.ignoreList) == 0 {
+		return aware
 	}
+	vectorMap := node.NumaTopology.VectorMap
+	ignore := sets.New[int]()
+	for name := range pp.ignoreList {
+		if idx := vectorMap.GetIndex(name); idx >= 0 {
+			ignore.Insert(idx)
+		}
+	}
+	return filterAware(aware, ignore)
 }
 
-// singleNUMAEvaluator requires each request to fit entirely within one NUMA zone (the lowest
-// that fits). Requests may land on different zones (container scope), but none may span zones.
+// allocatable reports whether the kubelet Topology Manager would align the task on the node. A task
+// the plugin does not constrain passes through as true.
+func (pp *numaPlugin) allocatable(task *pod_info.PodInfo, node *node_info.NodeInfo) bool {
+	return pp.solveTask(task, node, nil)
+}
+
+// evaluate returns the task's expected per-zone allocation on the node (nil for a task the plugin
+// does not constrain). Used by the placement path; the predicate uses allocatable (feasibility only).
+func (pp *numaPlugin) evaluate(task *pod_info.PodInfo, node *node_info.NodeInfo) (zoneAllocation, bool) {
+	alloc := zoneAllocation{}
+	if !pp.solveTask(task, node, alloc) {
+		return nil, false
+	}
+	return alloc, true
+}
+
+// solveTask resolves the task's requests and scope for the node and runs solve. A task the plugin
+// does not constrain passes through as admitted. When alloc is non-nil, solve records the placement
+// into it; when nil, it only decides feasibility (zero-allocation).
+func (pp *numaPlugin) solveTask(task *pod_info.PodInfo, node *node_info.NodeInfo, alloc zoneAllocation) bool {
+	if node == nil || !pp.shouldHandle(task, node.NumaTopology) {
+		return true
+	}
+	topo := node.NumaTopology
+	aware := pp.effectiveAware(node)
+	concurrent, serial := buildNumaRequests(task.Pod, topo.VectorMap).forScope(topo.Scope)
+	return solve(topo, aware, concurrent, serial, alloc)
+}
+
+// solve walks the concurrent and serial NUMA requests and reports whether the node can align them.
+// The concurrent requests share the per-zone ledger (native sidecars + app containers coexist), so
+// each reduces availability for the next; the serial (ordinary init) requests are each aligned
+// against the pristine availability, never accumulated. When alloc is non-nil the concurrent
+// requests' per-zone placement is recorded there; otherwise the walk is allocation-free (a `consumed`
+// scratch is taken only when a later request needs the reduced view).
+func solve(topo *node_info.NumaTopology, aware []int, concurrent, serial []resource_info.ResourceVector, alloc zoneAllocation) bool {
+	width := topo.VectorMap.Len()
+	var maskArr [stackZones]int
+	maskBuf := maskArr[:]
+	if len(topo.Zones) > stackZones {
+		maskBuf = make([]int, len(topo.Zones))
+	}
+
+	var consumed []float64
+	for i, req := range concurrent {
+		mask, ok := feasibleMask(topo, aware, req, consumed, width, maskBuf)
+		if !ok {
+			return false
+		}
+		last := i == len(concurrent)-1
+		if alloc == nil && last {
+			continue // nothing to record and no successor to reduce for
+		}
+		if consumed == nil && !last {
+			consumed = make([]float64, len(topo.Zones)*width)
+		}
+		drawAcrossMask(topo, aware, mask, req, consumed, alloc, width)
+	}
+	for _, req := range serial {
+		if _, ok := feasibleMask(topo, aware, req, nil, 0, nil); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// feasibleMask picks the mask the policy's evaluator would choose for one request, under the current
+// availability view (Available minus consumed).
+func feasibleMask(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, maskBuf []int) ([]int, bool) {
+	if topo.Policy == node_info.TopologyPolicySingleNUMANode {
+		return singleNUMAEvaluator{}.fit(topo, aware, req, consumed, width, maskBuf)
+	}
+	return restrictedEvaluator{}.fit(topo, aware, req, consumed, width, maskBuf)
+}
+
+// singleNUMAEvaluator (single-numa-node) requires each request to fit entirely within one NUMA zone,
+// the lowest that holds it.
 type singleNUMAEvaluator struct{}
 
-func (singleNUMAEvaluator) evaluate(topo *node_info.NumaTopology, ignoreList sets.Set[v1.ResourceName], requests []v1.ResourceList) (pod_info.NUMAPlacement, bool) {
-	available := cloneAvailable(topo.Zones)
-	allocation := map[int]v1.ResourceList{}
-
-	for _, request := range requests {
-		req := extractNumaRequest(request, topo.Resources, ignoreList)
-		idx, ok := lowestZoneFitting(available, req)
-		if !ok {
-			return nil, false
+func (singleNUMAEvaluator) fit(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, maskBuf []int) ([]int, bool) {
+	for z := range topo.Zones {
+		if reqFitsZone(topo, aware, req, consumed, width, z) {
+			return oneZoneMask(maskBuf, z), true
 		}
-		subtract(available[idx], req)
-		addAllocation(allocation, idx, req)
 	}
-	return placementFromAllocation(allocation), true
+	return nil, false
 }
 
-// restrictedEvaluator reproduces the kubelet's hint merge: a request is admitted iff there is a
-// single minimal-width NUMA mask that is a preferred (minimal-width) satisfying hint for every
-// resource it requests. Equivalently, all per-resource minimal widths must agree and a mask of
-// that width must satisfy every resource at once. single-numa-node is the |mask|==1 case.
-//
-// Preferred width is computed from Allocatable (matching the kubelet device manager's
-// m.allDevices pass), while feasibility is checked against Available (matching the kubelet's
-// available-device pass). When some devices are already allocated the two can disagree: a
-// single-zone placement may be preferred by capacity but infeasible by availability, making the
-// only feasible mask (multi-zone) non-preferred → restricted rejects, matching kubelet behavior.
+// restrictedEvaluator reproduces the kubelet hint merge: all per-resource preferred widths (from
+// static Allocatable) must agree, and a mask of that width must satisfy every resource against
+// Available. single-numa-node is the width==1 case.
 type restrictedEvaluator struct{}
 
-func (restrictedEvaluator) evaluate(topo *node_info.NumaTopology, ignoreList sets.Set[v1.ResourceName], requests []v1.ResourceList) (pod_info.NUMAPlacement, bool) {
-	available := cloneAvailable(topo.Zones)
-	allocatable := cloneAllocatable(topo.Zones)
-	allocation := map[int]v1.ResourceList{}
-
-	for _, request := range requests {
-		req := extractNumaRequest(request, topo.Resources, ignoreList)
-		mask, ok := preferredCommonMask(available, allocatable, req)
+func (restrictedEvaluator) fit(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, maskBuf []int) ([]int, bool) {
+	w := -1
+	for _, idx := range aware {
+		need := req.Get(idx)
+		if need <= 0 {
+			continue
+		}
+		k, ok := minWidthFromPrefix(topo.AllocatablePrefix[idx], need)
 		if !ok {
 			return nil, false
 		}
-		for idx, amt := range splitAcrossMask(available, mask, req) {
-			subtract(available[idx], amt)
-			addAllocation(allocation, idx, amt)
-		}
-	}
-	return placementFromAllocation(allocation), true
-}
-
-// placementFromAllocation converts the evaluator's zone-index→amounts accumulation into a
-// pod_info.NUMAPlacement, ordered by zone index for a deterministic placement (so the eviction
-// dedup's comparison is stable). Index-keyed: the internal scheduler representation. Translation
-// to the durable zone id happens only at the persistence boundary (BindRequest / annotation).
-func placementFromAllocation(allocation map[int]v1.ResourceList) pod_info.NUMAPlacement {
-	indices := make([]int, 0, len(allocation))
-	for idx := range allocation {
-		indices = append(indices, idx)
-	}
-	sort.Ints(indices)
-
-	placement := make(pod_info.NUMAPlacement, 0, len(indices))
-	for _, idx := range indices {
-		placement = append(placement, pod_info.ZonePlacement{
-			ZoneIndex: idx,
-			Amount:    allocation[idx],
-		})
-	}
-	return placement
-}
-
-// preferredCommonMask finds the lowest minimal-width NUMA mask that satisfies every requested
-// resource, or reports false. It rejects when per-resource minimal widths disagree.
-//
-// allocatable is used for min-width (preferred) computation; scratch (available) is used for
-// feasibility. This matches the kubelet device manager, which uses m.allDevices for
-// minAffinitySize and the available set for the per-mask device count check.
-func preferredCommonMask(available, allocatable []v1.ResourceList, req v1.ResourceList) ([]int, bool) {
-	width := -1
-	for r, qty := range req {
-		w, ok := minWidthForResource(allocatable, r, qty)
-		if !ok {
-			return nil, false
-		}
-		if width == -1 {
-			width = w
-		} else if w != width {
+		if w == -1 {
+			w = k
+		} else if k != w {
 			return nil, false
 		}
 	}
-	if width <= 0 {
-		return []int{}, true
+	if w <= 0 {
+		return maskBuf[:0], true // no positive aware requests: trivially aligned (nil-safe)
 	}
-	return lowestSatisfyingMask(available, req, width)
-}
-
-// minWidthForResource is the fewest zones whose largest Available values sum to at least qty,
-// i.e. the resource's preferred (minimal) NUMA-node count. Reports false when even all zones
-// together cannot satisfy qty.
-func minWidthForResource(scratch []v1.ResourceList, r v1.ResourceName, qty resource.Quantity) (int, bool) {
-	vals := make([]resource.Quantity, len(scratch))
-	total := resource.Quantity{}
-	for i := range scratch {
-		v := amountOf(scratch[i], r)
-		vals[i] = v
-		total.Add(v)
-	}
-	if total.Cmp(qty) < 0 {
-		return 0, false
-	}
-
-	sort.Slice(vals, func(i, j int) bool { return vals[i].Cmp(vals[j]) > 0 })
-	acc := resource.Quantity{}
-	for k := range vals {
-		acc.Add(vals[k])
-		if acc.Cmp(qty) >= 0 {
-			return k + 1, true
+	if w == 1 {
+		for z := range topo.Zones {
+			if reqFitsZone(topo, aware, req, consumed, width, z) {
+				return oneZoneMask(maskBuf, z), true
+			}
 		}
+		return nil, false
 	}
-	return 0, false
+	return lowestSatisfyingReqMask(topo, aware, req, consumed, width, w, maskBuf)
 }
 
-// lowestSatisfyingMask returns the lexicographically-lowest width-sized zone mask whose summed
+// lowestSatisfyingReqMask returns the lexicographically-lowest width-w zone mask whose summed
 // Available satisfies every requested resource.
-func lowestSatisfyingMask(available []v1.ResourceList, req v1.ResourceList, width int) ([]int, bool) {
+func lowestSatisfyingReqMask(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width, w int, maskBuf []int) ([]int, bool) {
 	var found []int
-	combinations(len(available), width, func(mask []int) bool {
-		if maskSatisfies(available, req, mask) {
-			found = append([]int(nil), mask...)
+	combinations(len(topo.Zones), w, func(mask []int) bool {
+		if maskSatisfiesReq(topo, aware, req, consumed, width, mask) {
+			found = append(maskBuf[:0], mask...)
 			return false
 		}
 		return true
@@ -169,52 +177,116 @@ func lowestSatisfyingMask(available []v1.ResourceList, req v1.ResourceList, widt
 	return found, found != nil
 }
 
-func maskSatisfies(available []v1.ResourceList, req v1.ResourceList, mask []int) bool {
-	for r, qty := range req {
-		sum := resource.Quantity{}
-		for _, i := range mask {
-			sum.Add(amountOf(available[i], r))
+// reqFitsZone reports whether zone z alone satisfies every requested resource of the request.
+func reqFitsZone(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width, z int) bool {
+	for _, idx := range aware {
+		need := req.Get(idx)
+		if need <= 0 {
+			continue
 		}
-		if sum.Cmp(qty) < 0 {
+		if availableAt(topo, consumed, width, z, idx) < need {
 			return false
 		}
 	}
 	return true
 }
 
-// splitAcrossMask distributes each resource greedily across the mask's zones (lowest first),
-// producing the per-zone amounts to allocate. The kubelet does not fix the per-zone split at
-// admission, so any split drawing each resource entirely from the mask is acceptable; this is
-// internal accounting only.
-func splitAcrossMask(scratch []v1.ResourceList, mask []int, req v1.ResourceList) map[int]v1.ResourceList {
-	split := map[int]v1.ResourceList{}
-	for r, qty := range req {
-		remaining := qty.DeepCopy()
-		for _, i := range mask {
-			if remaining.Sign() <= 0 {
-				break
-			}
-			take := amountOf(scratch[i], r)
-			if take.Cmp(remaining) > 0 {
-				take = remaining.DeepCopy()
-			}
-			if take.Sign() <= 0 {
-				continue
-			}
-			if split[i] == nil {
-				split[i] = v1.ResourceList{}
-			}
-			cur := amountOf(split[i], r)
-			cur.Add(take)
-			split[i][r] = cur
-			remaining.Sub(take)
+// maskSatisfiesReq reports whether the summed Available over the mask's zones satisfies every
+// requested resource of the request.
+func maskSatisfiesReq(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, mask []int) bool {
+	for _, idx := range aware {
+		need := req.Get(idx)
+		if need <= 0 {
+			continue
+		}
+		sum := 0.0
+		for _, z := range mask {
+			sum += availableAt(topo, consumed, width, z, idx)
+		}
+		if sum < need {
+			return false
 		}
 	}
-	return split
+	return true
 }
 
-// combinations yields every size-k subset of [0,n) as ascending index slices, in
-// lexicographic order, until yield returns false.
+// drawAcrossMask draws req greedily (lowest zone first) across its mask. It reduces `consumed` (when
+// non-nil) so the next concurrent request sees the draw, and records the per-zone amounts into
+// `alloc` (when non-nil) for the placement path. The kubelet does not fix the per-zone split at
+// admission, so any split drawing each resource entirely from the mask is acceptable.
+func drawAcrossMask(topo *node_info.NumaTopology, aware []int, mask []int, req resource_info.ResourceVector, consumed []float64, alloc zoneAllocation, width int) {
+	for _, idx := range aware {
+		remaining := req.Get(idx)
+		if remaining <= 0 {
+			continue
+		}
+		for _, z := range mask {
+			if remaining <= 0 {
+				break
+			}
+			take := availableAt(topo, consumed, width, z, idx)
+			if take > remaining {
+				take = remaining
+			}
+			if take <= 0 {
+				continue
+			}
+			if consumed != nil {
+				consumed[z*width+idx] += take
+			}
+			if alloc != nil {
+				recordAlloc(alloc, z, idx, take, topo.VectorMap)
+			}
+			remaining -= take
+		}
+	}
+}
+
+func recordAlloc(alloc zoneAllocation, z, idx int, amount float64, vectorMap *resource_info.ResourceVectorMap) {
+	vec := alloc[z]
+	if vec == nil {
+		vec = resource_info.NewResourceVector(vectorMap)
+		alloc[z] = vec
+	}
+	vec[idx] += amount
+}
+
+// availableAt is zone z's Available for resource idx, minus what prior requests in this evaluation
+// already consumed (consumed nil = pristine availability).
+func availableAt(topo *node_info.NumaTopology, consumed []float64, width, z, idx int) float64 {
+	v := topo.Zones[z].Available.Get(idx)
+	if consumed != nil {
+		v -= consumed[z*width+idx]
+	}
+	return v
+}
+
+// minWidthFromPrefix returns the fewest zones whose largest Allocatable values sum to at least need
+// (the resource's preferred NUMA width), from precomputed descending prefix sums.
+func minWidthFromPrefix(prefix []float64, need float64) (int, bool) {
+	if len(prefix) == 0 || prefix[len(prefix)-1] < need {
+		return 0, false
+	}
+	for k, sum := range prefix {
+		if sum >= need {
+			return k + 1, true
+		}
+	}
+	return 0, false
+}
+
+// oneZoneMask writes a single-zone mask into buf (reusing its backing array, no allocation) and
+// returns it. buf is nil only for serial requests, whose returned mask the caller ignores.
+func oneZoneMask(buf []int, z int) []int {
+	if buf == nil {
+		return nil
+	}
+	buf[0] = z
+	return buf[:1]
+}
+
+// combinations yields every size-k subset of [0,n) as ascending index slices, in lexicographic
+// order, until yield returns false.
 func combinations(n, k int, yield func([]int) bool) {
 	if k <= 0 || k > n {
 		return
@@ -241,92 +313,43 @@ func combinations(n, k int, yield func([]int) bool) {
 	}
 }
 
-// extractNumaRequest keeps only the resources that constrain zone selection: those reported per-zone
-// (aware) and not ignored, dropping zero-quantity entries. ignoreList is applied here rather
-// than at ingestion because it is plugin configuration, unknown to the topology builder.
-func extractNumaRequest(request v1.ResourceList, aware, ignoreList sets.Set[v1.ResourceName]) v1.ResourceList {
+// placementFromAllocation converts the zone-index→amounts accumulation into a pod_info.NUMAPlacement,
+// ordered by zone index for a deterministic placement (so the eviction dedup's comparison is stable).
+// Index-keyed: the internal scheduler representation; translation to the durable zone id happens only
+// at the persistence boundary (BindRequest / annotation).
+func placementFromAllocation(allocation zoneAllocation, topo *node_info.NumaTopology) pod_info.NUMAPlacement {
+	indices := make([]int, 0, len(allocation))
+	for idx := range allocation {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	placement := make(pod_info.NUMAPlacement, 0, len(indices))
+	for _, idx := range indices {
+		placement = append(placement, pod_info.ZonePlacement{
+			ZoneIndex: idx,
+			Amount:    vectorToResourceList(allocation[idx], topo),
+		})
+	}
+	return placement
+}
+
+// vectorToResourceList materializes a zone's allocated amounts into a ResourceList at the placement
+// boundary: CPU as a milli quantity, every other aware resource as a plain integer quantity. The
+// resource name is the NRT-reported one (AwareNames), not the shared map's normalized name.
+func vectorToResourceList(vec resource_info.ResourceVector, topo *node_info.NumaTopology) v1.ResourceList {
 	out := v1.ResourceList{}
-	for r, qty := range request {
-		if qty.Sign() == 0 || !aware.Has(r) || ignoreList.Has(r) {
+	for _, idx := range topo.AwareIndices {
+		val := vec.Get(idx)
+		if val <= 0 {
 			continue
 		}
-		out[r] = qty.DeepCopy()
+		name := topo.AwareNames[idx]
+		if idx == resource_info.CPUIndex {
+			out[name] = *resource.NewMilliQuantity(int64(val), resource.DecimalSI)
+		} else {
+			out[name] = *resource.NewQuantity(int64(val), resource.DecimalSI)
+		}
 	}
 	return out
-}
-
-func cloneAvailable(zones []*node_info.NumaZone) []v1.ResourceList {
-	available := make([]v1.ResourceList, len(zones))
-	for i, zone := range zones {
-		amounts := make(v1.ResourceList, len(zone.Available))
-		for r, qty := range zone.Available {
-			amounts[r] = qty.DeepCopy()
-		}
-		available[i] = amounts
-	}
-	return available
-}
-
-func cloneAllocatable(zones []*node_info.NumaZone) []v1.ResourceList {
-	allocatable := make([]v1.ResourceList, len(zones))
-	for i, zone := range zones {
-		amounts := make(v1.ResourceList, len(zone.Allocatable))
-		for r, qty := range zone.Allocatable {
-			amounts[r] = qty.DeepCopy()
-		}
-		allocatable[i] = amounts
-	}
-	return allocatable
-}
-
-func lowestZoneFitting(scratch []v1.ResourceList, req v1.ResourceList) (int, bool) {
-	for i := range scratch {
-		fits := true
-		for r, qty := range req {
-			if avail := amountOf(scratch[i], r); avail.Cmp(qty) < 0 {
-				fits = false
-				break
-			}
-		}
-		if fits {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
-func subtract(amounts, delta v1.ResourceList) {
-	for r, qty := range delta {
-		v := amountOf(amounts, r)
-		v.Sub(qty)
-		amounts[r] = v
-	}
-}
-
-func add(amounts, delta v1.ResourceList) {
-	for r, qty := range delta {
-		v := amountOf(amounts, r)
-		v.Add(qty)
-		amounts[r] = v
-	}
-}
-
-func addAllocation(allocation map[int]v1.ResourceList, idx int, amt v1.ResourceList) {
-	cur := allocation[idx]
-	if cur == nil {
-		cur = v1.ResourceList{}
-		allocation[idx] = cur
-	}
-	for r, qty := range amt {
-		v := amountOf(cur, r)
-		v.Add(qty)
-		cur[r] = v
-	}
-}
-
-func amountOf(amounts v1.ResourceList, r v1.ResourceName) resource.Quantity {
-	if qty, ok := amounts[r]; ok {
-		return qty.DeepCopy()
-	}
-	return resource.Quantity{}
 }

--- a/pkg/scheduler/plugins/numa/evaluator.go
+++ b/pkg/scheduler/plugins/numa/evaluator.go
@@ -8,7 +8,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -23,20 +22,12 @@ const stackZones = 16
 type zoneAllocation = map[int]resource_info.ResourceVector
 
 // effectiveAware returns the node's aware indices minus the ignored ones. When nothing is ignored
-// (the default) this is the topology's own AwareIndices.
+// (the default) this is the topology's own AwareIndices with no allocation or lookup.
 func (pp *numaPlugin) effectiveAware(node *node_info.NodeInfo) []int {
-	aware := node.NumaTopology.AwareIndices
-	if len(pp.ignoreList) == 0 {
-		return aware
+	if len(pp.ignoreIndices) == 0 {
+		return node.NumaTopology.AwareIndices
 	}
-	vectorMap := node.NumaTopology.VectorMap
-	ignore := sets.New[int]()
-	for name := range pp.ignoreList {
-		if idx := vectorMap.GetIndex(name); idx >= 0 {
-			ignore.Insert(idx)
-		}
-	}
-	return filterAware(aware, ignore)
+	return pp.effectiveAwareByNode[node.Name]
 }
 
 // allocatable reports whether the kubelet Topology Manager would align the task on the node. A task
@@ -64,7 +55,7 @@ func (pp *numaPlugin) solveTask(task *pod_info.PodInfo, node *node_info.NodeInfo
 	}
 	topo := node.NumaTopology
 	aware := pp.effectiveAware(node)
-	concurrent, serial := buildNumaRequests(task.Pod, topo.VectorMap).forScope(topo.Scope)
+	concurrent, serial := pp.numaRequestsFor(task, topo.VectorMap).forScope(topo.Scope)
 	return solve(topo, aware, concurrent, serial, alloc)
 }
 

--- a/pkg/scheduler/plugins/numa/evaluator_test.go
+++ b/pkg/scheduler/plugins/numa/evaluator_test.go
@@ -13,12 +13,35 @@ import (
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
 const gpu = "nvidia.com/gpu"
 
-// noIgnoreList is the empty ignoreList passed to evaluate in tests that do not exercise it.
+// noIgnoreList is the empty ignoreList passed in tests that do not exercise it.
 var noIgnoreList = sets.New[v1.ResourceName]()
+
+// evalPlacement runs the solver on requests (as the concurrent set) against topo and returns the
+// resulting placement and admit decision — the form the worked-example assertions read.
+func evalPlacement(topo *node_info.NumaTopology, ignore sets.Set[v1.ResourceName], requests []v1.ResourceList) (pod_info.NUMAPlacement, bool) {
+	aware := topo.AwareIndices
+	if ignore.Len() > 0 {
+		ig := sets.New[int]()
+		for name := range ignore {
+			if idx := topo.VectorMap.GetIndex(name); idx >= 0 {
+				ig.Insert(idx)
+			}
+		}
+		aware = filterAware(topo.AwareIndices, ig)
+	}
+	reqs := make([]resource_info.ResourceVector, len(requests))
+	for i, r := range requests {
+		reqs[i] = resource_info.NewResourceVectorFromResourceList(r, topo.VectorMap)
+	}
+	alloc := zoneAllocation{}
+	ok := solve(topo, aware, reqs, nil, alloc)
+	return placementFromAllocation(alloc, topo), ok
+}
 
 // amountAt returns the amounts placed on a given zone index, or nil if the zone is not in the placement.
 func amountAt(p pod_info.NUMAPlacement, zoneIndex int) v1.ResourceList {
@@ -30,7 +53,7 @@ func amountAt(p pod_info.NUMAPlacement, zoneIndex int) v1.ResourceList {
 	return nil
 }
 
-// req builds a request unit from resource-name/quantity-string pairs.
+// req builds a request from resource-name/quantity-string pairs.
 func req(pairs ...string) v1.ResourceList {
 	out := v1.ResourceList{}
 	for i := 0; i < len(pairs); i += 2 {
@@ -42,16 +65,16 @@ func req(pairs ...string) v1.ResourceList {
 // partialZone builds a NumaZone whose Allocatable differs from Available, modelling a zone
 // that has pre-existing allocations. allocatable is the static per-zone capacity; available is
 // what remains after current pod allocations are subtracted.
-func partialZone(id string, allocatable, available map[string]string) *node_info.NumaZone {
-	alloc := map[v1.ResourceName]resource.Quantity{}
+func partialZone(id string, allocatable, available map[string]string) node_info.NumaZoneSpec {
+	alloc := v1.ResourceList{}
 	for name, qty := range allocatable {
 		alloc[v1.ResourceName(name)] = resource.MustParse(qty)
 	}
-	avail := map[v1.ResourceName]resource.Quantity{}
+	avail := v1.ResourceList{}
 	for name, qty := range available {
 		avail[v1.ResourceName(name)] = resource.MustParse(qty)
 	}
-	return &node_info.NumaZone{ID: id, Allocatable: alloc, Available: avail}
+	return node_info.NumaZoneSpec{ID: id, Allocatable: alloc, Available: avail}
 }
 
 // twoZoneNode builds a restricted/single-numa node with two identical NUMA zones.
@@ -66,20 +89,19 @@ func twoZoneNode(policy node_info.TopologyManagerPolicy, perZone v1.ResourceList
 	)
 }
 
-func TestSingleNUMAEvaluator(t *testing.T) {
+func TestSingleNUMASolve(t *testing.T) {
 	node := twoZoneNode(node_info.TopologyPolicySingleNUMANode, req(gpu, "4", "cpu", "16"))
-	eval := singleNUMAEvaluator{}
 
 	t.Run("fits the lowest zone", func(t *testing.T) {
-		allocation, admit := eval.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "2", "cpu", "4")})
+		allocation, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "2", "cpu", "4")})
 		assert.True(t, admit)
 		assert.Equal(t, []int{0}, allocation.ZoneIndices(), "prefers the lowest zone")
 		gpuAllocated := amountAt(allocation, 0)[gpu]
 		assert.Equal(t, int64(2), gpuAllocated.Value())
 	})
 
-	t.Run("rejects a unit larger than any single zone", func(t *testing.T) {
-		_, admit := eval.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "6")})
+	t.Run("rejects a request larger than any single zone", func(t *testing.T) {
+		_, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "6")})
 		assert.False(t, admit, "6 GPUs cannot fit one 4-GPU zone")
 	})
 
@@ -89,7 +111,7 @@ func TestSingleNUMAEvaluator(t *testing.T) {
 			numaZone("node-0", map[string]string{gpu: "4"}),
 			numaZone("node-1", map[string]string{"cpu": "16"}),
 		)
-		_, admit := singleNUMAEvaluator{}.evaluate(split, noIgnoreList, []v1.ResourceList{req(gpu, "1", "cpu", "1")})
+		_, admit := evalPlacement(split, noIgnoreList, []v1.ResourceList{req(gpu, "1", "cpu", "1")})
 		assert.False(t, admit)
 	})
 
@@ -98,7 +120,7 @@ func TestSingleNUMAEvaluator(t *testing.T) {
 		// combined capacity (4 GPU, 8 CPU), but exceeds what any single zone holds (2 GPU, 4 CPU).
 		// single-numa requires one zone to satisfy everything, so it rejects despite the aggregate fit.
 		node := twoZoneNode(node_info.TopologyPolicySingleNUMANode, req(gpu, "2", "cpu", "4"))
-		_, admit := singleNUMAEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "3", "cpu", "6")})
+		_, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "3", "cpu", "6")})
 		assert.False(t, admit, "fits across both zones combined, but neither zone alone fits")
 	})
 
@@ -109,7 +131,7 @@ func TestSingleNUMAEvaluator(t *testing.T) {
 			numaZone("node-1", map[string]string{"cpu": "4", "memory": "16Gi"}),
 		)
 		ignoreList := sets.New[v1.ResourceName]("memory")
-		_, admit := singleNUMAEvaluator{}.evaluate(split, ignoreList, []v1.ResourceList{req("cpu", "2", "memory", "8Gi")})
+		_, admit := evalPlacement(split, ignoreList, []v1.ResourceList{req("cpu", "2", "memory", "8Gi")})
 		assert.True(t, admit, "ignored memory drops out, cpu fits a single zone")
 	})
 }
@@ -120,24 +142,24 @@ func TestSingleNUMAContainerScopeSharesHeadroom(t *testing.T) {
 	node := twoZoneNode(node_info.TopologyPolicySingleNUMANode, req("cpu", "4"))
 	requests := []v1.ResourceList{req("cpu", "3"), req("cpu", "3"), req("cpu", "2")}
 
-	_, admit := singleNUMAEvaluator{}.evaluate(node, noIgnoreList, requests)
+	_, admit := evalPlacement(node, noIgnoreList, requests)
 	assert.False(t, admit)
 
 	// The first two fit (one per zone).
-	_, admit = singleNUMAEvaluator{}.evaluate(node, noIgnoreList, requests[:2])
+	_, admit = evalPlacement(node, noIgnoreList, requests[:2])
 	assert.True(t, admit)
 }
 
 func TestRestrictedAllocatableVsAvailable(t *testing.T) {
 	t.Run("reject: per-resource minimal widths disagree (6 GPU + 10 CPU)", func(t *testing.T) {
 		node := twoZoneNode(node_info.TopologyPolicyRestricted, req(gpu, "4", "cpu", "16"))
-		_, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "6", "cpu", "10")})
+		_, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "6", "cpu", "10")})
 		assert.False(t, admit, "GPU needs 2 nodes, CPU needs 1 — no common preferred mask")
 	})
 
 	t.Run("admit on the common width-2 mask (6 GPU + 24 CPU)", func(t *testing.T) {
 		node := twoZoneNode(node_info.TopologyPolicyRestricted, req(gpu, "4", "cpu", "16"))
-		allocation, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "6", "cpu", "24")})
+		allocation, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "6", "cpu", "24")})
 		assert.True(t, admit)
 		assert.Equal(t, []int{0, 1}, allocation.ZoneIndices(), "spans both NUMA zones")
 
@@ -148,13 +170,13 @@ func TestRestrictedAllocatableVsAvailable(t *testing.T) {
 
 	t.Run("reject: 4-GPU + 1-CPU footgun", func(t *testing.T) {
 		node := twoZoneNode(node_info.TopologyPolicyRestricted, req(gpu, "2", "cpu", "100"))
-		_, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "4", "cpu", "1")})
+		_, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "4", "cpu", "1")})
 		assert.False(t, admit, "GPU needs 2 nodes, CPU needs 1")
 	})
 
 	t.Run("admit on a single zone when width is 1", func(t *testing.T) {
 		node := twoZoneNode(node_info.TopologyPolicyRestricted, req(gpu, "4", "cpu", "16"))
-		allocation, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "2", "cpu", "8")})
+		allocation, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "2", "cpu", "8")})
 		assert.True(t, admit)
 		assert.Equal(t, []int{0}, allocation.ZoneIndices(), "width 1 stays on one zone")
 	})
@@ -178,7 +200,7 @@ func TestRestrictedAllocatableVsAvailable(t *testing.T) {
 				map[string]string{gpu: "3", "cpu": "46"},
 			),
 		)
-		_, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "4", "cpu", "50")})
+		_, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "4", "cpu", "50")})
 		assert.False(t, admit, "single-zone preferred by allocatable but infeasible by available → non-preferred width-2 hint → reject")
 	})
 
@@ -196,7 +218,7 @@ func TestRestrictedAllocatableVsAvailable(t *testing.T) {
 				map[string]string{gpu: "3", "cpu": "46"},
 			),
 		)
-		_, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "1", "cpu", "50")})
+		_, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "1", "cpu", "50")})
 		assert.False(t, admit, "CPU fits by allocatable (minWidth=1) but no zone has 50 CPU available → non-preferred → reject")
 	})
 }
@@ -208,14 +230,7 @@ func TestRestrictedSelectsLowestMask(t *testing.T) {
 		numaZone("node-1", map[string]string{gpu: "2"}),
 		numaZone("node-2", map[string]string{gpu: "2"}),
 	)
-	allocation, admit := restrictedEvaluator{}.evaluate(node, noIgnoreList, []v1.ResourceList{req(gpu, "4")})
+	allocation, admit := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, "4")})
 	assert.True(t, admit)
 	assert.Equal(t, []int{0, 1}, allocation.ZoneIndices(), "selects the lowest satisfying mask, not node-2")
-}
-
-func TestEvaluatorFor(t *testing.T) {
-	assert.IsType(t, singleNUMAEvaluator{}, evaluatorFor(node_info.TopologyPolicySingleNUMANode))
-	assert.IsType(t, restrictedEvaluator{}, evaluatorFor(node_info.TopologyPolicyRestricted))
-	assert.Nil(t, evaluatorFor(node_info.TopologyPolicyBestEffort))
-	assert.Nil(t, evaluatorFor(node_info.TopologyPolicyNone))
 }

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -4,21 +4,21 @@
 package numa
 
 import (
+	"errors"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
-// fitErrorMessage is the predicate rejection reason surfaced to the scheduler.
-const fitErrorMessage = "node cannot NUMA-align the pod's resources under its Topology Manager policy"
+var errNotNumaAligned = errors.New("node cannot NUMA-align the pod's resources under its Topology Manager policy")
 
 const (
 	pluginName              = "numa"
@@ -35,6 +35,10 @@ type numaPlugin struct {
 	// safer default. Set false to trust NRT Available (e.g. when the placement exporter is absent and
 	// predicted-only reconstruction is not wanted).
 	reconstructAvailable bool
+
+	// ssn is the current session, set in OnSessionOpen and cleared in OnSessionClose, so the deferred
+	// callbacks (prePredicate, allocate, deallocate) reach the cluster snapshot without capturing it.
+	ssn *framework.Session
 }
 
 func New(arguments framework.PluginArguments) framework.Plugin {
@@ -59,6 +63,7 @@ func (pp *numaPlugin) Name() string {
 }
 
 func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
+	pp.ssn = ssn
 	pp.seedPlacements(ssn)
 	if pp.reconstructAvailable {
 		pp.reconstructNodeAvailable(ssn)
@@ -67,53 +72,40 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddPredicateFn(pp.predicate)
 	ssn.AddNumaPlacementFn(pp.placement)
 	ssn.AddEventHandler(&framework.EventHandler{
-		AllocateFunc:   func(event *framework.Event) { pp.allocate(ssn, event) },
-		DeallocateFunc: func(event *framework.Event) { pp.deallocate(ssn, event) },
+		AllocateFunc:   pp.allocate,
+		DeallocateFunc: pp.deallocate,
 	})
 }
 
-// evaluate is the shared core of predicate and placement: it returns the task's expected NUMA
-// placement on the node and whether the kubelet's Topology Manager would admit it. A task the
-// plugin does not constrain (wrong policy/QoS, or no NRT) passes through as (nil, true).
-func (pp *numaPlugin) evaluate(task *pod_info.PodInfo, node *node_info.NodeInfo) (pod_info.NUMAPlacement, bool) {
-	if node == nil || !pp.shouldHandle(task, node.NumaTopology) {
-		return nil, true
-	}
-	topo := node.NumaTopology
-	eval := evaluatorFor(topo.Policy)
-	concurrent, serial := requestUnits(task, topo.Scope)
-	placement, admit := eval.evaluate(topo, pp.ignoreList, concurrent)
-	if !admit {
-		return nil, false
-	}
-	// Ordinary init containers run serially before the app containers and free their resources
-	// first, so each must be alignable on its own but is not accumulated into the placement.
-	for _, unit := range serial {
-		if _, ok := eval.evaluate(topo, pp.ignoreList, []v1.ResourceList{unit}); !ok {
-			return nil, false
+// filterAware returns the aware indices with the ignored ones removed.
+func filterAware(aware []int, ignore sets.Set[int]) []int {
+	out := make([]int, 0, len(aware))
+	for _, idx := range aware {
+		if !ignore.Has(idx) {
+			out = append(out, idx)
 		}
 	}
-	return placement, true
+	return out
 }
 
-// placement is the session NumaPlacementFn: the task's expected NUMA placement on the node. It's called
-// after the predicate, so it's expected to always return a placement - the error log is for safety.
+// placement is the session NumaPlacementFn: the task's expected NUMA placement on the node. Called
+// after the predicate, so it should always admit — the error log guards the unexpected case.
 func (pp *numaPlugin) placement(task *pod_info.PodInfo, node *node_info.NodeInfo) pod_info.NUMAPlacement {
-	placement, admit := pp.evaluate(task, node)
+	allocation, admit := pp.evaluate(task, node)
 	if !admit {
 		// FittingNode runs the predicate before the allocation path stamps the placement, so a
 		// rejection at stamp time is unexpected (the ledger changed between filter and stamp).
 		log.InfraLogger.Errorf("numa plugin: task <%s/%s> cannot be NUMA-aligned on node <%s>",
 			task.Namespace, task.Name, node.Name)
 	}
-	return placement
+	return placementFromAllocation(allocation, node.NumaTopology)
 }
 
 func (pp *numaPlugin) predicate(task *pod_info.PodInfo, _ *podgroup_info.PodGroupInfo, node *node_info.NodeInfo) error {
-	if _, admit := pp.evaluate(task, node); !admit {
-		log.InfraLogger.V(6).Infof("numa plugin: task <%s/%s> cannot be NUMA-aligned on node <%s>",
-			task.Namespace, task.Name, node.Name)
-		return common_info.NewFitError(task.Name, task.Namespace, node.Name, fitErrorMessage)
+	if !pp.allocatable(task, node) {
+		// FittingNode already logs this failure at V(6); the shared sentinel keeps the reject path
+		// allocation-free (see errNotNumaAligned).
+		return errNotNumaAligned
 	}
 	return nil
 }
@@ -122,9 +114,9 @@ func (pp *numaPlugin) predicate(task *pod_info.PodInfo, _ *podgroup_info.PodGrou
 // is decided before the statement op — stamped by the allocation path via the NumaPlacementFn, or
 // restored from the snapshot on eviction undo — so this handler only charges; it never evaluates.
 // An empty placement (non-NUMA pod, or unknown) is a no-op.
-func (pp *numaPlugin) allocate(ssn *framework.Session, event *framework.Event) {
+func (pp *numaPlugin) allocate(event *framework.Event) {
 	task := event.Task
-	node := ssn.ClusterInfo.Nodes[task.NodeName]
+	node := pp.ssn.ClusterInfo.Nodes[task.NodeName]
 	if node == nil || node.NumaTopology == nil {
 		return
 	}
@@ -132,12 +124,12 @@ func (pp *numaPlugin) allocate(ssn *framework.Session, event *framework.Event) {
 }
 
 // deallocate frees a task's NUMA placement, if it's known, from the node's numa topology resources.
-func (pp *numaPlugin) deallocate(ssn *framework.Session, event *framework.Event) {
+func (pp *numaPlugin) deallocate(event *framework.Event) {
 	task := event.Task
 	if len(task.NUMAPlacement) == 0 {
 		return
 	}
-	node := ssn.ClusterInfo.Nodes[task.NodeName]
+	node := pp.ssn.ClusterInfo.Nodes[task.NodeName]
 	if node == nil {
 		log.InfraLogger.Errorf("numa plugin: node <%s> not found in session", task.NodeName)
 		return
@@ -156,7 +148,8 @@ func numaAllocate(topo *node_info.NumaTopology, placement pod_info.NUMAPlacement
 			log.InfraLogger.Errorf("numa plugin: zone index <%d> out of range", zone.ZoneIndex)
 			continue
 		}
-		subtract(topo.Zones[zone.ZoneIndex].Available, zone.Amount)
+		delta := resource_info.NewResourceVectorFromResourceList(zone.Amount, topo.VectorMap)
+		topo.Zones[zone.ZoneIndex].Available.Sub(delta)
 	}
 }
 
@@ -166,11 +159,14 @@ func numaDeallocate(topo *node_info.NumaTopology, placement pod_info.NUMAPlaceme
 			log.InfraLogger.Errorf("numa plugin: zone index <%d> out of range", zone.ZoneIndex)
 			continue
 		}
-		add(topo.Zones[zone.ZoneIndex].Available, zone.Amount)
+		delta := resource_info.NewResourceVectorFromResourceList(zone.Amount, topo.VectorMap)
+		topo.Zones[zone.ZoneIndex].Available.Add(delta)
 	}
 }
 
-func (pp *numaPlugin) OnSessionClose(_ *framework.Session) {}
+func (pp *numaPlugin) OnSessionClose(_ *framework.Session) {
+	pp.ssn = nil
+}
 
 func parseIgnoreList(arguments framework.PluginArguments) sets.Set[v1.ResourceName] {
 	ignoreList := sets.New[v1.ResourceName]()

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -39,6 +40,17 @@ type numaPlugin struct {
 	// ssn is the current session, set in OnSessionOpen and cleared in OnSessionClose, so the deferred
 	// callbacks (prePredicate, allocate, deallocate) reach the cluster snapshot without capturing it.
 	ssn *framework.Session
+
+	// numaRequestCache caches each task's NUMA request vectors, keyed by pod ID. Rebuilt each session.
+	numaRequestCache map[common_info.PodID]*podNumaRequests
+	// ignoreIndices is ignoreList projected to shared-map indices (empty in the common case).
+	ignoreIndices sets.Set[int]
+	// effectiveAwareByNode maps a node name to its aware indices minus ignoreIndices; populated only
+	// when ignoreIndices is non-empty (otherwise the topology's AwareIndices are used directly).
+	effectiveAwareByNode map[string][]int
+	// hasModeledNodes is false when no node carries a modeled-policy topology, letting the
+	// PrePredicateFn skip all per-task precompute.
+	hasModeledNodes bool
 }
 
 func New(arguments framework.PluginArguments) framework.Plugin {
@@ -68,13 +80,45 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 	if pp.reconstructAvailable {
 		pp.reconstructNodeAvailable(ssn)
 	}
+	pp.initCaches(ssn)
 
+	ssn.AddPrePredicateFn(pp.prePredicate)
 	ssn.AddPredicateFn(pp.predicate)
 	ssn.AddNumaPlacementFn(pp.placement)
 	ssn.AddEventHandler(&framework.EventHandler{
 		AllocateFunc:   pp.allocate,
 		DeallocateFunc: pp.deallocate,
 	})
+}
+
+// initCaches (re)builds the per-session predicate fast-path state (see evaluator.go): the per-task
+// memo, the ignore indices, the per-node effective-aware indices, and hasModeledNodes.
+func (pp *numaPlugin) initCaches(ssn *framework.Session) {
+	pp.numaRequestCache = map[common_info.PodID]*podNumaRequests{}
+	pp.ignoreIndices = sets.New[int]()
+	pp.effectiveAwareByNode = nil
+	pp.hasModeledNodes = false
+
+	vectorMap := ssn.ClusterInfo.ResourceVectorMap
+	for name := range pp.ignoreList {
+		if idx := vectorMap.GetIndex(name); idx >= 0 {
+			pp.ignoreIndices.Insert(idx)
+		}
+	}
+
+	if pp.ignoreIndices.Len() > 0 {
+		pp.effectiveAwareByNode = map[string][]int{}
+	}
+	for _, node := range ssn.ClusterInfo.Nodes {
+		topo := node.NumaTopology
+		if topo == nil || !isModeledPolicy(topo.Policy) {
+			continue
+		}
+		pp.hasModeledNodes = true
+		if pp.effectiveAwareByNode != nil {
+			pp.effectiveAwareByNode[node.Name] = filterAware(topo.AwareIndices, pp.ignoreIndices)
+		}
+	}
 }
 
 // filterAware returns the aware indices with the ignored ones removed.
@@ -86,6 +130,17 @@ func filterAware(aware []int, ignore sets.Set[int]) []int {
 		}
 	}
 	return out
+}
+
+// prePredicate is the PrePredicateFn: it computes a task's NUMA requests once, before FittingNode runs
+// per node. Skipped when no modeled node exists or the task is not Guaranteed.
+func (pp *numaPlugin) prePredicate(task *pod_info.PodInfo, _ *podgroup_info.PodGroupInfo) error {
+	vectorMap := pp.ssn.ClusterInfo.ResourceVectorMap
+	if !pp.hasModeledNodes || vectorMap == nil || task.Pod == nil || task.Pod.Status.QOSClass != v1.PodQOSGuaranteed {
+		return nil // predicate builds the requests lazily against the node's (shared) map
+	}
+	pp.numaRequestsFor(task, vectorMap)
+	return nil
 }
 
 // placement is the session NumaPlacementFn: the task's expected NUMA placement on the node. Called

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -22,45 +22,45 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
 )
 
-// numaZone builds a NUMA zone with the given per-resource Available quantities.
-func numaZone(id string, available map[string]string) *node_info.NumaZone {
-	a := map[v1.ResourceName]resource.Quantity{}
+// numaZone builds a NUMA zone spec with the given per-resource Available quantities. In tests all
+// zones are at full capacity (no pre-existing allocations), so Allocatable == Available.
+func numaZone(id string, available map[string]string) node_info.NumaZoneSpec {
+	list := v1.ResourceList{}
 	for name, qty := range available {
-		a[v1.ResourceName(name)] = resource.MustParse(qty)
+		list[v1.ResourceName(name)] = resource.MustParse(qty)
 	}
-	// In tests all zones are at full capacity (no pre-existing allocations), so
-	// Allocatable == Available.
-	alloc := map[v1.ResourceName]resource.Quantity{}
-	for r, qty := range a {
-		alloc[r] = qty.DeepCopy()
-	}
-	return &node_info.NumaZone{ID: id, Available: a, Allocatable: alloc}
+	return node_info.NumaZoneSpec{ID: id, Available: list, Allocatable: list}
 }
 
-// numaTopology builds a NumaTopology directly (no NRT round-trip), computing the reported
-// resource set from the zones.
-func numaTopology(policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope, zones ...*node_info.NumaZone) *node_info.NumaTopology {
-	resources := sets.New[v1.ResourceName]()
-	for _, z := range zones {
-		for r := range z.Available {
-			resources.Insert(r)
-		}
-	}
-	return &node_info.NumaTopology{Policy: policy, Scope: scope, Zones: zones, Resources: resources}
+// numaTopology builds a NumaTopology from zone specs against a fresh seeded map.
+func numaTopology(policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope, zones ...node_info.NumaZoneSpec) *node_info.NumaTopology {
+	return nodes_fake.NewNumaTopology(policy, scope, zones...)
 }
 
-func singleNUMANodeTopology(scope node_info.TopologyManagerScope, zones ...*node_info.NumaZone) *node_info.NumaTopology {
+func singleNUMANodeTopology(scope node_info.TopologyManagerScope, zones ...node_info.NumaZoneSpec) *node_info.NumaTopology {
 	return numaTopology(node_info.TopologyPolicySingleNUMANode, scope, zones...)
+}
+
+// zoneAvail reads a zone's Available amount for a resource in the request's natural unit (cpu in
+// cores, others by count), translating from the vector's milli-cpu storage.
+func zoneAvail(topo *node_info.NumaTopology, zoneIdx int, name v1.ResourceName) int64 {
+	idx := topo.VectorMap.GetIndex(name)
+	val := topo.Zones[zoneIdx].Available.Get(idx)
+	if idx == resource_info.CPUIndex {
+		return int64(val) / 1000
+	}
+	return int64(val)
 }
 
 // wiredPlugin returns a plugin, a session whose node map holds a single node-a carrying topo,
 // and that node (the same object the plugin charges, so predicate observes the in-cycle ledger).
 func wiredPlugin(topo *node_info.NumaTopology) (*numaPlugin, *framework.Session, *node_info.NodeInfo) {
 	node := &node_info.NodeInfo{Name: "node-a", NumaTopology: topo}
-	pp := &numaPlugin{ignoreList: sets.New[v1.ResourceName]()}
 	ssn := &framework.Session{ClusterInfo: &schedapi.ClusterInfo{Nodes: map[string]*node_info.NodeInfo{"node-a": node}}}
+	pp := &numaPlugin{ignoreList: sets.New[v1.ResourceName](), ssn: ssn}
 	return pp, ssn, node
 }
 
@@ -158,8 +158,8 @@ func TestOnSessionOpenRegistersWithoutState(t *testing.T) {
 	plugin := New(framework.PluginArguments{}).(*numaPlugin)
 	ssn := &framework.Session{ClusterInfo: &schedapi.ClusterInfo{Nodes: nodes}}
 
-	// The plugin is stateless across sessions: OnSessionOpen only registers callbacks (it holds no
-	// node map), so open/close are safe no-ops on plugin state.
+	// OnSessionOpen registers callbacks and records the session; OnSessionClose clears it. No state
+	// leaks across sessions, so open/close are safe.
 	plugin.OnSessionOpen(ssn)
 	plugin.OnSessionClose(ssn)
 
@@ -192,41 +192,40 @@ func gPod(uid string, requests map[string]string) *pod_info.PodInfo {
 	}
 }
 
-func TestRequestUnits(t *testing.T) {
+func TestBuildNumaRequests(t *testing.T) {
 	always := v1.ContainerRestartPolicyAlways
 	cpu := func(q string) v1.ResourceRequirements {
 		return v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse(q)}}
 	}
-	task := &pod_info.PodInfo{Pod: &v1.Pod{Spec: v1.PodSpec{
+	pod := &v1.Pod{Spec: v1.PodSpec{
 		InitContainers: []v1.Container{
-			{Resources: cpu("10")},                        // ordinary init: not a steady-state unit
-			{Resources: cpu("1"), RestartPolicy: &always}, // native sidecar: a steady-state unit
+			{Resources: cpu("10")},                        // ordinary init: not a steady-state request
+			{Resources: cpu("1"), RestartPolicy: &always}, // native sidecar: a steady-state request
 		},
 		Containers: []v1.Container{{Resources: cpu("2")}, {Resources: cpu("2")}},
-	}}}
+	}}
+	reqs := buildNumaRequests(pod, resource_info.NewResourceVectorMap())
+	cores := func(v resource_info.ResourceVector) int64 { return int64(v.Get(resource_info.CPUIndex)) / 1000 }
 
-	t.Run("pod scope aggregates into one unit", func(t *testing.T) {
-		concurrent, serial := requestUnits(task, node_info.TopologyScopePod)
+	t.Run("pod scope aggregates into one request", func(t *testing.T) {
+		concurrent, serial := reqs.forScope(node_info.TopologyScopePod)
 		assert.Len(t, concurrent, 1)
 		assert.Empty(t, serial, "pod scope folds init containers into the effective pod request")
 		// PodRequests = max(init peak 10, sidecar+regulars 1+2+2=5) = 10.
-		got := concurrent[0]["cpu"]
-		assert.Equal(t, int64(10), got.Value())
+		assert.Equal(t, int64(10), cores(concurrent[0]))
 	})
 
-	t.Run("container scope splits concurrent and serial units", func(t *testing.T) {
-		concurrent, serial := requestUnits(task, node_info.TopologyScopeContainer)
+	t.Run("container scope splits concurrent and serial requests", func(t *testing.T) {
+		concurrent, serial := reqs.forScope(node_info.TopologyScopeContainer)
 		assert.Len(t, concurrent, 3, "native sidecar + two regular containers")
 		var total int64
 		for _, u := range concurrent {
-			q := u["cpu"]
-			total += q.Value()
+			total += cores(u)
 		}
 		assert.Equal(t, int64(5), total, "1 (sidecar) + 2 + 2")
 
-		assert.Len(t, serial, 1, "the ordinary init container is a serial unit")
-		initCPU := serial[0]["cpu"]
-		assert.Equal(t, int64(10), initCPU.Value())
+		assert.Len(t, serial, 1, "the ordinary init container is a serial request")
+		assert.Equal(t, int64(10), cores(serial[0]))
 	})
 }
 
@@ -288,21 +287,21 @@ func TestPredicate(t *testing.T) {
 }
 
 func TestInCycleReservation(t *testing.T) {
-	pp, ssn, node := wiredPlugin(singleNUMANodeTopology(node_info.TopologyScopePod,
+	pp, _, node := wiredPlugin(singleNUMANodeTopology(node_info.TopologyScopePod,
 		numaZone("node-0", map[string]string{"cpu": "4"}),
 	))
-	avail := func() int64 { q := node.NumaTopology.Zones[0].Available["cpu"]; return q.Value() }
+	avail := func() int64 { return zoneAvail(node.NumaTopology, 0, "cpu") }
 
 	first := gPod("first", map[string]string{"cpu": "3"})
 	first.NUMAPlacement = pp.placement(first, node) // stamped before the op, as the allocation path does
-	pp.allocate(ssn, &framework.Event{Task: first})
+	pp.allocate(&framework.Event{Task: first})
 	assert.Equal(t, int64(1), avail(), "zone charged by the first pod")
 	assert.Equal(t, []int{0}, first.NUMAPlacement.ZoneIndices(), "placement recorded on the task (zone 0)")
 
 	second := gPod("second", map[string]string{"cpu": "3"})
 	assert.Error(t, pp.predicate(second, nil, node), "only 1 cpu left in the single zone")
 
-	pp.deallocate(ssn, &framework.Event{Task: first})
+	pp.deallocate(&framework.Event{Task: first})
 	assert.Equal(t, int64(4), avail(), "zone credited back exactly on rollback")
 	assert.NoError(t, pp.predicate(second, nil, node), "zone freed, second pod now fits")
 }
@@ -311,7 +310,7 @@ func TestAllocateReusesExistingPlacement(t *testing.T) {
 	// A task arrives with a placement already set (restored on unevict, or seeded from
 	// the annotation). allocate must charge THAT placement, not re-evaluate — a fresh
 	// evaluate would pick the lowest zone (node-0), but the placement says node-1.
-	pp, ssn, node := wiredPlugin(singleNUMANodeTopology(node_info.TopologyScopePod,
+	pp, _, node := wiredPlugin(singleNUMANodeTopology(node_info.TopologyScopePod,
 		numaZone("node-0", map[string]string{"cpu": "4"}),
 		numaZone("node-1", map[string]string{"cpu": "4"}),
 	))
@@ -320,15 +319,15 @@ func TestAllocateReusesExistingPlacement(t *testing.T) {
 		{ZoneIndex: 1, Amount: v1.ResourceList{"cpu": resource.MustParse("3")}},
 	}
 
-	pp.allocate(ssn, &framework.Event{Task: task})
-	n0, n1 := node.NumaTopology.Zones[0].Available["cpu"], node.NumaTopology.Zones[1].Available["cpu"]
-	assert.Equal(t, int64(4), n0.Value(), "node-0 untouched (no re-evaluation)")
-	assert.Equal(t, int64(1), n1.Value(), "the existing placement on zone 1 is charged")
+	pp.allocate(&framework.Event{Task: task})
+	n0, n1 := zoneAvail(node.NumaTopology, 0, "cpu"), zoneAvail(node.NumaTopology, 1, "cpu")
+	assert.Equal(t, int64(4), n0, "node-0 untouched (no re-evaluation)")
+	assert.Equal(t, int64(1), n1, "the existing placement on zone 1 is charged")
 	assert.Equal(t, []int{1}, task.NUMAPlacement.ZoneIndices(), "placement unchanged")
 
-	pp.deallocate(ssn, &framework.Event{Task: task})
-	n1 = node.NumaTopology.Zones[1].Available["cpu"]
-	assert.Equal(t, int64(4), n1.Value(), "credited back to node-1")
+	pp.deallocate(&framework.Event{Task: task})
+	n1 = zoneAvail(node.NumaTopology, 1, "cpu")
+	assert.Equal(t, int64(4), n1, "credited back to node-1")
 }
 
 func observedZone(zone, cpu string) schedulingv1alpha2.NUMAZonePlacement {

--- a/pkg/scheduler/plugins/numa/reclaim_repipeline_test.go
+++ b/pkg/scheduler/plugins/numa/reclaim_repipeline_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
@@ -29,11 +28,11 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
 
-func cpuZone(id, allocatable, available string) *node_info.NumaZone {
-	return &node_info.NumaZone{
+func cpuZone(id, allocatable, available string) node_info.NumaZoneSpec {
+	return node_info.NumaZoneSpec{
 		ID:          id,
-		Allocatable: map[v1.ResourceName]resource.Quantity{"cpu": resource.MustParse(allocatable)},
-		Available:   map[v1.ResourceName]resource.Quantity{"cpu": resource.MustParse(available)},
+		Allocatable: v1.ResourceList{"cpu": resource.MustParse(allocatable)},
+		Available:   v1.ResourceList{"cpu": resource.MustParse(available)},
 	}
 }
 
@@ -89,12 +88,10 @@ func TestReclaimRepipelineDoesNotGoNegative(t *testing.T) {
 		tasksToNodeMap, nil, vectorMap)
 	node := nodesInfoMap["node0"]
 
-	node.NumaTopology = &node_info.NumaTopology{
-		Policy:    node_info.TopologyPolicySingleNUMANode,
-		Scope:     node_info.TopologyScopePod,
-		Zones:     []*node_info.NumaZone{cpuZone("node-0", "4", "1"), cpuZone("node-1", "4", "1")},
-		Resources: sets.New[v1.ResourceName]("cpu"),
-	}
+	node.NumaTopology = nodes_fake.NewNumaTopologyWithMap(
+		node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod, vectorMap,
+		cpuZone("node-0", "4", "1"), cpuZone("node-1", "4", "1"),
+	)
 
 	victim0 := singleTask(jobsInfoMap["victim0"])
 	victim1 := singleTask(jobsInfoMap["victim1"])
@@ -114,7 +111,8 @@ func TestReclaimRepipelineDoesNotGoNegative(t *testing.T) {
 	}
 	numa.New(framework.PluginArguments{}).OnSessionOpen(ssn) // registers the charge/credit EventHandler
 
-	zone := func(i int) int64 { q := node.NumaTopology.Zones[i].Available["cpu"]; return q.Value() }
+	cpuIdx := vectorMap.GetIndex("cpu")
+	zone := func(i int) int64 { return int64(node.NumaTopology.Zones[i].Available.Get(cpuIdx)) / 1000 }
 	stmt := ssn.Statement()
 
 	// pipeline mirrors allocateTaskToNode: the allocation path stamps the task's NUMA placement for

--- a/pkg/scheduler/plugins/numa/reconstruct.go
+++ b/pkg/scheduler/plugins/numa/reconstruct.go
@@ -4,9 +4,6 @@
 package numa
 
 import (
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
@@ -41,10 +38,6 @@ func (pp *numaPlugin) reconstructNodeAvailable(ssn *framework.Session) {
 // the starting point from which reconstructNodeAvailable subtracts pod placements.
 func resetAvailableToAllocatable(topo *node_info.NumaTopology) {
 	for _, zone := range topo.Zones {
-		available := make(map[v1.ResourceName]resource.Quantity, len(zone.Allocatable))
-		for r, qty := range zone.Allocatable {
-			available[r] = qty.DeepCopy()
-		}
-		zone.Available = available
+		zone.Available = zone.Allocatable.Clone()
 	}
 }

--- a/pkg/scheduler/plugins/numa/reconstruct_test.go
+++ b/pkg/scheduler/plugins/numa/reconstruct_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 )
 
-func cpuMap(q string) map[v1.ResourceName]resource.Quantity {
-	return map[v1.ResourceName]resource.Quantity{"cpu": resource.MustParse(q)}
+func cpuList(q string) v1.ResourceList {
+	return v1.ResourceList{"cpu": resource.MustParse(q)}
 }
 
 func TestNewReconstructAvailableFlag(t *testing.T) {
@@ -34,14 +34,11 @@ func TestNewReconstructAvailableFlag(t *testing.T) {
 func TestReconstructNodeAvailable(t *testing.T) {
 	// Two zones, Allocatable 4 CPU each. Available is deliberately stale (99) to prove reconstruction
 	// discards the NRT-reported value and rebuilds from Allocatable.
-	topo := &node_info.NumaTopology{
-		Policy: node_info.TopologyPolicySingleNUMANode,
-		Scope:  node_info.TopologyScopePod,
-		Zones: []*node_info.NumaZone{
-			{ID: "node-0", Allocatable: cpuMap("4"), Available: cpuMap("99")},
-			{ID: "node-1", Allocatable: cpuMap("4"), Available: cpuMap("99")},
-		},
-	}
+	topo := numaTopology(
+		node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod,
+		node_info.NumaZoneSpec{ID: "node-0", Allocatable: cpuList("4"), Available: cpuList("99")},
+		node_info.NumaZoneSpec{ID: "node-1", Allocatable: cpuList("4"), Available: cpuList("99")},
+	)
 
 	// Bound pod observed on node-1 (cpu 2) → subtracted.
 	bound := gPod("bound", map[string]string{"cpu": "2"})
@@ -76,8 +73,9 @@ func TestReconstructNodeAvailable(t *testing.T) {
 
 	pp.reconstructNodeAvailable(ssn)
 
-	z0 := topo.Zones[0].Available["cpu"]
-	z1 := topo.Zones[1].Available["cpu"]
-	assert.Equal(t, int64(2), z0.Value(), "node-0: Allocatable 4 minus pipelined 2 (pending excluded, stale 99 discarded)")
-	assert.Equal(t, int64(2), z1.Value(), "node-1: Allocatable 4 minus the running pod's observed 2")
+	cpuIdx := topo.VectorMap.GetIndex("cpu")
+	z0 := int64(topo.Zones[0].Available.Get(cpuIdx)) / 1000
+	z1 := int64(topo.Zones[1].Available.Get(cpuIdx)) / 1000
+	assert.Equal(t, int64(2), z0, "node-0: Allocatable 4 minus pipelined 2 (pending excluded, stale 99 discarded)")
+	assert.Equal(t, int64(2), z1, "node-1: Allocatable 4 minus the running pod's observed 2")
 }

--- a/pkg/scheduler/plugins/numa/requests.go
+++ b/pkg/scheduler/plugins/numa/requests.go
@@ -8,46 +8,45 @@ import (
 	resourcehelper "k8s.io/component-helpers/resource"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
-// requestUnits decomposes a task into the alignment units the kubelet Topology Manager hints for,
-// under the node's scope. It returns the concurrently-running units, which are charged against the
-// per-zone ledger, and the serial init-container units, which must each be alignable on their own
-// but are not accumulated (an ordinary init container completes and frees its resources before the
-// app containers run). The evaluator intersects each unit with the node's topology-aware resources,
-// so non-aligned resources drop out.
-func requestUnits(task *pod_info.PodInfo, scope node_info.TopologyManagerScope) (concurrent, serial []v1.ResourceList) {
-	if scope == node_info.TopologyScopePod {
-		return []v1.ResourceList{toAmounts(resourcehelper.PodRequests(task.Pod, resourcehelper.PodResourcesOptions{}))}, nil
-	}
-	return containerUnits(task.Pod)
+// podNumaRequests is a task decomposed into the alignment units the kubelet Topology Manager hints
+// for, as vectors. Pod scope: the whole pod is one request. Container scope: concurrent units (app
+// containers + native sidecars, charged against a shared per-zone ledger) and serial units (ordinary
+// init containers, each alignable on its own but never accumulated, since they free their resources
+// before the app containers run).
+type podNumaRequests struct {
+	podScope   []resource_info.ResourceVector
+	concurrent []resource_info.ResourceVector
+	serial     []resource_info.ResourceVector
 }
 
-// containerUnits splits a pod into container-scope alignment units. Native sidecars (restartable
-// init containers) keep running alongside the app containers, so they are concurrent and
-// accumulated. An ordinary init container runs serially before the app containers and frees its
-// resources first, so it is returned as a serial unit: checked for alignability on its own, never
-// accumulated into the concurrent set.
-func containerUnits(pod *v1.Pod) (concurrent, serial []v1.ResourceList) {
+func (r *podNumaRequests) forScope(scope node_info.TopologyManagerScope) (concurrent, serial []resource_info.ResourceVector) {
+	if scope == node_info.TopologyScopePod {
+		return r.podScope, nil
+	}
+	return r.concurrent, r.serial
+}
+
+func buildNumaRequests(pod *v1.Pod, vectorMap *resource_info.ResourceVectorMap) *podNumaRequests {
+	podReq := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+	reqs := &podNumaRequests{
+		podScope: []resource_info.ResourceVector{resource_info.NewResourceVectorFromResourceList(podReq, vectorMap)},
+	}
+
 	for i := range pod.Spec.InitContainers {
 		c := &pod.Spec.InitContainers[i]
+		vec := resource_info.NewResourceVectorFromResourceList(c.Resources.Requests, vectorMap)
 		if c.RestartPolicy != nil && *c.RestartPolicy == v1.ContainerRestartPolicyAlways {
-			concurrent = append(concurrent, toAmounts(c.Resources.Requests))
+			reqs.concurrent = append(reqs.concurrent, vec)
 		} else {
-			serial = append(serial, toAmounts(c.Resources.Requests))
+			reqs.serial = append(reqs.serial, vec)
 		}
 	}
 	for i := range pod.Spec.Containers {
-		concurrent = append(concurrent, toAmounts(pod.Spec.Containers[i].Resources.Requests))
+		reqs.concurrent = append(reqs.concurrent,
+			resource_info.NewResourceVectorFromResourceList(pod.Spec.Containers[i].Resources.Requests, vectorMap))
 	}
-	return concurrent, serial
-}
-
-func toAmounts(list v1.ResourceList) v1.ResourceList {
-	amounts := make(v1.ResourceList, len(list))
-	for name, qty := range list {
-		amounts[name] = qty.DeepCopy()
-	}
-	return amounts
+	return reqs
 }

--- a/pkg/scheduler/plugins/numa/requests.go
+++ b/pkg/scheduler/plugins/numa/requests.go
@@ -7,7 +7,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourcehelper "k8s.io/component-helpers/resource"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
@@ -27,6 +29,20 @@ func (r *podNumaRequests) forScope(scope node_info.TopologyManagerScope) (concur
 		return r.podScope, nil
 	}
 	return r.concurrent, r.serial
+}
+
+// numaRequestsFor builds and caches the task's NUMA requests on first use. Not safe for concurrent
+// use: the predicate path is assumed serial.
+func (pp *numaPlugin) numaRequestsFor(task *pod_info.PodInfo, vectorMap *resource_info.ResourceVectorMap) *podNumaRequests {
+	if pp.numaRequestCache == nil {
+		pp.numaRequestCache = map[common_info.PodID]*podNumaRequests{}
+	}
+	if reqs, ok := pp.numaRequestCache[task.UID]; ok {
+		return reqs
+	}
+	reqs := buildNumaRequests(task.Pod, vectorMap)
+	pp.numaRequestCache[task.UID] = reqs
+	return reqs
 }
 
 func buildNumaRequests(pod *v1.Pod, vectorMap *resource_info.ResourceVectorMap) *podNumaRequests {

--- a/pkg/scheduler/plugins/numa/restricted_evaluator_test.go
+++ b/pkg/scheduler/plugins/numa/restricted_evaluator_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+)
+
+// initReq is one init container in a test pod: its request, and whether it is a native sidecar
+// (restartable, so it runs alongside the app containers) or an ordinary init container.
+type initReq struct {
+	req         v1.ResourceList
+	restartable bool
+}
+
+// restrictedPod builds a Guaranteed pod with the given app-container and init-container requests.
+// The unique name doubles as the pod UID so the per-task request cache does not alias across rows.
+func restrictedPod(name string, apps []v1.ResourceList, inits ...initReq) *pod_info.PodInfo {
+	always := v1.ContainerRestartPolicyAlways
+	spec := v1.PodSpec{}
+	for _, in := range inits {
+		c := v1.Container{Resources: v1.ResourceRequirements{Requests: in.req}}
+		if in.restartable {
+			c.RestartPolicy = &always
+		}
+		spec.InitContainers = append(spec.InitContainers, c)
+	}
+	for _, a := range apps {
+		spec.Containers = append(spec.Containers, v1.Container{Resources: v1.ResourceRequirements{Requests: a}})
+	}
+	return &pod_info.PodInfo{
+		UID:  common_info.PodID(name),
+		Name: name,
+		Pod:  &v1.Pod{Status: v1.PodStatus{QOSClass: v1.PodQOSGuaranteed}, Spec: spec},
+	}
+}
+
+// assertPlacement checks the placement's zones and exact per-zone amounts against want (an empty want
+// asserts an empty placement).
+func assertPlacement(t *testing.T, placement pod_info.NUMAPlacement, want map[int]v1.ResourceList) {
+	t.Helper()
+
+	wantZones := make([]int, 0, len(want))
+	for z := range want {
+		wantZones = append(wantZones, z)
+	}
+	sort.Ints(wantZones)
+	assert.Equal(t, wantZones, placement.ZoneIndices(), "placement zones")
+
+	for z, amounts := range want {
+		got := amountAt(placement, z)
+		assert.Lenf(t, got, len(amounts), "resource count on zone %d", z)
+		for name, wantQty := range amounts {
+			gotQty := got[name]
+			assert.Equalf(t, wantQty.Value(), gotQty.Value(), "zone %d resource %s", z, name)
+		}
+	}
+}
+
+// TestRestrictedScopeAndInit exercises the request decomposition feeding the restricted evaluator:
+// pod vs container scope, ordinary init containers (serial, checked alone) and native sidecars
+// (concurrent, accumulated). Two symmetric NUMA zones, 4 GPU / 8 CPU / 16Gi each.
+func TestRestrictedScopeAndInit(t *testing.T) {
+	base := []node_info.NumaZoneSpec{
+		numaZone("node-0", map[string]string{gpu: "4", "cpu": "8", "memory": "16Gi"}),
+		numaZone("node-1", map[string]string{gpu: "4", "cpu": "8", "memory": "16Gi"}),
+	}
+
+	tests := []struct {
+		name  string
+		scope node_info.TopologyManagerScope
+		apps  []v1.ResourceList
+		inits []initReq
+		admit bool
+		want  map[int]v1.ResourceList
+	}{
+		{
+			name:  "container scope: second container spills to the second zone",
+			scope: node_info.TopologyScopeContainer,
+			apps:  []v1.ResourceList{req(gpu, "3"), req(gpu, "3")},
+			admit: true,
+			want:  map[int]v1.ResourceList{0: req(gpu, "3"), 1: req(gpu, "3")},
+		},
+		{
+			name:  "pod scope: the same pod aggregates into a width-2 mask",
+			scope: node_info.TopologyScopePod,
+			apps:  []v1.ResourceList{req(gpu, "3"), req(gpu, "3")},
+			admit: true,
+			want:  map[int]v1.ResourceList{0: req(gpu, "4"), 1: req(gpu, "2")},
+		},
+		{
+			name:  "container scope: per-container widths agree, admits across zones",
+			scope: node_info.TopologyScopeContainer,
+			apps:  []v1.ResourceList{req(gpu, "3", "memory", "8Gi"), req(gpu, "3", "memory", "8Gi")},
+			admit: true,
+			want: map[int]v1.ResourceList{
+				0: req(gpu, "3", "memory", "8Gi"),
+				1: req(gpu, "3", "memory", "8Gi"),
+			},
+		},
+		{
+			name:  "pod scope: the same pod rejects on aggregate width disagreement",
+			scope: node_info.TopologyScopePod,
+			apps:  []v1.ResourceList{req(gpu, "3", "memory", "8Gi"), req(gpu, "3", "memory", "8Gi")},
+			admit: false, // pod request 6 GPU (width 2) + 16Gi (width 1) → no common preferred width
+		},
+		{
+			name:  "container scope: ordinary init is checked alone, not accumulated",
+			scope: node_info.TopologyScopeContainer,
+			inits: []initReq{{req: req(gpu, "4")}},
+			apps:  []v1.ResourceList{req(gpu, "4")},
+			admit: true,
+			want:  map[int]v1.ResourceList{0: req(gpu, "4")}, // app reuses zone 0; the init is not in the placement
+		},
+		{
+			name:  "container scope: an init larger than any mask rejects the pod",
+			scope: node_info.TopologyScopeContainer,
+			inits: []initReq{{req: req(gpu, "9")}},
+			apps:  []v1.ResourceList{req(gpu, "1")},
+			admit: false,
+		},
+		{
+			name:  "container scope: a native sidecar is accumulated with the app container",
+			scope: node_info.TopologyScopeContainer,
+			inits: []initReq{{req: req(gpu, "3"), restartable: true}},
+			apps:  []v1.ResourceList{req(gpu, "3")},
+			admit: true,
+			want:  map[int]v1.ResourceList{0: req(gpu, "3"), 1: req(gpu, "3")}, // sidecar on 0, app pushed to 1
+		},
+		{
+			name:  "pod scope: the request uses the init peak",
+			scope: node_info.TopologyScopePod,
+			inits: []initReq{{req: req(gpu, "8")}},
+			apps:  []v1.ResourceList{req(gpu, "2")},
+			admit: true,
+			want:  map[int]v1.ResourceList{0: req(gpu, "4"), 1: req(gpu, "4")}, // max(init 8, app 2) = 8 → width 2
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			topo := numaTopology(node_info.TopologyPolicyRestricted, tc.scope, base...)
+			pp, _, node := wiredPlugin(topo)
+
+			alloc, admit := pp.evaluate(restrictedPod(tc.name, tc.apps, tc.inits...), node)
+			assert.Equal(t, tc.admit, admit)
+			if tc.admit {
+				assertPlacement(t, placementFromAllocation(alloc, node.NumaTopology), tc.want)
+			}
+		})
+	}
+}
+
+// TestRestrictedMaskSelection exercises the evaluator's mask choice when the preferred width (from
+// Allocatable) and feasibility (from Available) diverge: masks that exclude the first zone, memory
+// participating in the width merge, and a request on a resource the node does not report per zone.
+func TestRestrictedMaskSelection(t *testing.T) {
+	tests := []struct {
+		name  string
+		zones []node_info.NumaZoneSpec
+		req   v1.ResourceList
+		admit bool
+		want  map[int]v1.ResourceList
+	}{
+		{
+			name: "width-1 mask lands on the second zone",
+			zones: []node_info.NumaZoneSpec{
+				partialZone("node-0", map[string]string{gpu: "4"}, map[string]string{gpu: "1"}),
+				partialZone("node-1", map[string]string{gpu: "4"}, map[string]string{gpu: "4"}),
+			},
+			req:   req(gpu, "3"),
+			admit: true,
+			want:  map[int]v1.ResourceList{1: req(gpu, "3")}, // preferred width 1, only zone 1 is feasible
+		},
+		{
+			name: "width-2 mask excludes the first zone",
+			zones: []node_info.NumaZoneSpec{
+				partialZone("node-0", map[string]string{gpu: "4"}, map[string]string{gpu: "1"}),
+				partialZone("node-1", map[string]string{gpu: "4"}, map[string]string{gpu: "4"}),
+				partialZone("node-2", map[string]string{gpu: "4"}, map[string]string{gpu: "4"}),
+			},
+			req:   req(gpu, "6"),
+			admit: true,
+			want:  map[int]v1.ResourceList{1: req(gpu, "4"), 2: req(gpu, "2")}, // {0,1} and {0,2} infeasible → {1,2}
+		},
+		{
+			name: "memory-driven width disagreement rejects",
+			zones: []node_info.NumaZoneSpec{
+				numaZone("node-0", map[string]string{gpu: "4", "cpu": "8", "memory": "16Gi"}),
+				numaZone("node-1", map[string]string{gpu: "4", "cpu": "8", "memory": "16Gi"}),
+			},
+			req:   req(gpu, "2", "memory", "20Gi"),
+			admit: false, // GPU width 1, memory 20Gi width 2 → no common preferred width
+		},
+		{
+			name: "a non-reported resource is trivially aligned",
+			zones: []node_info.NumaZoneSpec{
+				numaZone("node-0", map[string]string{gpu: "4"}),
+				numaZone("node-1", map[string]string{gpu: "4"}),
+			},
+			req:   req("cpu", "2"),
+			admit: true,
+			want:  map[int]v1.ResourceList{}, // cpu is not zone-reported → no aware request → empty placement
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			topo := numaTopology(node_info.TopologyPolicyRestricted, node_info.TopologyScopeContainer, tc.zones...)
+			pp, _, node := wiredPlugin(topo)
+
+			alloc, admit := pp.evaluate(restrictedPod(tc.name, []v1.ResourceList{tc.req}), node)
+			assert.Equal(t, tc.admit, admit)
+			if tc.admit {
+				assertPlacement(t, placementFromAllocation(alloc, node.NumaTopology), tc.want)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/numa/restricted_evaluator_test.go
+++ b/pkg/scheduler/plugins/numa/restricted_evaluator_test.go
@@ -61,7 +61,7 @@ func assertPlacement(t *testing.T, placement pod_info.NUMAPlacement, want map[in
 		assert.Lenf(t, got, len(amounts), "resource count on zone %d", z)
 		for name, wantQty := range amounts {
 			gotQty := got[name]
-			assert.Equalf(t, wantQty.Value(), gotQty.Value(), "zone %d resource %s", z, name)
+			assert.Equalf(t, 0, gotQty.Cmp(wantQty), "zone %d resource %s", z, name)
 		}
 	}
 }

--- a/pkg/scheduler/test_utils/nodes_fake/nodes.go
+++ b/pkg/scheduler/test_utils/nodes_fake/nodes.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 
+	nrtv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -249,37 +250,102 @@ func toSorted(tasks pod_info.PodsMap) []*pod_info.PodInfo {
 	return sortedTasks
 }
 
-// NewNumaZone builds a NUMA zone whose Allocatable equals its Available (no in-flight usage).
+// NewNumaZone builds a NUMA zone spec whose Allocatable equals its Available (no in-flight usage).
 // Amounts are resource-name to quantity-string, e.g. {"cpu": "4", "memory": "16Gi"}.
-func NewNumaZone(id string, available map[v1.ResourceName]string) *node_info.NumaZone {
+func NewNumaZone(id string, available map[v1.ResourceName]string) node_info.NumaZoneSpec {
 	return NewNumaZoneWithAllocatable(id, available, available)
 }
 
-// NewNumaZoneWithAllocatable builds a NUMA zone with distinct static capacity (allocatable) and
-// current headroom (available) — used to model zones already partly consumed by running pods.
-func NewNumaZoneWithAllocatable(id string, allocatable, available map[v1.ResourceName]string) *node_info.NumaZone {
-	return &node_info.NumaZone{
+// NewNumaZoneWithAllocatable builds a NUMA zone spec with distinct static capacity (allocatable)
+// and current headroom (available) — used to model zones already partly consumed by running pods.
+func NewNumaZoneWithAllocatable(id string, allocatable, available map[v1.ResourceName]string) node_info.NumaZoneSpec {
+	return node_info.NumaZoneSpec{
 		ID:          id,
 		Allocatable: parseQuantities(allocatable),
 		Available:   parseQuantities(available),
 	}
 }
 
-// NewNumaTopology builds a NumaTopology, deriving the per-zone Resources set from the zones.
+// NewNumaTopology builds a NumaTopology from zone specs against a fresh resource map seeded with the
+// zones' resources, mirroring production where the cluster map is populated from node resources
+// before topologies are built. Goes through the real NRT path (BuildNumaTopology).
 func NewNumaTopology(
-	policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope, zones ...*node_info.NumaZone,
+	policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope, zones ...node_info.NumaZoneSpec,
 ) *node_info.NumaTopology {
-	resources := sets.New[v1.ResourceName]()
+	vectorMap := resource_info.NewResourceVectorMap()
 	for _, zone := range zones {
-		for name := range zone.Available {
-			resources.Insert(name)
-		}
+		vectorMap.AddResourceList(zone.Allocatable)
+		vectorMap.AddResourceList(zone.Available)
 	}
-	return &node_info.NumaTopology{Policy: policy, Scope: scope, Zones: zones, Resources: resources}
+	return NewNumaTopologyWithMap(policy, scope, vectorMap, zones...)
 }
 
-func parseQuantities(amounts map[v1.ResourceName]string) map[v1.ResourceName]resource.Quantity {
-	out := make(map[v1.ResourceName]resource.Quantity, len(amounts))
+// NewNumaTopologyWithMap builds a NumaTopology against a caller-provided resource map, for tests
+// that index tasks and zones through one shared map. Zone-reported resources absent from the map
+// are ignored, matching production BuildNumaTopology.
+func NewNumaTopologyWithMap(
+	policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope,
+	vectorMap *resource_info.ResourceVectorMap, zones ...node_info.NumaZoneSpec,
+) *node_info.NumaTopology {
+	return node_info.BuildNumaTopology(numaTopologyNRT(policy, scope, zones), vectorMap)
+}
+
+// numaTopologyNRT renders zone specs as the NodeResourceTopology object an exporter would publish,
+// so tests exercise the same parsing path as production. Policy/scope map to the canonical kubelet
+// attribute strings; zone type "Node" is the only level BuildNumaTopology models.
+func numaTopologyNRT(
+	policy node_info.TopologyManagerPolicy, scope node_info.TopologyManagerScope, zones []node_info.NumaZoneSpec,
+) *nrtv1alpha2.NodeResourceTopology {
+	nrtZones := make(nrtv1alpha2.ZoneList, len(zones))
+	for i, zone := range zones {
+		names := sets.New[v1.ResourceName]()
+		for name := range zone.Allocatable {
+			names.Insert(name)
+		}
+		for name := range zone.Available {
+			names.Insert(name)
+		}
+		resources := make(nrtv1alpha2.ResourceInfoList, 0, len(names))
+		for name := range names {
+			resources = append(resources, nrtv1alpha2.ResourceInfo{
+				Name:        string(name),
+				Allocatable: zone.Allocatable[name],
+				Available:   zone.Available[name],
+			})
+		}
+		nrtZones[i] = nrtv1alpha2.Zone{Name: zone.ID, Type: "Node", Resources: resources}
+	}
+	return &nrtv1alpha2.NodeResourceTopology{
+		Attributes: nrtv1alpha2.AttributeList{
+			{Name: "topologyManagerPolicy", Value: numaPolicyAttr(policy)},
+			{Name: "topologyManagerScope", Value: numaScopeAttr(scope)},
+		},
+		Zones: nrtZones,
+	}
+}
+
+func numaPolicyAttr(policy node_info.TopologyManagerPolicy) string {
+	switch policy {
+	case node_info.TopologyPolicySingleNUMANode:
+		return "single-numa-node"
+	case node_info.TopologyPolicyRestricted:
+		return "restricted"
+	case node_info.TopologyPolicyBestEffort:
+		return "best-effort"
+	default:
+		return "none"
+	}
+}
+
+func numaScopeAttr(scope node_info.TopologyManagerScope) string {
+	if scope == node_info.TopologyScopePod {
+		return "pod"
+	}
+	return "container"
+}
+
+func parseQuantities(amounts map[v1.ResourceName]string) v1.ResourceList {
+	out := make(v1.ResourceList, len(amounts))
 	for name, qty := range amounts {
 		out[name] = resource.MustParse(qty)
 	}

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -361,11 +361,12 @@ func matchNUMAZonesAvailable(
 			continue
 		}
 		zone := ssnNode.NumaTopology.Zones[zoneIndex]
+		vectorMap := ssnNode.NumaTopology.VectorMap
 		for name, want := range resources {
-			expectedQty := resource.MustParse(want)
-			actualQty := zone.Available[name]
-			if actualQty.Cmp(expectedQty) != 0 {
-				t.Errorf("Test number: %d, name: %v, has failed. Node %v zone %d resource %v: actual Available %v, was expecting %v", testNumber, testName, nodeName, zoneIndex, name, actualQty.String(), want)
+			expected := resource_info.NewResourceVectorFromResourceList(v1.ResourceList{name: resource.MustParse(want)}, vectorMap)
+			idx := vectorMap.GetIndex(name)
+			if zone.Available.Get(idx) != expected.Get(idx) {
+				t.Errorf("Test number: %d, name: %v, has failed. Node %v zone %d resource %v: actual Available %v, was expecting %v", testNumber, testName, nodeName, zoneIndex, name, zone.Available.Get(idx), want)
 			}
 		}
 	}

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -365,6 +365,10 @@ func matchNUMAZonesAvailable(
 		for name, want := range resources {
 			expected := resource_info.NewResourceVectorFromResourceList(v1.ResourceList{name: resource.MustParse(want)}, vectorMap)
 			idx := vectorMap.GetIndex(name)
+			if idx < 0 {
+				t.Errorf("Test number: %d, name: %v, has failed. Node %v zone %d resource %v missing from vector map", testNumber, testName, nodeName, zoneIndex, name)
+				continue
+			}
 			if zone.Available.Get(idx) != expected.Get(idx) {
 				t.Errorf("Test number: %d, name: %v, has failed. Node %v zone %d resource %v: actual Available %v, was expecting %v", testNumber, testName, nodeName, zoneIndex, name, zone.Available.Get(idx), want)
 			}


### PR DESCRIPTION
This PR improves the NUMA plugin's performance by
- Converting the NUMA resource representation to ResourceVectors
- Minimizing memory allocations

Review could be easier if done commit - by - commit:

1. **vectorize NUMA zone accounting and unify the evaluator**
  - Change the resource representation to vectors
  - Unify the NUMA evaluator and minimize it's memory allocation
2. **precompute pods' resource requests** — precompute each task's request vectors, "aware indices" (NUMA-relevant resources' indices on the resource vectors, per node)
3. **unit tests for the restricted evaluator** — pod vs container scope, init vs sidecar, masks excluding the first zone, exact per-zone amounts. Added to validate the refactor.
4. Changelog

## Related Issues

Fixes #1856

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [ ] Documentation — n/a
- [x] Changelog fragment 

## Breaking Changes

None

## Additional Notes

Tested on a hero preempt adversarial scenario, with disabled action budgets. Nodes have 2*4 GPU numa zones in restricted mode, victims are 3 GPUs each so a 2-GPU vacancy exists on each node, preemptor has 250 2-GPU pods - this is to make sure that no GPU accounting optimizations affect the results. Preempt duration decreased by roughly 50% from ~406s to ~195s.

Snapshot file for replication:
[snapshot-numa-preempt-gang-nobudget.zip](https://github.com/user-attachments/files/30079349/snapshot-numa-preempt-gang-nobudget.zip)
