### PR TITLE
ci(release): adopt changelog fragments + release automation (v0.9)

### DIFF
--- a/.changes/header.tpl.md
+++ b/.changes/header.tpl.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

--- a/.changes/unreleased/0001-fixed.yaml
+++ b/.changes/unreleased/0001-fixed.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0002-fixed.yaml
+++ b/.changes/unreleased/0002-fixed.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0003-fixed.yaml
+++ b/.changes/unreleased/0003-fixed.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -1,0 +1,29 @@
+changesDir: .changes
+unreleasedDir: unreleased
+headerPath: header.tpl.md
+changelogPath: CHANGELOG.md
+versionExt: md
+# Timestamped, non-serial filenames so concurrent PRs and backports never collide.
+fragmentFileFormat: '{{.Kind}}-{{.Time.Format "20060102-150405"}}'
+versionFormat: '## [{{.Version}}] - {{.Time.Format "2006-01-02"}}'
+kindFormat: '### {{.Kind}}'
+changeFormat: '- {{.Body}}{{if .Custom.Issue}} [#{{.Custom.Issue}}](https://github.com/kai-scheduler/KAI-Scheduler/issues/{{.Custom.Issue}}){{end}}{{if .Custom.Author}} [{{.Custom.Author}}](https://github.com/{{.Custom.Author}}){{end}}'
+kinds:
+  - label: Added
+  - label: Changed
+  - label: Fixed
+  - label: Removed
+custom:
+  - key: Issue
+    label: Issue or PR number (optional, e.g. 1817)
+    type: string
+    optional: true
+  - key: Author
+    label: GitHub username to credit (optional)
+    type: string
+    optional: true
+newlines:
+  afterChangelogHeader: 0
+  beforeChangelogVersion: 1
+  beforeKind: 1
+  endOfVersion: 1

--- a/.github/workflows/changelog-comment.yaml
+++ b/.github/workflows/changelog-comment.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# After a PR that added changelog fragment(s) is merged, KAIBOT comments on the PR with a
+# link to each fragment. Pending fragments are folded into CHANGELOG.md at release time
+# (`make changelog-release`), so this confirms to the contributor that their entry was
+# recorded even though CHANGELOG.md did not change in the PR.
+
+name: Changelog Comment
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+      - 'v*.*'
+    paths:
+      - '.changes/unreleased/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Comment changelog fragment link
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment with fragment link(s)
+        env:
+          GH_TOKEN: ${{ secrets.KAIBOT_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate \
+            --jq '.[] | select(.status=="added") | .filename' \
+            | grep -E '^\.changes/unreleased/[^/]+\.ya?ml$' || true)
+          if [ -z "$files" ]; then
+            echo "No changelog fragment added by this PR; skipping comment."
+            exit 0
+          fi
+          {
+            echo "### 📝 Changelog fragment recorded"
+            echo ""
+            echo "Thanks! This PR added the changelog fragment(s) below. Pending fragments are folded into \`CHANGELOG.md\` at **release time**, so it was intentionally not modified by this PR — your entry will appear in the next release:"
+            echo ""
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              echo "- [\`$f\`](https://github.com/$REPO/blob/$SHA/$f)"
+            done <<< "$files"
+          } > comment.md
+          gh pr comment "$PR" --repo "$REPO" --body-file comment.md
+          echo "Posted changelog fragment comment."

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,0 +1,80 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Release, step 1 of 2 — Prepare Changelog (manual dispatch).
+#
+# Folds the pending changie fragments (.changes/unreleased/*.yaml) into CHANGELOG.md as a new
+# "## [VERSION]" section, clears the fragments, and opens a PR against the branch this workflow
+# was dispatched on (main for minors/majors, a v*.* branch for patches).
+#
+# A maintainer reviews and merges that PR. Merging it triggers release-publish.yaml (step 2),
+# which tags the version and creates the GitHub Release.
+
+name: Release — Prepare Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. v0.17.0 (minors/majors from main, patches from a v*.* branch)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Fold changelog & open PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ github.ref_name }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.KAIBOT_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.6'
+
+      - name: Fold fragments into CHANGELOG.md
+        run: make changelog-release VERSION="${{ inputs.version }}"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.KAIBOT_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          BASE: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/prepare-$VERSION"
+
+          git config --local user.name "kai-release-bot"
+          git config --local user.email "action@github.com"
+
+          git switch -c "$BRANCH"
+          git add -A
+          git commit -s -m "chore(release): prepare changelog for $VERSION"
+          git push --force-with-lease -u origin "$BRANCH"
+
+          BODY="${RUNNER_TEMP:-/tmp}/pr-body.md"
+          {
+            echo "Automated by the **Release — Prepare Changelog** workflow."
+            echo
+            echo "Folds the pending \`.changes/unreleased/\` fragments into \`CHANGELOG.md\` as \`## [$VERSION]\` and clears them. \`CHANGELOG.md\` is the source of truth."
+            echo
+            echo "**Merging this PR** triggers \`release-publish.yaml\`, which tags \`$VERSION\` and creates the GitHub Release from this changelog section."
+            echo
+            echo "- Review the new \`## [$VERSION]\` section for accuracy."
+            echo "- Target branch: \`$BASE\`."
+          } > "$BODY"
+
+          gh pr create \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --title "chore(release): prepare changelog for $VERSION" \
+            --label skip-changelog \
+            --body-file "$BODY"

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,0 +1,90 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Release, step 2 of 2 — Tag & Publish (automatic).
+#
+# Fires when a "release/prepare-*" PR from release-prepare.yaml is merged into main or a v*.*
+# branch. Reads the freshly-folded top section of CHANGELOG.md, creates the git tag, and creates
+# the GitHub Release with that section as the notes.
+
+name: Release — Tag & Publish
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - 'v*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Tag & create GitHub Release
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/prepare-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merged ${{ github.event.pull_request.base.ref }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.KAIBOT_TOKEN }}
+
+      - name: Derive version and release notes from CHANGELOG.md
+        id: notes
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Top "## [VERSION] - date" heading is the version this PR just folded in.
+          VERSION="$(grep -m1 -oE '^## \[[^]]+\]' CHANGELOG.md | sed -E 's/^## \[(.+)\]/\1/')"
+          BRANCH_VERSION="${HEAD_REF#release/prepare-}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read a version heading from CHANGELOG.md"; exit 1
+          fi
+          if [ "$VERSION" != "$BRANCH_VERSION" ]; then
+            echo "::error::CHANGELOG top version ($VERSION) != branch version ($BRANCH_VERSION)"; exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::Tag $VERSION already exists"; exit 1
+          fi
+
+          # Extract the body of the top section (everything after its heading, up to the next
+          # "## [" heading), trimming leading blank lines.
+          awk '
+            /^## \[/ { n++; if (n==1) next; if (n==2) exit }
+            n==1 { print }
+          ' CHANGELOG.md | sed '/./,$!d' > "${RUNNER_TEMP:-/tmp}/notes.md"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release $VERSION notes:"; cat "${RUNNER_TEMP:-/tmp}/notes.md"
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ steps.notes.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config --local user.name "kai-release-bot"
+          git config --local user.email "action@github.com"
+          git tag "$VERSION"
+          git push origin "refs/tags/$VERSION"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.KAIBOT_TOKEN }}
+          VERSION: ${{ steps.notes.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file "${RUNNER_TEMP:-/tmp}/notes.md"

--- a/.github/workflows/validate-changelog.yaml
+++ b/.github/workflows/validate-changelog.yaml
@@ -9,23 +9,32 @@ on:
     branches:
       - main
       - 'v*.*'
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   validate-changelog:
     name: Validate Changelog
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
     steps:
-      - uses: actions/checkout@v4
+      # For merge queue: changelog was already validated, just succeed
+      - name: Skip validation for merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Changelog was already validated before entering merge queue"
+
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && !contains(github.event.pull_request.labels.*.name, 'dependencies')
         with:
           fetch-depth: 0
 
-      - name: Check CHANGELOG.md updated
+      # Changelog entries are managed as changie fragments (see CONTRIBUTING.md).
+      # A behavior-changing PR must add a fragment under .changes/unreleased/ (run `make changelog`).
+      - name: Check changelog fragment added
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && !contains(github.event.pull_request.labels.*.name, 'dependencies')
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG.md$'; then
-            echo "CHANGELOG.md has been updated."
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '^\.changes/unreleased/[^/]+\.yaml$'; then
+            echo "Changelog fragment added."
           else
-            echo "::error::CHANGELOG.md has not been updated. Please update the changelog or add the 'skip-changelog' label to opt out."
+            echo "::error::No changelog fragment found. Run 'make changelog' to add one, or add the 'skip-changelog' label to opt out."
             exit 1
           fi
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-- Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
-- In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
-- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
-
 ## [v0.9.20] - 2026-06-22
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Help us keep the docs clear and useful by fixing typos, updating outdated inform
 - Fork and Clone – Begin by forking the repository and cloning it to your local machine.
 - Create a Branch – Use a descriptive branch name, such as feature/add-cool-feature or bugfix/fix-issue123.
 - Make Changes – Keep your commits small, focused, and well-documented. For detailed build and test instructions, refer to [Building from Source](docs/developer/building-from-source.md).
-- Log Changes – For behavior-affecting changes (features, fixes, API changes), update the [changelog](CHANGELOG.md) file under the "Unreleased" section. Follow the format at [keepachangelog.com](https://keepachangelog.com/en/1.1.0/). Skip logging internal changes like refactoring or tests.
+- Log Changes – For behavior-affecting changes (features, fixes, API changes), add a changelog entry by running `make changelog` (powered by [changie](https://changie.dev)). This creates a small fragment file under `.changes/unreleased/` instead of editing `CHANGELOG.md` directly, so entries never conflict between PRs or backports. `CHANGELOG.md` is the source of truth for released versions (following [keepachangelog.com](https://keepachangelog.com/en/1.1.0/)); your fragment stays in `.changes/unreleased/` until a maintainer cuts the next release, which folds the pending fragments into `CHANGELOG.md` and clears them. Skip logging internal changes like refactoring or tests. CI checks for a fragment; add the `skip-changelog` label to your PR to skip if your change doesn't require a changelog entry.
 - Submit a PR – Open a pull request and reference any relevant issues or discussions.
 - Approval Policy – PRs from external contributors require approval from 2 trusted reviewers (organization members or collaborators) before merging.
 - Coverage - Please look at the coverage change details and create unit tests, integration tests or end-to-end tests to cover new functionality or changes.
@@ -41,7 +41,7 @@ Each pull request should meet the following requirements:
 - All tests pass – Run the full test suite locally with: `make build validate test`
 - Test coverage – Add or update tests for any affected code.
 - Documentation – Update relevant documentation to reflect your changes.
-- Changes logged - If your changes warrant logging - like behavior changes (including bugfixes) or new features - add them to the [Changelog](CHANGELOG.md)
+- Changes logged - If your changes warrant logging - like behavior changes (including bugfixes) or new features - run `make changelog` to add a changelog fragment (do not edit `CHANGELOG.md` directly). Use the `skip-changelog` label to opt out if not needed.
 
 ## Getting Help
 Need support or have a question? We're here to help:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.20.1
 MOCKGEN_VERSION ?= v0.6.0
 ADDLICENSE_VERSION ?= v1.1.1
 KUSTOMIZE_VERSION ?= v5.0.0
+CHANGIE_VERSION ?= v1.25.0
 
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
@@ -13,6 +14,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 MOCKGEN ?= $(LOCALBIN)/mockgen
 ADDLICENSE ?= $(LOCALBIN)/addlicense
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CHANGIE ?= $(LOCALBIN)/changie
 
 # Space seperated list of services to build by default
 # SERVICE_NAMES := service1 service2 service3
@@ -58,7 +60,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 .PHONY: gen-license
 gen-license: addlicense
-	$(ADDLICENSE) -c "NVIDIA CORPORATION" -s=only -l apache -v .
+	$(ADDLICENSE) -c "NVIDIA CORPORATION" -s=only -l apache -v -ignore '.changes/**' -ignore '.changie.yaml' .
 
 .PHONY: manifests
 manifests: controller-gen kustomize ## Generate ClusterRole and CustomResourceDefinition objects.
@@ -93,6 +95,25 @@ $(MOCKGEN): $(LOCALBIN)
 addlicense: $(ADDLICENSE) ## Download google-addlicense locally if necessary.
 $(ADDLICENSE): $(LOCALBIN)
 	test -s $(LOCALBIN)/addlicense || GOBIN=$(LOCALBIN) go install github.com/google/addlicense@$(ADDLICENSE_VERSION)
+
+.PHONY: changie
+changie: $(CHANGIE) ## Download changie locally if necessary.
+$(CHANGIE): $(LOCALBIN)
+	test -s $(LOCALBIN)/changie || GOBIN=$(LOCALBIN) go install github.com/miniscruff/changie@$(CHANGIE_VERSION)
+
+.PHONY: changelog
+changelog: changie ## Add a changelog entry as a fragment (interactive). Use instead of editing CHANGELOG.md.
+	$(CHANGIE) new
+
+.PHONY: changelog-release
+changelog-release: changie ## Fold unreleased fragments into CHANGELOG.md as VERSION and clear them. Usage: make changelog-release VERSION=v0.9.21
+	@test -n "$(VERSION)" || { echo "VERSION is required, e.g. make changelog-release VERSION=v0.9.21"; exit 1; }
+	CHANGIE=$(CHANGIE) bash hack/changelog-fold.sh $(VERSION)
+
+.PHONY: changelog-preview
+changelog-preview: changie ## Preview the next release section without writing anything. Usage: make changelog-preview VERSION=v0.9.21
+	@test -n "$(VERSION)" || { echo "VERSION is required, e.g. make changelog-preview VERSION=v0.9.21"; exit 1; }
+	$(CHANGIE) batch $(VERSION) --dry-run
 
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/hack/changelog-fold.sh
+++ b/hack/changelog-fold.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Fold pending changie fragments into CHANGELOG.md as a new released version section,
+# then clear the fragments. CHANGELOG.md is the source of truth — this edits it in place
+# and does NOT keep a per-version archive.
+#
+# Usage: hack/changelog-fold.sh vX.Y.Z
+#   CHANGIE=/path/to/changie hack/changelog-fold.sh v0.17.0   # override the binary
+#
+# The new section is rendered by `changie batch --dry-run` (no disk writes, fragments left
+# intact) and inserted immediately before the newest existing version heading, keeping one
+# blank line between versions per Keep a Changelog. Fragments are removed only after the
+# CHANGELOG.md write succeeds.
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 1
+fi
+
+CHANGIE="${CHANGIE:-bin/changie}"
+if [ ! -x "$CHANGIE" ]; then
+  echo "changie not found at '$CHANGIE' — run: make changie" >&2
+  exit 1
+fi
+
+CHANGELOG="CHANGELOG.md"
+
+# Render the version section only (no header, no disk mutation, fragments untouched).
+section="$("$CHANGIE" batch "$VERSION" --dry-run)"
+if [ -z "$section" ]; then
+  echo "no unreleased fragments to release for $VERSION" >&2
+  exit 1
+fi
+
+# Insert the section before the first existing "## [" heading (one blank line between).
+# Falls back to appending after the header block if the changelog has no versions yet.
+SECTION="$section" awk '
+  BEGIN { sec = ENVIRON["SECTION"] }
+  /^## \[/ && !ins { print sec "\n"; ins = 1 }
+  { print }
+  END { if (!ins) print "\n" sec }
+' "$CHANGELOG" > "$CHANGELOG.tmp"
+mv "$CHANGELOG.tmp" "$CHANGELOG"
+
+# Clear the folded fragments (keep the directory + .gitkeep).
+find .changes/unreleased -maxdepth 1 -type f -name '*.yaml' -delete
+
+echo "Folded $(basename "$VERSION") into $CHANGELOG and cleared fragments."


### PR DESCRIPTION
## Description

Import the changie changelog-fragment workflow + release automation to the **v0.9** branch, matching the system built for `main` in #1839 and the ports in #1907 (v0.16) and #1914 (v0.14). Authored as an **independent PR** (not a git backport — #1839's commits touch files that differ per branch and would conflict on nearly everything).

**What changes**
- `CHANGELOG.md` becomes the source of truth for released versions; contributors run `make changelog` to drop a fragment under `.changes/unreleased/` instead of hand-editing the `## [Unreleased]` block. The three pending Unreleased entries (all `### Fixed`) were migrated to fragments and the block removed (released history byte-for-byte intact).
- Adds `.changie.yaml`, `.changes/header.tpl.md`, `hack/changelog-fold.sh`, and `changelog*` Makefile targets.
- **Release automation:** `Release — Prepare Changelog` (dispatch → folds fragments into `CHANGELOG.md`, opens a PR) and `Release — Tag & Publish` (on merge → tag + GitHub Release via `KAIBOT_TOKEN`, so `push-artifacts.yaml` + `on-release.yaml` fire). Plus `changelog-comment.yaml`.
- `validate-changelog.yaml` now requires a fragment (not a `CHANGELOG.md` edit).
- Action pins: `actions/checkout@v6`, `actions/setup-go@v5` with `go-version: 1.25.6` (this branch's house style).

**Verified locally:** fragments fold set-equal to the old Unreleased block; `make changelog-preview VERSION=v0.9.21` renders a clean section; released history is byte-identical to origin minus the `## [Unreleased]` block.

## Branch drift adapted (v0.9 is the oldest branch)
- **No `AGENTS.md`** on v0.9 — the AGENTS.md wording update from the newer ports was skipped (file does not exist).
- **No `.github/pull_request_template.md`** on v0.9 — the PR-template checklist line was skipped (file does not exist).
- **No `backport.yaml` / fix-backport-changelog files** on v0.9 — nothing to remove; the backport step was skipped entirely.
- `CONTRIBUTING.md` wording differed slightly from newer branches; the two changelog lines were replaced with the changie versions.

## Checklist
- [x] Self-reviewed
- [x] Updated documentation (CONTRIBUTING.md)
- [x] `skip-changelog` applied — CI/tooling change

## Note
- No pre-existing CHANGELOG gap: the latest tag `v0.9.20` is the top released section. The three pending entries target the next release (`v0.9.21`).

## Required after merge
- Confirm `KAIBOT_TOKEN` can push tags + create releases on `v0.9` and no tag-protection rule blocks the bot.
- First patch cut from `v0.9` is the rehearsal — watch prepare PR → tag → `push-artifacts` → Release → `on-release`.
