### PR TITLE
test(scheduler): benchmark reclaim fit-error retention across full cycle

### DIFF
--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -6,6 +6,7 @@ package reclaim
 import (
 	"flag"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -15,7 +16,11 @@ import (
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/consolidation"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/preempt"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/stalegangeviction"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
@@ -33,6 +38,8 @@ var reclaimLargeJobNodeLocalGreedyBudget = flag.String(
 	"",
 	"optional NodeLocalGreedy generator budget override for BenchmarkReclaimLargeJobs",
 )
+
+var manySingleGPUJobsBenchmarkKeepAlive *framework.Session
 
 func init() {
 	test_utils.InitTestingInfrastructure()
@@ -79,29 +86,100 @@ func BenchmarkReclaimManySingleGPUJobs_200Node(b *testing.B) {
 }
 
 func BenchmarkReclaimManySingleGPUJobs_500Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobs(b, 500)
+	benchmarkReclaimManySingleGPUJobsWithParams(b, defaultManySingleGPUJobsReclaimParams(500), true)
 }
 
 func BenchmarkReclaimManySingleGPUJobsWithMinRuntime_500Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobsWithParams(b, manySingleGPUJobsReclaimParamsWithMinRuntime(500))
+	benchmarkReclaimManySingleGPUJobsWithParams(b, manySingleGPUJobsReclaimParamsWithMinRuntime(500), false)
 }
 
 func benchmarkReclaimManySingleGPUJobs(b *testing.B, numNodes int) {
-	benchmarkReclaimManySingleGPUJobsWithParams(b, defaultManySingleGPUJobsReclaimParams(numNodes))
+	benchmarkReclaimManySingleGPUJobsWithParams(b, defaultManySingleGPUJobsReclaimParams(numNodes), false)
 }
 
-func benchmarkReclaimManySingleGPUJobsWithParams(b *testing.B, params manySingleGPUJobsReclaimParams) {
+// ReclaimManySingleGPUJobs names identify the matching scale-test scenario. Each benchmark runs a full scheduling cycle.
+func benchmarkReclaimManySingleGPUJobsWithParams(
+	b *testing.B,
+	params manySingleGPUJobsReclaimParams,
+	measureLiveHeap bool,
+) {
 	defer gock.Off()
 
 	topology := buildManySingleGPUJobsReclaimTopology(params)
+	actions := manySingleGPUJobsSchedulingCycleActions()
 	b.ReportAllocs()
+	var heapAfterAllocate uint64
+	var heapAfterCycle uint64
+	var fitErrorTasks int
 
 	for b.Loop() {
+		var before runtime.MemStats
+		if measureLiveHeap {
+			b.StopTimer()
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+			b.StartTimer()
+		}
+
 		ctrl := gomock.NewController(b)
 		ssn := test_utils.BuildSession(topology, ctrl)
-		reclaim.New().Execute(ssn)
+		for actionIndex, action := range actions {
+			action.Execute(ssn)
+			if measureLiveHeap && actionIndex == 0 {
+				fitErrorTasks += countManySingleGPUFitErrorTasks(ssn)
+				manySingleGPUJobsBenchmarkKeepAlive = ssn
+				b.StopTimer()
+				runtime.GC()
+				var after runtime.MemStats
+				runtime.ReadMemStats(&after)
+				heapAfterAllocate += heapDelta(before.HeapAlloc, after.HeapAlloc)
+				b.StartTimer()
+			}
+		}
+		if measureLiveHeap {
+			manySingleGPUJobsBenchmarkKeepAlive = ssn
+			b.StopTimer()
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			heapAfterCycle += heapDelta(before.HeapAlloc, after.HeapAlloc)
+			b.StartTimer()
+		}
 		ctrl.Finish()
 	}
+	b.StopTimer()
+	b.ReportMetric(1, "full_cycles/op")
+	if measureLiveHeap {
+		iterations := uint64(b.N)
+		b.ReportMetric(float64(fitErrorTasks)/float64(iterations), "fit_error_tasks_after_allocate/op")
+		b.ReportMetric(float64(heapAfterAllocate/iterations), "heap_live_after_allocate_bytes/op")
+		b.ReportMetric(float64(heapAfterCycle/iterations), "heap_live_after_cycle_bytes/op")
+	}
+}
+
+func manySingleGPUJobsSchedulingCycleActions() []framework.Action {
+	return []framework.Action{
+		allocate.New(),
+		consolidation.New(),
+		reclaim.New(),
+		preempt.New(),
+		stalegangeviction.New(),
+	}
+}
+
+func countManySingleGPUFitErrorTasks(ssn *framework.Session) int {
+	fitErrorTasks := 0
+	for _, job := range ssn.ClusterInfo.PodGroupInfos {
+		fitErrorTasks += len(job.TasksFitErrors)
+	}
+	return fitErrorTasks
+}
+
+func heapDelta(before, after uint64) uint64 {
+	if after <= before {
+		return 0
+	}
+	return after - before
 }
 
 func benchmarkReclaimLargeJobs(b *testing.B, numNodes int) {

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -69,36 +69,35 @@ func BenchmarkReclaimLargeJobs_1000Node(b *testing.B) {
 	benchmarkReclaimLargeJobs(b, 1000)
 }
 
-func BenchmarkReclaimManySingleGPUJobs_10Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobs(b, 10)
+func BenchmarkReclaimManySingleGPUJobsFullCycle_10Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsFullCycle(b, 10)
 }
 
-func BenchmarkReclaimManySingleGPUJobs_50Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobs(b, 50)
+func BenchmarkReclaimManySingleGPUJobsFullCycle_50Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsFullCycle(b, 50)
 }
 
-func BenchmarkReclaimManySingleGPUJobs_100Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobs(b, 100)
+func BenchmarkReclaimManySingleGPUJobsFullCycle_100Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsFullCycle(b, 100)
 }
 
-func BenchmarkReclaimManySingleGPUJobs_200Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobs(b, 200)
+func BenchmarkReclaimManySingleGPUJobsFullCycle_200Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsFullCycle(b, 200)
 }
 
-func BenchmarkReclaimManySingleGPUJobs_500Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobsWithParams(b, defaultManySingleGPUJobsReclaimParams(500), true)
+func BenchmarkReclaimManySingleGPUJobsFullCycle_500Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsFullCycleWithParams(b, defaultManySingleGPUJobsReclaimParams(500), true)
 }
 
-func BenchmarkReclaimManySingleGPUJobsWithMinRuntime_500Node(b *testing.B) {
-	benchmarkReclaimManySingleGPUJobsWithParams(b, manySingleGPUJobsReclaimParamsWithMinRuntime(500), false)
+func BenchmarkReclaimManySingleGPUJobsFullCycleWithMinRuntime_500Node(b *testing.B) {
+	benchmarkReclaimManySingleGPUJobsFullCycleWithParams(b, manySingleGPUJobsReclaimParamsWithMinRuntime(500), false)
 }
 
-func benchmarkReclaimManySingleGPUJobs(b *testing.B, numNodes int) {
-	benchmarkReclaimManySingleGPUJobsWithParams(b, defaultManySingleGPUJobsReclaimParams(numNodes), false)
+func benchmarkReclaimManySingleGPUJobsFullCycle(b *testing.B, numNodes int) {
+	benchmarkReclaimManySingleGPUJobsFullCycleWithParams(b, defaultManySingleGPUJobsReclaimParams(numNodes), false)
 }
 
-// ReclaimManySingleGPUJobs names identify the matching scale-test scenario. Each benchmark runs a full scheduling cycle.
-func benchmarkReclaimManySingleGPUJobsWithParams(
+func benchmarkReclaimManySingleGPUJobsFullCycleWithParams(
 	b *testing.B,
 	params manySingleGPUJobsReclaimParams,
 	measureLiveHeap bool,

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_many_single_gpu_topology_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_many_single_gpu_topology_test.go
@@ -5,6 +5,7 @@ package reclaim
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/reclaim"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
@@ -22,6 +22,19 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
+
+func TestManySingleGPUJobsSchedulingCycleActions(t *testing.T) {
+	actions := manySingleGPUJobsSchedulingCycleActions()
+	actionNames := make([]string, 0, len(actions))
+	for _, action := range actions {
+		actionNames = append(actionNames, string(action.Name()))
+	}
+
+	expected := []string{"allocate", "consolidation", "reclaim", "preempt", "stalegangeviction"}
+	if !reflect.DeepEqual(actionNames, expected) {
+		t.Fatalf("scheduling cycle actions = %v, want %v", actionNames, expected)
+	}
+}
 
 type manySingleGPUJobsReclaimParams struct {
 	NumNodes          int
@@ -55,9 +68,16 @@ func TestManySingleGPUJobsReclaimTopology(t *testing.T) {
 		onJobSolutionStartCalls++
 	})
 
-	reclaim.New().Execute(ssn)
-
 	expectedTasks := params.NumNodes * params.GPUsPerNode
+	actions := manySingleGPUJobsSchedulingCycleActions()
+	actions[0].Execute(ssn)
+	if fitErrorTasks := countManySingleGPUFitErrorTasks(ssn); fitErrorTasks != expectedTasks {
+		t.Fatalf("expected %d tasks with fit errors after allocate, got %d", expectedTasks, fitErrorTasks)
+	}
+	for _, action := range actions[1:] {
+		action.Execute(ssn)
+	}
+
 	if onJobSolutionStartCalls == 0 {
 		t.Fatal("expected reclaim to attempt solving pending jobs")
 	}


### PR DESCRIPTION
## Description

This PR replaces the scale-test-inspired `ReclaimManySingleGPUJobs` benchmark series with `ReclaimManySingleGPUJobsFullCycle`, which runs a complete scheduling cycle instead of invoking only Reclaim.

Each iteration executes Allocate, Consolidation, Reclaim, Preempt, and StaleGangEviction. The standard 500-node variant reports retained heap after Allocate and after the full cycle, together with the number of tasks that retain fit errors after Allocate.

The `FullCycle` suffix intentionally creates a new benchmark data series. The old reclaim-only series is abandoned because its results are not comparable with the complete-cycle workload.

This integration benchmark is included in the default CI benchmark sweep through its `pkg/scheduler/actions/integration_tests/reclaim` package; it is not part of the separate curated regex for `pkg/scheduler/actions/reclaim`.

## Related Issues

Related to #1827

Related to #1653

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [x] Updated documentation (not needed for benchmark-only changes)

## Breaking Changes

None.

## Additional Notes

Validation performed:

- `go test ./pkg/scheduler/actions/integration_tests/reclaim -run=^$ -bench=BenchmarkReclaimManySingleGPUJobsFullCycle_500Node -benchmem -benchtime=1x -count=1 -timeout=30m`

500-node baseline result:

| Metric | Result |
|---|---:|
| Tasks with fit errors after Allocate | 4,000 |
| Live-heap delta after Allocate | 597.6 MB |
| Live-heap delta after full cycle | 612.2 MB |
| Bytes/op | 14.13 GB |
| Allocations/op | 397.5 M |
