### PR TITLE
fix(scheduler): scope fit errors to authoritative allocation attempts

### DIFF
--- a/.changes/unreleased/Fixed-20260717-224428.yaml
+++ b/.changes/unreleased/Fixed-20260717-224428.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+kind: Fixed
+body: Prevent simulations and discarded allocation alternatives from publishing stale fit errors.
+time: 2026-07-17T22:44:28+02:00
+custom:
+    Author: enoodle
+    Issue: "1827"

--- a/pkg/scheduler/actions/common/allocate.go
+++ b/pkg/scheduler/actions/common/allocate.go
@@ -17,6 +17,21 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
+type allocationOutcome struct {
+	success        bool
+	allocatedTasks int
+	failedTask     *pod_info.PodInfo
+	taskFitError   *common_info.TasksFitErrors
+	jobFitErrors   []common_info.JobFitError
+}
+
+func selectOutcomeByAllocatedTasks(current, candidate allocationOutcome) allocationOutcome {
+	if candidate.allocatedTasks > current.allocatedTasks {
+		return candidate
+	}
+	return current
+}
+
 func AllocateJob(ssn *framework.Session, stmt *framework.Statement, nodes []*node_info.NodeInfo,
 	job *podgroup_info.PodGroupInfo, isPipelineOnly bool) bool {
 	ssn.PreJobAllocation(job)
@@ -35,35 +50,61 @@ func AllocateJob(ssn *framework.Session, stmt *framework.Statement, nodes []*nod
 		}
 		return false
 	}
-	return allocateSubGroupSet(ssn, stmt, nodes, job, job.RootSubGroupSet, tasksToAllocate, isPipelineOnly)
+	return allocateSubGroupSet(ssn, stmt, nodes, job, job.RootSubGroupSet, tasksToAllocate, isPipelineOnly).success
+}
+
+func publishFitErrors(job *podgroup_info.PodGroupInfo, outcome allocationOutcome) {
+	if outcome.failedTask != nil && outcome.taskFitError != nil {
+		job.AddTaskFitErrors(outcome.failedTask, outcome.taskFitError)
+	}
+	for _, fitError := range outcome.jobFitErrors {
+		job.AddJobFitError(fitError)
+	}
 }
 
 func allocateSubGroupSet(ssn *framework.Session, stmt *framework.Statement, nodes []*node_info.NodeInfo,
 	job *podgroup_info.PodGroupInfo, subGroupSet *subgroup_info.SubGroupSet, subtreeTasksToAllocate []*pod_info.PodInfo,
 	isPipelineOnly bool,
-) bool {
+) allocationOutcome {
 	if len(subtreeTasksToAllocate) == 0 {
-		return true
+		return allocationOutcome{success: true}
 	}
 	relevantPodSets := subtreePodSetsContainingTasks(subGroupSet, subtreeTasksToAllocate)
-	nodeSets, err := ssn.SubsetNodesFn(job, &subGroupSet.SubGroupInfo, relevantPodSets, subtreeTasksToAllocate, nodes)
+	subsetResult, err := ssn.SubsetNodesFn(
+		job, &subGroupSet.SubGroupInfo, relevantPodSets, subtreeTasksToAllocate, nodes, !isPipelineOnly,
+	)
 	if err != nil {
 		log.InfraLogger.Errorf(
 			"Failed to run SubsetNodes on job <%s/%s>: %v", job.Namespace, job.Name, err)
-		return false
+		return allocationOutcome{}
+	}
+	nodeSets := subsetResult.NodeSets
+	if len(nodeSets) == 0 && len(subsetResult.FitErrors) != 0 {
+		outcome := allocationOutcome{jobFitErrors: subsetResult.FitErrors}
+		publishFitErrors(job, outcome)
+		return outcome
 	}
 
+	var bestFailure allocationOutcome
+	hasFailure := false
 	for _, nodeSet := range nodeSets {
 		cp := stmt.Checkpoint()
-		if allocateMembersOnNodes(ssn, stmt, nodeSet, job, subGroupSet, subtreeTasksToAllocate, isPipelineOnly) {
-			return true
+		outcome := allocateMembersOnNodes(ssn, stmt, nodeSet, job, subGroupSet, subtreeTasksToAllocate, isPipelineOnly)
+		if outcome.success {
+			return outcome
 		}
 		if err := stmt.Rollback(cp); err != nil {
 			log.InfraLogger.Errorf("Failed to rollback statement in session %v, err: %v", ssn.ID, err)
 		}
+		if !hasFailure {
+			bestFailure = outcome
+			hasFailure = true
+		} else {
+			bestFailure = selectOutcomeByAllocatedTasks(bestFailure, outcome)
+		}
 	}
 
-	return false
+	return bestFailure
 }
 
 // allocateMembersOnNodes allocates the tasks that appear in subtreeTasksToAllocate by traversing the subtree rooted at subGroupSet.
@@ -72,22 +113,25 @@ func allocateSubGroupSet(ssn *framework.Session, stmt *framework.Statement, node
 func allocateMembersOnNodes(ssn *framework.Session, stmt *framework.Statement, nodes node_info.NodeSet,
 	job *podgroup_info.PodGroupInfo, subGroupSet *subgroup_info.SubGroupSet, subtreeTasksToAllocate []*pod_info.PodInfo,
 	isPipelineOnly bool,
-) bool {
+) allocationOutcome {
+	allocatedTasks := 0
 	for _, memberGeneric := range orderedMembers(ssn, subGroupSet.GetMembers()) {
+		var outcome allocationOutcome
 		switch member := memberGeneric.(type) {
 		case *subgroup_info.PodSet:
-			if !allocatePodSet(ssn, stmt, nodes, job, member,
-				filterTasksForPodSet(member, subtreeTasksToAllocate), isPipelineOnly) {
-				return false
-			}
+			outcome = allocatePodSet(ssn, stmt, nodes, job, member,
+				filterTasksForPodSet(member, subtreeTasksToAllocate), isPipelineOnly)
 		case *subgroup_info.SubGroupSet:
-			if !allocateSubGroupSet(ssn, stmt, nodes, job, member,
-				filterTasksForPodSets(member.GetDescendantPodSets(), subtreeTasksToAllocate), isPipelineOnly) {
-				return false
-			}
+			outcome = allocateSubGroupSet(ssn, stmt, nodes, job, member,
+				filterTasksForPodSets(member.GetDescendantPodSets(), subtreeTasksToAllocate), isPipelineOnly)
 		}
+		if !outcome.success {
+			outcome.allocatedTasks += allocatedTasks
+			return outcome
+		}
+		allocatedTasks += outcome.allocatedTasks
 	}
-	return true
+	return allocationOutcome{success: true, allocatedTasks: allocatedTasks}
 }
 
 // subtreePodSetsContainingTasks returns only the PodSets that are a descendant of the given SubGroupSet and that have at least one task in the list.
@@ -109,68 +153,104 @@ func subtreePodSetsContainingTasks(subGroupSet *subgroup_info.SubGroupSet, tasks
 func allocatePodSet(ssn *framework.Session, stmt *framework.Statement, nodes node_info.NodeSet,
 	job *podgroup_info.PodGroupInfo, podSet *subgroup_info.PodSet, podsetTasksToAllocate []*pod_info.PodInfo,
 	isPipelineOnly bool,
-) bool {
+) allocationOutcome {
 	if len(podsetTasksToAllocate) == 0 {
-		return true
+		return allocationOutcome{success: true}
 	}
 	podSets := map[string]*subgroup_info.PodSet{
 		podSet.GetName(): podSet,
 	}
-	nodeSets, err := ssn.SubsetNodesFn(job, &podSet.SubGroupInfo, podSets, podsetTasksToAllocate, nodes)
+	subsetResult, err := ssn.SubsetNodesFn(
+		job, &podSet.SubGroupInfo, podSets, podsetTasksToAllocate, nodes, !isPipelineOnly,
+	)
 	if err != nil {
 		log.InfraLogger.Errorf(
 			"Failed to run SubsetNodes on job <%s/%s>: %v", job.Namespace, job.Name, err)
-		return false
+		return allocationOutcome{}
+	}
+	nodeSets := subsetResult.NodeSets
+	if len(nodeSets) == 0 && len(subsetResult.FitErrors) != 0 {
+		outcome := allocationOutcome{jobFitErrors: subsetResult.FitErrors}
+		publishFitErrors(job, outcome)
+		return outcome
 	}
 
+	var bestFailure allocationOutcome
+	hasFailure := false
 	for _, nodeSet := range nodeSets {
 		cp := stmt.Checkpoint()
-		if allocateTasksOnNodeSet(ssn, stmt, nodeSet, job, podsetTasksToAllocate, isPipelineOnly) {
-			return true
+		outcome := allocateTasksOnNodeSet(ssn, stmt, nodeSet, job, podsetTasksToAllocate, isPipelineOnly)
+		if outcome.success {
+			return outcome
 		}
 		if err := stmt.Rollback(cp); err != nil {
 			log.InfraLogger.Errorf("Failed to rollback statement in session %v, err: %v", ssn.ID, err)
 		}
+		if !hasFailure {
+			bestFailure = outcome
+			hasFailure = true
+		} else {
+			bestFailure = selectOutcomeByAllocatedTasks(bestFailure, outcome)
+		}
 	}
-	return false
+	return bestFailure
 }
 
 func allocateTasksOnNodeSet(ssn *framework.Session, stmt *framework.Statement, nodes node_info.NodeSet,
-	job *podgroup_info.PodGroupInfo, tasksToAllocate []*pod_info.PodInfo, isPipelineOnly bool) bool {
+	job *podgroup_info.PodGroupInfo, tasksToAllocate []*pod_info.PodInfo, isPipelineOnly bool) allocationOutcome {
 	for index, task := range tasksToAllocate {
-		success := allocateTask(ssn, stmt, nodes, task, isPipelineOnly)
+		success, taskFitError := allocateTask(ssn, stmt, nodes, task, isPipelineOnly)
 		if !success {
-			handleFailedTaskAllocation(job, task, index)
-			return false
+			outcome := allocationOutcome{allocatedTasks: index}
+			if !isPipelineOnly {
+				outcome.failedTask = task
+				outcome.taskFitError = taskFitError
+				outcome.jobFitErrors = []common_info.JobFitError{
+					newFailedTaskAllocationError(job, task, index, taskFitError),
+				}
+			}
+			publishFitErrors(job, outcome)
+			return outcome
 		}
 	}
-	return true
+	return allocationOutcome{success: true, allocatedTasks: len(tasksToAllocate)}
 }
 
 func allocateTask(ssn *framework.Session, stmt *framework.Statement, nodes []*node_info.NodeInfo,
-	task *pod_info.PodInfo, isPipelineOnly bool) (success bool) {
+	task *pod_info.PodInfo, isPipelineOnly bool) (success bool, taskFitError *common_info.TasksFitErrors) {
 	job := ssn.ClusterInfo.PodGroupInfos[task.Job]
 	if job == nil {
 		log.InfraLogger.Errorf("Failed to find job <%s> in session <%s>", task.Job, ssn.ID)
-		return false
+		return false, nil
 	}
 	err := ssn.PrePredicateFn(task, job)
 	if err != nil {
 		log.InfraLogger.V(6).Infof("pre-predicates failed on task %s/%s. Error: %v",
 			task.Namespace, task.Name, err)
 
-		fitErrors := common_info.NewFitErrors()
-		fitErrors.SetError(err.Error())
-		job.AddTaskFitErrors(task, fitErrors)
-		return false
+		if !isPipelineOnly {
+			taskFitError = common_info.NewFitErrors()
+			taskFitError.SetError(err.Error())
+		}
+		return false, taskFitError
 	}
 
 	log.InfraLogger.V(6).Infof("Looking for best node for task - Task: <%s/%s>, init requested: <%v>.",
 		task.Namespace, task.Name, task.ResReqVector)
 
 	orderedNodes := ssn.OrderedNodesByTask(nodes, task)
+	var fitErrors *common_info.TasksFitErrors
+	hasFitErrors := false
+	if !isPipelineOnly {
+		fitErrors = common_info.NewFitErrors()
+	}
 	for _, node := range orderedNodes {
-		if !ssn.FittingNode(task, node, !isPipelineOnly) {
+		fits, fitError := ssn.FittingNode(task, node, !isPipelineOnly)
+		if fitErrors != nil && fitError != nil {
+			fitErrors.SetNodeError(node.Name, fitError)
+			hasFitErrors = true
+		}
+		if !fits {
 			continue
 		}
 		success = allocateTaskToNode(ssn, stmt, task, node, isPipelineOnly)
@@ -185,10 +265,13 @@ func allocateTask(ssn *framework.Session, stmt *framework.Statement, nodes []*no
 	if success {
 		log.InfraLogger.V(6).Infof("Allocation succeeded for task: <%v/%v>", task.Namespace, task.Name)
 	} else {
+		if hasFitErrors {
+			taskFitError = fitErrors
+		}
 		log.InfraLogger.V(6).Infof("Failed statement allocate for task: <%v/%v>", task.Namespace, task.Name)
 	}
 
-	return success
+	return success, taskFitError
 }
 
 func allocateTaskToNode(ssn *framework.Session, stmt *framework.Statement, task *pod_info.PodInfo, node *node_info.NodeInfo, isPipelineOnly bool) bool {
@@ -226,10 +309,13 @@ func pipelineTaskToNode(ssn *framework.Session, stmt *framework.Statement, task 
 	return true
 }
 
-func handleFailedTaskAllocation(job *podgroup_info.PodGroupInfo, unschedulableTask *pod_info.PodInfo, numSchedulableTasks int) {
-	allocationError, found := job.TasksFitErrors[unschedulableTask.UID]
-
-	if !found {
+func newFailedTaskAllocationError(
+	job *podgroup_info.PodGroupInfo,
+	unschedulableTask *pod_info.PodInfo,
+	numSchedulableTasks int,
+	allocationError *common_info.TasksFitErrors,
+) common_info.JobFitError {
+	if allocationError == nil {
 		allocationError = common_info.NewFitErrors()
 		allocationError.SetError(common_info.DefaultPodError)
 	}
@@ -242,26 +328,30 @@ func handleFailedTaskAllocation(job *podgroup_info.PodGroupInfo, unschedulableTa
 	taskSubGroup := job.GetAllPodSets()[taskSubGroupName]
 
 	if !gangScheduling || taskSubGroup.GetNumActiveUsedTasks() >= int(taskSubGroup.GetMinAvailable()) {
-		job.AddSimpleJobFitError(
-			podgroup_info.PodSchedulingErrors,
-			fmt.Sprintf("Resources were not found for pod %s/%s due to: %s",
-				unschedulableTask.Namespace, unschedulableTask.Name, allocationError.Error()))
-		return
+		return newPodSchedulingJobFitError(job, fmt.Sprintf("Resources were not found for pod %s/%s due to: %s",
+			unschedulableTask.Namespace, unschedulableTask.Name, allocationError.Error()))
 	}
 
 	if len(job.GetAllPodSets()) == 1 && taskSubGroup.GetName() == podgroup_info.DefaultSubGroup {
-		job.AddSimpleJobFitError(
-			podgroup_info.PodSchedulingErrors,
+		return newPodSchedulingJobFitError(job,
 			fmt.Sprintf("Resources were found for %d pods while %d are required for gang scheduling. "+
 				"Additional pods cannot be scheduled due to: %s",
 				numSchedulableTasks, taskSubGroup.GetMinAvailable(), allocationError.Error()))
-		return
 	}
-	job.AddSimpleJobFitError(
-		podgroup_info.PodSchedulingErrors,
+	return newPodSchedulingJobFitError(job,
 		fmt.Sprintf("Resources were found for %d pods from all sub-groups while sub-group %s requires %d pods for gang scheduling. "+
 			"Additional pods cannot be scheduled in this sub-group due to: %s",
 			numSchedulableTasks, taskSubGroup.GetName(), taskSubGroup.GetMinAvailable(), allocationError.Error()))
+}
+
+func newPodSchedulingJobFitError(job *podgroup_info.PodGroupInfo, message string) common_info.JobFitError {
+	return common_info.NewJobFitError(
+		job.Name,
+		podgroup_info.DefaultSubGroup,
+		job.Namespace,
+		podgroup_info.PodSchedulingErrors,
+		[]string{message},
+	)
 }
 
 func isGangScheduling(job *podgroup_info.PodGroupInfo) bool {

--- a/pkg/scheduler/actions/common/allocate.go
+++ b/pkg/scheduler/actions/common/allocate.go
@@ -50,7 +50,11 @@ func AllocateJob(ssn *framework.Session, stmt *framework.Statement, nodes []*nod
 		}
 		return false
 	}
-	return allocateSubGroupSet(ssn, stmt, nodes, job, job.RootSubGroupSet, tasksToAllocate, isPipelineOnly).success
+	outcome := allocateSubGroupSet(ssn, stmt, nodes, job, job.RootSubGroupSet, tasksToAllocate, isPipelineOnly)
+	if !outcome.success && !isPipelineOnly {
+		publishFitErrors(job, outcome)
+	}
+	return outcome.success
 }
 
 func publishFitErrors(job *podgroup_info.PodGroupInfo, outcome allocationOutcome) {
@@ -80,9 +84,7 @@ func allocateSubGroupSet(ssn *framework.Session, stmt *framework.Statement, node
 	}
 	nodeSets := subsetResult.NodeSets
 	if len(nodeSets) == 0 && len(subsetResult.FitErrors) != 0 {
-		outcome := allocationOutcome{jobFitErrors: subsetResult.FitErrors}
-		publishFitErrors(job, outcome)
-		return outcome
+		return allocationOutcome{jobFitErrors: subsetResult.FitErrors}
 	}
 
 	var bestFailure allocationOutcome
@@ -170,9 +172,7 @@ func allocatePodSet(ssn *framework.Session, stmt *framework.Statement, nodes nod
 	}
 	nodeSets := subsetResult.NodeSets
 	if len(nodeSets) == 0 && len(subsetResult.FitErrors) != 0 {
-		outcome := allocationOutcome{jobFitErrors: subsetResult.FitErrors}
-		publishFitErrors(job, outcome)
-		return outcome
+		return allocationOutcome{jobFitErrors: subsetResult.FitErrors}
 	}
 
 	var bestFailure allocationOutcome
@@ -209,7 +209,6 @@ func allocateTasksOnNodeSet(ssn *framework.Session, stmt *framework.Statement, n
 					newFailedTaskAllocationError(job, task, index, taskFitError),
 				}
 			}
-			publishFitErrors(job, outcome)
 			return outcome
 		}
 	}

--- a/pkg/scheduler/actions/common/allocate_test.go
+++ b/pkg/scheduler/actions/common/allocate_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestPipelineOnlyFailureDoesNotMutateFitErrors(t *testing.T) {
+	task := &pod_info.PodInfo{
+		UID:       "task",
+		Job:       "job",
+		Name:      "task",
+		Namespace: "namespace",
+	}
+	job := podgroup_info.NewPodGroupInfo(task.Job, task)
+	existingTaskError := common_info.NewFitErrors()
+	existingTaskError.SetError("existing task error")
+	job.AddTaskFitErrors(task, existingTaskError)
+	existingJobError := common_info.NewJobFitError(
+		job.Name, podgroup_info.DefaultSubGroup, job.Namespace,
+		podgroup_info.PodSchedulingErrors, []string{"existing job error"},
+	)
+	job.AddJobFitError(existingJobError)
+
+	clusterInfo := api.NewClusterInfo()
+	clusterInfo.PodGroupInfos[job.UID] = job
+	ssn := &framework.Session{ClusterInfo: clusterInfo}
+	ssn.AddPrePredicateFn(func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo) error {
+		return errors.New("simulation-only failure")
+	})
+
+	outcome := allocateTasksOnNodeSet(ssn, ssn.Statement(), nil, job, []*pod_info.PodInfo{task}, true)
+
+	require.False(t, outcome.success)
+	require.Same(t, existingTaskError, job.TasksFitErrors[task.UID])
+	require.Equal(t, []common_info.JobFitError{existingJobError}, job.JobFitErrors)
+}
+
+func TestSelectOutcomeByAllocatedTasks(t *testing.T) {
+	firstTask := &pod_info.PodInfo{UID: "first"}
+	secondTask := &pod_info.PodInfo{UID: "second"}
+	first := allocationOutcome{allocatedTasks: 1, failedTask: firstTask}
+	second := allocationOutcome{allocatedTasks: 2, failedTask: secondTask}
+
+	require.Same(t, secondTask, selectOutcomeByAllocatedTasks(first, second).failedTask)
+	require.Same(t, firstTask, selectOutcomeByAllocatedTasks(first, first).failedTask)
+}

--- a/pkg/scheduler/actions/integration_tests/allocate/allocate_fit_errors_test.go
+++ b/pkg/scheduler/actions/integration_tests/allocate/allocate_fit_errors_test.go
@@ -5,18 +5,22 @@ package allocate_test
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
@@ -58,6 +62,127 @@ func TestAllocateFitErrorsMixedPredicates(t *testing.T) {
 	assertPendingFitErrorMessage(t, ssn, numNodes*fitErrorBenchmarkGPUsPerNode,
 		"no nodes with enough resources were found: 5 node(s) didn't match Pod's node affinity/selector. \n"+
 			"5 node(s) had no matching persistent volumes.")
+}
+
+func TestAllocateJobDiscardsFailedAlternativeDiagnosticsAfterSuccess(t *testing.T) {
+	ssn, job, nodes := buildAlternativeAllocationSession(t, 2, 2)
+	addAlternativeNodeSets(ssn, nodes)
+
+	require.True(t, common.AllocateJob(ssn, ssn.Statement(), nodes, job, false))
+	require.Empty(t, job.TasksFitErrors)
+	require.Empty(t, job.JobFitErrors)
+}
+
+func TestAllocateJobPublishesBestFailedAlternative(t *testing.T) {
+	ssn, job, nodes := buildAlternativeAllocationSession(t, 3, 2)
+	addAlternativeNodeSets(ssn, nodes)
+
+	require.False(t, common.AllocateJob(ssn, ssn.Statement(), nodes, job, false))
+	require.Len(t, job.TasksFitErrors, 1)
+	for _, taskFitError := range job.TasksFitErrors {
+		require.Contains(t, taskFitError.Error(), "2 node(s) didn't have enough resources: GPUs")
+	}
+	require.Len(t, job.JobFitErrors, 1)
+	require.Contains(t, job.JobFitErrors[0].DetailedMessage(),
+		"Resources were found for 2 pods while 3 are required for gang scheduling")
+}
+
+func TestPipelineOnlyAllocateJobDoesNotMutateFitErrors(t *testing.T) {
+	ssn, job, nodes := buildAlternativeAllocationSession(t, 3, 2)
+	task := job.GetAllPodsMap()["job-0"]
+	existingTaskError := common_info.NewFitErrors()
+	existingTaskError.SetError("existing task error")
+	job.AddTaskFitErrors(task, existingTaskError)
+	existingJobError := common_info.NewJobFitError(
+		job.Name, podgroup_info.DefaultSubGroup, job.Namespace,
+		podgroup_info.PodSchedulingErrors, []string{"existing job error"},
+	)
+	job.AddJobFitError(existingJobError)
+
+	require.False(t, common.AllocateJob(ssn, ssn.Statement(), nodes, job, true))
+	require.Same(t, existingTaskError, job.TasksFitErrors[task.UID])
+	require.Equal(t, []common_info.JobFitError{existingJobError}, job.JobFitErrors)
+}
+
+func TestAllocateJobFailurePreservesExistingFitErrors(t *testing.T) {
+	ssn, job, nodes := buildAlternativeAllocationSession(t, 3, 2)
+	addAlternativeNodeSets(ssn, nodes)
+	failedTask := job.GetAllPodsMap()["job-2"]
+	existingTaskError := common_info.NewFitErrors()
+	existingTaskError.SetNodeError("existing-node", common_info.NewFitError(
+		failedTask.Name, failedTask.Namespace, "existing-node", "existing task error"))
+	job.AddTaskFitErrors(failedTask, existingTaskError)
+	existingJobError := common_info.NewJobFitError(
+		job.Name, podgroup_info.DefaultSubGroup, job.Namespace,
+		podgroup_info.PodSchedulingErrors, []string{"existing job error"},
+	)
+	job.AddJobFitError(existingJobError)
+
+	require.False(t, common.AllocateJob(ssn, ssn.Statement(), nodes, job, false))
+
+	require.Same(t, existingTaskError, job.TasksFitErrors[failedTask.UID])
+	require.Contains(t, existingTaskError.Error(), "existing task error")
+	require.Contains(t, existingTaskError.Error(), "2 node(s) didn't have enough resources: GPUs")
+	require.Len(t, job.JobFitErrors, 2)
+	require.Equal(t, existingJobError, job.JobFitErrors[0])
+}
+
+func buildAlternativeAllocationSession(
+	t *testing.T,
+	taskCount int,
+	nodeCount int,
+) (*framework.Session, *podgroup_info.PodGroupInfo, []*node_info.NodeInfo) {
+	t.Helper()
+	test_utils.InitTestingInfrastructure()
+	controller := gomock.NewController(t)
+	t.Cleanup(controller.Finish)
+
+	root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+	root.AddPodSet(subgroup_info.NewPodSet(podgroup_info.DefaultSubGroup, int32(taskCount), nil))
+	tasks := make([]*tasks_fake.TestTaskBasic, taskCount)
+	for index := range tasks {
+		tasks[index] = &tasks_fake.TestTaskBasic{State: pod_status.Pending}
+	}
+	nodeSpecs := make(map[string]nodes_fake.TestNodeBasic, nodeCount)
+	for index := range nodeCount {
+		nodeSpecs[fmt.Sprintf("alternative-node-%d", index)] = nodes_fake.TestNodeBasic{GPUs: 1}
+	}
+	topology := test_utils.TestTopologyBasic{
+		Name:  "alternative allocation fit errors",
+		Nodes: nodeSpecs,
+		Jobs: []*jobs_fake.TestJobBasic{{
+			Name:                "job",
+			QueueName:           "queue",
+			Priority:            constants.PriorityTrainNumber,
+			RequiredGPUsPerTask: 1,
+			RootSubGroupSet:     root,
+			Tasks:               tasks,
+		}},
+		Queues: []test_utils.TestQueueBasic{{Name: "queue", DeservedGPUs: 100}},
+		Mocks:  &test_utils.TestMock{CacheRequirements: &test_utils.CacheMocking{}},
+	}
+	ssn := test_utils.BuildSession(topology, controller)
+	nodes := make([]*node_info.NodeInfo, 0, len(ssn.ClusterInfo.Nodes))
+	for _, node := range ssn.ClusterInfo.Nodes {
+		nodes = append(nodes, node)
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
+	return ssn, ssn.ClusterInfo.PodGroupInfos["job"], nodes
+}
+
+func addAlternativeNodeSets(ssn *framework.Session, nodes []*node_info.NodeInfo) {
+	ssn.AddSubsetNodesFn(func(
+		_ *podgroup_info.PodGroupInfo,
+		subGroup *subgroup_info.SubGroupInfo,
+		_ map[string]*subgroup_info.PodSet,
+		_ []*pod_info.PodInfo,
+		nodeSet node_info.NodeSet,
+	) ([]node_info.NodeSet, error) {
+		if subGroup.GetName() != podgroup_info.DefaultSubGroup {
+			return []node_info.NodeSet{nodeSet}, nil
+		}
+		return []node_info.NodeSet{nodes[:1], nodes}, nil
+	})
 }
 
 func buildResourceFullFitErrorTopology(numNodes int) test_utils.TestTopologyBasic {

--- a/pkg/scheduler/actions/integration_tests/allocate/allocate_fit_errors_test.go
+++ b/pkg/scheduler/actions/integration_tests/allocate/allocate_fit_errors_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -177,11 +178,12 @@ func addAlternativeNodeSets(ssn *framework.Session, nodes []*node_info.NodeInfo)
 		_ map[string]*subgroup_info.PodSet,
 		_ []*pod_info.PodInfo,
 		nodeSet node_info.NodeSet,
-	) ([]node_info.NodeSet, error) {
+		_ bool,
+	) (api.SubsetNodesResult, error) {
 		if subGroup.GetName() != podgroup_info.DefaultSubGroup {
-			return []node_info.NodeSet{nodeSet}, nil
+			return api.SubsetNodesResult{NodeSets: []node_info.NodeSet{nodeSet}}, nil
 		}
-		return []node_info.NodeSet{nodes[:1], nodes}, nil
+		return api.SubsetNodesResult{NodeSets: []node_info.NodeSet{nodes[:1], nodes}}, nil
 	})
 }
 

--- a/pkg/scheduler/actions/integration_tests/allocate/allocate_fit_errors_test.go
+++ b/pkg/scheduler/actions/integration_tests/allocate/allocate_fit_errors_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package allocate_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/allocate"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+const (
+	fitErrorBenchmarkRunningQueue = "fit-error-running-queue"
+	fitErrorBenchmarkPendingQueue = "fit-error-pending-queue"
+	fitErrorBenchmarkDepartment   = "fit-error-department"
+	fitErrorBenchmarkGPUsPerNode  = 8
+)
+
+func TestAllocateFitErrorsResourceFull(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const numNodes = 10
+	ssn := test_utils.BuildSession(buildResourceFullFitErrorTopology(numNodes), ctrl)
+	allocate.New().Execute(ssn)
+
+	assertPendingFitErrorMessage(t, ssn, numNodes*fitErrorBenchmarkGPUsPerNode,
+		fmt.Sprintf("no nodes with enough resources were found: %d node(s) didn't have enough resources: GPUs.", numNodes))
+}
+
+func TestAllocateFitErrorsMixedPredicates(t *testing.T) {
+	test_utils.InitTestingInfrastructure()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const numNodes = 10
+	ssn := test_utils.BuildSession(buildPredicateFitErrorTopology(numNodes), ctrl)
+	addMixedFailurePredicate(ssn)
+	allocate.New().Execute(ssn)
+
+	assertPendingFitErrorMessage(t, ssn, numNodes*fitErrorBenchmarkGPUsPerNode,
+		"no nodes with enough resources were found: 5 node(s) didn't match Pod's node affinity/selector. \n"+
+			"5 node(s) had no matching persistent volumes.")
+}
+
+func buildResourceFullFitErrorTopology(numNodes int) test_utils.TestTopologyBasic {
+	totalGPUs := numNodes * fitErrorBenchmarkGPUsPerNode
+	nodes := make(map[string]nodes_fake.TestNodeBasic, numNodes)
+	for nodeIndex := range numNodes {
+		nodes[fmt.Sprintf("node-%d", nodeIndex)] = nodes_fake.TestNodeBasic{GPUs: fitErrorBenchmarkGPUsPerNode}
+	}
+
+	jobs := make([]*jobs_fake.TestJobBasic, 0, totalGPUs*2)
+	for jobIndex := range totalGPUs {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("running-job-%d", jobIndex),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           fitErrorBenchmarkRunningQueue,
+			Tasks: []*tasks_fake.TestTaskBasic{{
+				State:    pod_status.Running,
+				NodeName: fmt.Sprintf("node-%d", jobIndex/fitErrorBenchmarkGPUsPerNode),
+			}},
+		})
+	}
+	jobs = append(jobs, buildPendingFitErrorJobs(totalGPUs)...)
+	return fitErrorBenchmarkTopology("resource full fit errors", nodes, jobs, totalGPUs)
+}
+
+func buildPredicateFitErrorTopology(numNodes int) test_utils.TestTopologyBasic {
+	totalPendingTasks := numNodes * fitErrorBenchmarkGPUsPerNode
+	nodes := make(map[string]nodes_fake.TestNodeBasic, numNodes)
+	for nodeIndex := range numNodes {
+		nodes[fmt.Sprintf("node-%d", nodeIndex)] = nodes_fake.TestNodeBasic{GPUs: fitErrorBenchmarkGPUsPerNode}
+	}
+	return fitErrorBenchmarkTopology(
+		"mixed predicate fit errors", nodes, buildPendingFitErrorJobs(totalPendingTasks), totalPendingTasks)
+}
+
+func buildPendingFitErrorJobs(count int) []*jobs_fake.TestJobBasic {
+	jobs := make([]*jobs_fake.TestJobBasic, 0, count)
+	for jobIndex := range count {
+		jobs = append(jobs, &jobs_fake.TestJobBasic{
+			Name:                fmt.Sprintf("pending-job-%d", jobIndex),
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           fitErrorBenchmarkPendingQueue,
+			Tasks:               []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+		})
+	}
+	return jobs
+}
+
+func fitErrorBenchmarkTopology(
+	name string,
+	nodes map[string]nodes_fake.TestNodeBasic,
+	jobs []*jobs_fake.TestJobBasic,
+	deservedGPUs int,
+) test_utils.TestTopologyBasic {
+	return test_utils.TestTopologyBasic{
+		Name:  name,
+		Nodes: nodes,
+		Jobs:  jobs,
+		Queues: []test_utils.TestQueueBasic{
+			{
+				Name:               fitErrorBenchmarkRunningQueue,
+				ParentQueue:        fitErrorBenchmarkDepartment,
+				DeservedGPUs:       float64(deservedGPUs),
+				GPUOverQuotaWeight: 1,
+			},
+			{
+				Name:               fitErrorBenchmarkPendingQueue,
+				ParentQueue:        fitErrorBenchmarkDepartment,
+				DeservedGPUs:       float64(deservedGPUs),
+				GPUOverQuotaWeight: 1,
+			},
+		},
+		Departments: []test_utils.TestDepartmentBasic{{
+			Name:         fitErrorBenchmarkDepartment,
+			DeservedGPUs: float64(deservedGPUs * 2),
+		}},
+	}
+}
+
+func addMixedFailurePredicate(ssn *framework.Session) {
+	ssn.AddPredicateFn(func(
+		task *pod_info.PodInfo,
+		_ *podgroup_info.PodGroupInfo,
+		node *node_info.NodeInfo,
+	) error {
+		index, err := strconv.Atoi(strings.TrimPrefix(node.Name, "node-"))
+		if err != nil {
+			return err
+		}
+		if index%2 == 0 {
+			return common_info.NewFitError(task.Name, task.Namespace, node.Name,
+				"node(s) didn't match Pod's node affinity/selector")
+		}
+		return common_info.NewFitError(task.Name, task.Namespace, node.Name,
+			"node(s) had no matching persistent volumes")
+	})
+}
+
+func assertPendingFitErrorMessage(
+	t testing.TB,
+	ssn *framework.Session,
+	expectedPendingJobs int,
+	expectedMessage string,
+) {
+	t.Helper()
+	pendingJobs := 0
+	for _, job := range ssn.ClusterInfo.PodGroupInfos {
+		if strings.HasPrefix(job.Name, "pending-job-") {
+			pendingJobs++
+		}
+	}
+	if pendingJobs != expectedPendingJobs {
+		t.Fatalf("pending jobs = %d, want %d", pendingJobs, expectedPendingJobs)
+	}
+
+	pendingJob := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID("pending-job-0")]
+	if pendingJob == nil {
+		t.Fatal("expected pending-job-0 to exist")
+	}
+	task := pendingJob.PodStatusIndex[pod_status.Pending]["pending-job-0-0"]
+	if task == nil {
+		t.Fatal("expected pending-job-0-0 to remain pending")
+	}
+	fitErrors := pendingJob.TasksFitErrors[task.UID]
+	if fitErrors == nil {
+		t.Fatal("expected pending task to have fit errors")
+	}
+	if got := fitErrors.Error(); got != expectedMessage {
+		t.Fatalf("fitErrors.Error() = %q, want %q", got, expectedMessage)
+	}
+}

--- a/pkg/scheduler/api/common_info/pod_errors.go
+++ b/pkg/scheduler/api/common_info/pod_errors.go
@@ -188,6 +188,9 @@ func (f *TasksFitErrors) SetNodeError(nodeName string, err error) {
 	var fe *TasksFitError
 	switch obj := err.(type) {
 	case *TasksFitError:
+		if obj == nil {
+			return
+		}
 		obj.NodeName = nodeName
 		fe = obj
 	default:

--- a/pkg/scheduler/api/common_info/pod_errors_test.go
+++ b/pkg/scheduler/api/common_info/pod_errors_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
@@ -39,6 +41,15 @@ func TestFitErrors_Error(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFitErrorsSetNodeErrorIgnoresTypedNil(t *testing.T) {
+	fitErrors := NewFitErrors()
+	var fitError *TasksFitError
+
+	fitErrors.SetNodeError("node-a", fitError)
+
+	assert.Equal(t, ResourcesWereNotFoundMsg, fitErrors.Error())
 }
 
 func TestNewFitErrorInsufficientResource(t *testing.T) {

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -21,6 +21,7 @@ package api
 
 import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -29,9 +30,16 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
+// SubsetNodesResult contains surviving node sets and diagnostics when none survive.
+type SubsetNodesResult struct {
+	NodeSets  []node_info.NodeSet
+	FitErrors []common_info.JobFitError
+}
+
 // SubsetNodesFn is used to divide the nodes into sets
 type SubsetNodesFn func(podGroup *podgroup_info.PodGroupInfo, subGroup *subgroup_info.SubGroupInfo,
-	podSets map[string]*subgroup_info.PodSet, tasks []*pod_info.PodInfo, nodeSet node_info.NodeSet) ([]node_info.NodeSet, error)
+	podSets map[string]*subgroup_info.PodSet, tasks []*pod_info.PodInfo, nodeSet node_info.NodeSet,
+	collectFitErrors bool) (SubsetNodesResult, error)
 
 // PredicateFn is used to predicate node for task.
 type PredicateFn func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo, *node_info.NodeInfo) error

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -223,23 +223,19 @@ func (ssn *Session) sortGPUs(filteredGPUs []string, pod *pod_info.PodInfo, node 
 	return sortedGPUs
 }
 
-func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo, writeFittingDelta bool) bool {
-	var fitErrors *common_info.TasksFitErrors
-	if writeFittingDelta {
-		fitErrors = common_info.NewFitErrors()
-	}
-
+func (ssn *Session) FittingNode(
+	task *pod_info.PodInfo, node *node_info.NodeInfo, collectFitError bool,
+) (bool, error) {
 	job := ssn.ClusterInfo.PodGroupInfos[task.Job]
 
 	log.InfraLogger.V(6).Infof("Checking if task <%v/%v> is allocatable on node <%v>: <%v> vs. <%v>",
 		task.Namespace, task.Name, node.Name, task.ResReqVector, node.IdleVector)
-	allocatable, fitError := ssn.isTaskAllocatableOnNode(task, job, node, writeFittingDelta)
+	allocatable, fitError := ssn.isTaskAllocatableOnNode(task, job, node, collectFitError)
 	if !allocatable {
-		if fitError != nil && writeFittingDelta {
-			fitErrors.SetNodeError(node.Name, fitError)
-			job.AddTaskFitErrors(task, fitErrors)
+		if collectFitError {
+			return false, fitError
 		}
-		return false
+		return false, nil
 	}
 
 	log.InfraLogger.V(6).Infof("Running predicates for task <%v/%v> on node <%v>",
@@ -247,13 +243,12 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 	if err := ssn.PredicateFn(task, job, node); err != nil {
 		log.InfraLogger.V(6).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
 			task.Namespace, task.Name, node.Name, err)
-		if writeFittingDelta {
-			fitErrors.SetNodeError(node.Name, err)
-			job.AddTaskFitErrors(task, fitErrors)
+		if collectFitError {
+			return false, err
 		}
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // OrderedNodesByTask scores nodes for a task and returns them in order of their scores

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -378,24 +378,30 @@ func (ssn *Session) IsTaskAllocationOnNodeOverCapacityFn(task *pod_info.PodInfo,
 func (ssn *Session) SubsetNodesFn(
 	podGroup *podgroup_info.PodGroupInfo, subGroupInfo *subgroup_info.SubGroupInfo,
 	podSets map[string]*subgroup_info.PodSet, tasks []*pod_info.PodInfo, initNodeSet node_info.NodeSet,
-) ([]node_info.NodeSet, error) {
+	collectFitErrors bool,
+) (api.SubsetNodesResult, error) {
 	nodeSets := []node_info.NodeSet{initNodeSet}
 	for _, subsetNodesFn := range ssn.SubsetNodesFns {
 		log.InfraLogger.V(7).Infof(
 			"Running plugin func <%v> on podGroup <%s/%s>", subsetNodesFn, podGroup.Namespace, podGroup.Namespace)
 		var newNodeSets []node_info.NodeSet
+		var fitErrors []common_info.JobFitError
 		for _, nodeSet := range nodeSets {
-			nodeSubsets, err := subsetNodesFn(podGroup, subGroupInfo, podSets, tasks, nodeSet)
+			result, err := subsetNodesFn(podGroup, subGroupInfo, podSets, tasks, nodeSet, collectFitErrors)
 			if err != nil {
-				return nil, err
+				return api.SubsetNodesResult{}, err
 			}
-			newNodeSets = append(newNodeSets, nodeSubsets...)
+			newNodeSets = append(newNodeSets, result.NodeSets...)
+			fitErrors = append(fitErrors, result.FitErrors...)
 		}
 		nodeSets = newNodeSets
+		if len(nodeSets) == 0 {
+			return api.SubsetNodesResult{FitErrors: fitErrors}, nil
+		}
 
 		logNodeSetsPluginResult(subsetNodesFn, podGroup, nodeSets)
 	}
-	return nodeSets, nil
+	return api.SubsetNodesResult{NodeSets: nodeSets}, nil
 }
 
 func logNodeSetsPluginResult(subsetNodesFn api.SubsetNodesFn, podGroup *podgroup_info.PodGroupInfo, nodeSets []node_info.NodeSet) {

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -157,7 +157,7 @@ func TestPartitionMultiImplementation(t *testing.T) {
 		},
 	}
 
-	shardClusterSubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupInfo, _ map[string]*subgroup_info.PodSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet) ([]node_info.NodeSet, error) {
+	shardClusterSubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupInfo, _ map[string]*subgroup_info.PodSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet, _ bool) (api.SubsetNodesResult, error) {
 		var subset1 []*node_info.NodeInfo
 		var subset2 []*node_info.NodeInfo
 		for _, node := range nodeset {
@@ -167,10 +167,10 @@ func TestPartitionMultiImplementation(t *testing.T) {
 				subset2 = append(subset2, node)
 			}
 		}
-		return []node_info.NodeSet{subset1, subset2}, nil
+		return api.SubsetNodesResult{NodeSets: []node_info.NodeSet{subset1, subset2}}, nil
 	}
 
-	topologySubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupInfo, _ map[string]*subgroup_info.PodSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet) ([]node_info.NodeSet, error) {
+	topologySubseting := func(_ *podgroup_info.PodGroupInfo, _ *subgroup_info.SubGroupInfo, _ map[string]*subgroup_info.PodSet, _ []*pod_info.PodInfo, nodeset node_info.NodeSet, _ bool) (api.SubsetNodesResult, error) {
 		var subset1 []*node_info.NodeInfo
 		var subset2 []*node_info.NodeInfo
 		for _, node := range nodeset {
@@ -180,7 +180,7 @@ func TestPartitionMultiImplementation(t *testing.T) {
 				subset2 = append(subset2, node)
 			}
 		}
-		return []node_info.NodeSet{subset1, subset2}, nil
+		return api.SubsetNodesResult{NodeSets: []node_info.NodeSet{subset1, subset2}}, nil
 	}
 
 	ssn := &Session{}
@@ -188,7 +188,8 @@ func TestPartitionMultiImplementation(t *testing.T) {
 	ssn.AddSubsetNodesFn(shardClusterSubseting)
 	ssn.AddSubsetNodesFn(topologySubseting)
 
-	partitions, _ := ssn.SubsetNodesFn(podgroup_info.NewPodGroupInfo("a"), nil, nil, nil, nodes)
+	result, _ := ssn.SubsetNodesFn(podgroup_info.NewPodGroupInfo("a"), nil, nil, nil, nodes, false)
+	partitions := result.NodeSets
 
 	assert.Equal(t, 4, len(partitions))
 

--- a/pkg/scheduler/plugins/topology/job_filtering.go
+++ b/pkg/scheduler/plugins/topology/job_filtering.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -31,48 +32,54 @@ type jobAllocationMetaData struct {
 
 func (t *topologyPlugin) subSetNodesFn(
 	job *podgroup_info.PodGroupInfo, subGroup *subgroup_info.SubGroupInfo, podSets map[string]*subgroup_info.PodSet,
-	tasks []*pod_info.PodInfo, nodeSet node_info.NodeSet,
-) ([]node_info.NodeSet, error) {
+	tasks []*pod_info.PodInfo, nodeSet node_info.NodeSet, collectFitErrors bool,
+) (api.SubsetNodesResult, error) {
 	topologyTree, found := t.getJobTopology(subGroup)
 	if !found {
-		job.AddSimpleJobFitError(
-			podgroup_info.PodSchedulingErrors,
-			fmt.Sprintf("Requested topology %s does not exist", subGroup.GetTopologyConstraint().Topology))
-		return []node_info.NodeSet{}, nil
+		result := api.SubsetNodesResult{}
+		if collectFitErrors {
+			result.FitErrors = []common_info.JobFitError{newTopologyPodSchedulingError(
+				job, fmt.Sprintf("Requested topology %s does not exist", subGroup.GetTopologyConstraint().Topology),
+			)}
+		}
+		return result, nil
 	}
 	if topologyTree == nil || len(tasks) == 0 {
-		return []node_info.NodeSet{nodeSet}, nil
+		return api.SubsetNodesResult{NodeSets: []node_info.NodeSet{nodeSet}}, nil
 	}
 
 	id, level, validNodes := lowestCommonDomainID(nodeSet, topologyTree.TopologyResource.Spec.Levels, subGroup.GetTopologyConstraint())
 	domain, ok := topologyTree.DomainsByLevel[level][id]
 	if !ok {
-		return nil, fmt.Errorf("domain not found for node set in topology %s", topologyTree.Name)
+		return api.SubsetNodesResult{}, fmt.Errorf("domain not found for node set in topology %s", topologyTree.Name)
 	}
 
 	t.treeAllocatableCleanup(topologyTree)
 	calcSubTreeFreeResources(domain)
 	if useRepresentorPodsAccounting(tasks) {
 		if err := t.calcTreeAllocatable(tasks, domain); err != nil {
-			return nil, err
+			return api.SubsetNodesResult{}, err
 		}
 	}
 
 	tasksResources, tasksCount := getTasksAllocationMetadata(tasks)
 
-	if err := checkJobDomainFit(job, subGroup, tasksResources, tasksCount, domain, topologyTree.VectorMap); err != nil {
-		if domain.ID == rootDomainId {
-			job.AddSimpleJobFitError(
-				podgroup_info.PodSchedulingErrors,
-				getNoTopologyMatchError(job, subGroup, topologyTree, "not enough resources in the cluster to allocate the job").Error())
-
-		} else {
-			job.AddSimpleJobFitError(
-				podgroup_info.PodSchedulingErrors,
-				getNoTopologyMatchError(job, subGroup, topologyTree,
-					fmt.Sprintf("not enough resources in %s to allocate the job", string(domain.ID))).Error())
+	if !jobFitsDomain(tasksResources, tasksCount, domain, topologyTree.VectorMap) {
+		result := api.SubsetNodesResult{}
+		if !collectFitErrors {
+			return result, nil
 		}
-		return []node_info.NodeSet{}, nil
+		var message string
+		if domain.ID == rootDomainId {
+			message = getNoTopologyMatchError(
+				job, subGroup, topologyTree, "not enough resources in the cluster to allocate the job",
+			).Error()
+		} else {
+			message = getNoTopologyMatchError(job, subGroup, topologyTree,
+				fmt.Sprintf("not enough resources in %s to allocate the job", string(domain.ID))).Error()
+		}
+		result.FitErrors = []common_info.JobFitError{newTopologyPodSchedulingError(job, message)}
+		return result, nil
 	}
 
 	// Sorting the tree for both packing and closest preferred level domain scoring
@@ -87,9 +94,11 @@ func (t *topologyPlugin) subSetNodesFn(
 		t.subGroupNodeScores[subGroup.GetName()] = calculateNodeScores(domain, preferredLevel)
 	}
 
-	jobAllocatableDomains, err := t.getJobAllocatableDomains(job, subGroup, podSets, tasksResources, tasksCount, topologyTree)
+	jobAllocatableDomains, fitErrors, err := t.getJobAllocatableDomains(
+		job, subGroup, podSets, tasksResources, tasksCount, topologyTree, collectFitErrors,
+	)
 	if err != nil {
-		return nil, err
+		return api.SubsetNodesResult{}, err
 	}
 
 	jobAllocatableDomains = sortDomainInfos(topologyTree, jobAllocatableDomains)
@@ -106,7 +115,17 @@ func (t *topologyPlugin) subSetNodesFn(
 		domainNodeSets = append(domainNodeSets, domainNodeSet)
 	}
 
-	return domainNodeSets, nil
+	return api.SubsetNodesResult{NodeSets: domainNodeSets, FitErrors: fitErrors}, nil
+}
+
+func newTopologyPodSchedulingError(job *podgroup_info.PodGroupInfo, message string) common_info.JobFitError {
+	return common_info.NewJobFitError(
+		job.Name,
+		podgroup_info.DefaultSubGroup,
+		job.Namespace,
+		podgroup_info.PodSchedulingErrors,
+		[]string{message},
+	)
 }
 
 func getTasksAllocationMetadata(tasks []*pod_info.PodInfo) (resource_info.ResourceVector, int) {
@@ -254,11 +273,11 @@ func calcNodeAccommodation(jobAllocationMetaData *jobAllocationMetaData, node *n
 
 func (t *topologyPlugin) getJobAllocatableDomains(
 	job *podgroup_info.PodGroupInfo, subGroup *subgroup_info.SubGroupInfo, podSets map[string]*subgroup_info.PodSet,
-	tasksResources resource_info.ResourceVector, tasksCount int, topologyTree *Info,
-) ([]*DomainInfo, error) {
+	tasksResources resource_info.ResourceVector, tasksCount int, topologyTree *Info, collectFitErrors bool,
+) ([]*DomainInfo, []common_info.JobFitError, error) {
 	relevantLevels, err := t.calculateRelevantDomainLevels(subGroup, topologyTree)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate that the domains do not clash with the chosen domain for active pods of the job
@@ -274,10 +293,10 @@ func (t *topologyPlugin) getJobAllocatableDomains(
 	var topLevelFitErrors []common_info.JobFitError
 	for levelIndex, level := range relevantLevels {
 		for _, domain := range relevantDomainsByLevel[level] {
-			err := checkJobDomainFit(job, subGroup, tasksResources, tasksCount, domain, topologyTree.VectorMap)
-			if err != nil { // Filter domains that cannot allocate the job
-				if levelIndex == len(relevantLevels)-1 {
-					topLevelFitErrors = append(topLevelFitErrors, err)
+			if !jobFitsDomain(tasksResources, tasksCount, domain, topologyTree.VectorMap) {
+				if collectFitErrors && levelIndex == len(relevantLevels)-1 {
+					topLevelFitErrors = append(topLevelFitErrors,
+						checkJobDomainFit(job, subGroup, tasksResources, tasksCount, domain, topologyTree.VectorMap))
 				}
 				continue
 			}
@@ -287,16 +306,15 @@ func (t *topologyPlugin) getJobAllocatableDomains(
 	}
 
 	if len(domains) == 0 {
-		for _, fitError := range topLevelFitErrors {
-			job.AddJobFitError(fitError)
+		if !collectFitErrors {
+			return []*DomainInfo{}, nil, nil
 		}
-		job.AddSimpleJobFitError(
-			podgroup_info.PodSchedulingErrors,
-			getNoTopologyMatchError(job, subGroup, topologyTree).Error())
-		return []*DomainInfo{}, nil
+		topLevelFitErrors = append(topLevelFitErrors,
+			newTopologyPodSchedulingError(job, getNoTopologyMatchError(job, subGroup, topologyTree).Error()))
+		return []*DomainInfo{}, topLevelFitErrors, nil
 	}
 
-	return domains, nil
+	return domains, nil, nil
 }
 
 func hasActiveAllocatedTasks(podSets map[string]*subgroup_info.PodSet) bool {
@@ -352,21 +370,29 @@ func hasTopologyRequiredConstraint(subGroup *subgroup_info.SubGroupInfo) bool {
 func checkJobDomainFit(job *podgroup_info.PodGroupInfo, subGroup *subgroup_info.SubGroupInfo,
 	tasksResources resource_info.ResourceVector, tasksCount int, domain *DomainInfo,
 	vectorMap *resource_info.ResourceVectorMap) *common_info.TopologyFitError {
-	if domain.AllocatablePods != allocatablePodsNotSet {
-		if domain.AllocatablePods < tasksCount {
-			return common_info.NewTopologyFitError(
-				job.Name, subGroup.GetName(), job.Namespace, string(domain.ID), common_info.UnschedulableWorkloadReason,
-				[]string{fmt.Sprintf("node-group %s can allocate only %d of %d required pods", domain.ID, domain.AllocatablePods, tasksCount)})
-		}
+	if jobFitsDomain(tasksResources, tasksCount, domain, vectorMap) {
 		return nil
 	}
-
-	if getJobRatioToFreeResources(tasksResources, domain, vectorMap) > maxAllocatableTasksRatio {
-		err := common_info.NewTopologyInsufficientResourcesError(
-			job.Name, subGroup.GetName(), job.Namespace, string(domain.ID), tasksResources, domain.IdleOrReleasingVector, vectorMap)
-		return err
+	if domain.AllocatablePods != allocatablePodsNotSet {
+		return common_info.NewTopologyFitError(
+			job.Name, subGroup.GetName(), job.Namespace, string(domain.ID), common_info.UnschedulableWorkloadReason,
+			[]string{fmt.Sprintf("node-group %s can allocate only %d of %d required pods", domain.ID, domain.AllocatablePods, tasksCount)})
 	}
-	return nil
+
+	return common_info.NewTopologyInsufficientResourcesError(
+		job.Name, subGroup.GetName(), job.Namespace, string(domain.ID), tasksResources, domain.IdleOrReleasingVector, vectorMap)
+}
+
+func jobFitsDomain(
+	tasksResources resource_info.ResourceVector,
+	tasksCount int,
+	domain *DomainInfo,
+	vectorMap *resource_info.ResourceVectorMap,
+) bool {
+	if domain.AllocatablePods != allocatablePodsNotSet {
+		return domain.AllocatablePods >= tasksCount
+	}
+	return getJobRatioToFreeResources(tasksResources, domain, vectorMap) <= maxAllocatableTasksRatio
 }
 
 func (*topologyPlugin) calculateRelevantDomainLevels(

--- a/pkg/scheduler/plugins/topology/job_filtering_test.go
+++ b/pkg/scheduler/plugins/topology/job_filtering_test.go
@@ -602,9 +602,10 @@ func TestTopologyPlugin_subsetNodesFn(t *testing.T) {
 			}
 
 			// Call the function under test
-			subsets, err := plugin.subSetNodesFn(job, &job.RootSubGroupSet.SubGroupInfo,
+			result, err := plugin.subSetNodesFn(job, &job.RootSubGroupSet.SubGroupInfo,
 				job.RootSubGroupSet.GetDescendantPodSets(), podgroup_info.GetTasksToAllocate(job, nil, nil, true),
-				maps.Values(nodesInfoMap))
+				maps.Values(nodesInfoMap), true)
+			subsets := result.NodeSets
 
 			// Check error
 			if tt.expectedError != "" {
@@ -619,12 +620,20 @@ func TestTopologyPlugin_subsetNodesFn(t *testing.T) {
 			}
 
 			if tt.expectedJobFitError != "" {
-				if len(job.JobFitErrors) == 0 {
+				if len(result.FitErrors) == 0 {
 					t.Errorf("expected job fit error '%s', but got nil", tt.expectedJobFitError)
 				}
-				if job.JobFitErrors[0].Messages()[0] != tt.expectedJobFitError {
-					t.Errorf("expected job fit error '%s', but got '%s'", tt.expectedJobFitError, job.JobFitErrors[0].Messages()[0])
+				if result.FitErrors[0].Messages()[0] != tt.expectedJobFitError {
+					t.Errorf("expected job fit error '%s', but got '%s'", tt.expectedJobFitError, result.FitErrors[0].Messages()[0])
 				}
+				assert.Empty(t, job.JobFitErrors)
+
+				withoutFitErrors, disabledErr := plugin.subSetNodesFn(job, &job.RootSubGroupSet.SubGroupInfo,
+					job.RootSubGroupSet.GetDescendantPodSets(), podgroup_info.GetTasksToAllocate(job, nil, nil, true),
+					maps.Values(nodesInfoMap), false)
+				assert.NoError(t, disabledErr)
+				assert.Empty(t, withoutFitErrors.FitErrors)
+				assert.Empty(t, job.JobFitErrors)
 			}
 
 			if err != nil {
@@ -2189,9 +2198,9 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 			}
 			tasksCount := len(tasks)
 
-			result, err := plugin.getJobAllocatableDomains(job, &job.RootSubGroupSet.SubGroupInfo,
+			result, fitErrors, err := plugin.getJobAllocatableDomains(job, &job.RootSubGroupSet.SubGroupInfo,
 				job.RootSubGroupSet.GetDescendantPodSets(), tasksResources.ToVector(testVectorMap), tasksCount,
-				tt.topologyTree)
+				tt.topologyTree, true)
 
 			// Check error
 			if tt.expectedError != "" {
@@ -2202,12 +2211,12 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 				if err.Error() != tt.expectedError {
 					t.Errorf("expected error '%s', but got '%s'", tt.expectedError, err.Error())
 				}
-				if len(job.JobFitErrors) != len(tt.expectedFitErrors) {
-					t.Errorf("expected %d fit errors, but got %d", len(tt.expectedFitErrors), len(job.JobFitErrors))
+				if len(fitErrors) != len(tt.expectedFitErrors) {
+					t.Errorf("expected %d fit errors, but got %d", len(tt.expectedFitErrors), len(fitErrors))
 				}
 				if len(tt.expectedFitErrors) > 0 {
 					for i, expectedFitError := range tt.expectedFitErrors {
-						actualFitError := job.JobFitErrors[i]
+						actualFitError := fitErrors[i]
 						if !slices.Equal(expectedFitError.Messages(), actualFitError.Messages()) {
 							t.Errorf("expected fit error %d: messages %v, but got %v", i, expectedFitError.Messages(), actualFitError.Messages())
 						}
@@ -2223,7 +2232,6 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
 			// Check result
 			if len(result) != len(tt.expectedDomains) {
 				t.Errorf("expected %d domains, but got %d", len(tt.expectedDomains), len(result))
@@ -2258,4 +2266,19 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJobFitsDomainDoesNotAllocateDiagnostics(t *testing.T) {
+	vectorMap := resource_info.NewResourceVectorMap()
+	domain := &DomainInfo{
+		AllocatablePods:       allocatablePodsNotSet,
+		IdleOrReleasingVector: resource_info.NewResource(0, 0, 1).ToVector(vectorMap),
+	}
+	requested := resource_info.NewResource(0, 0, 2).ToVector(vectorMap)
+
+	allocations := testing.AllocsPerRun(100, func() {
+		assert.False(t, jobFitsDomain(requested, 1, domain, vectorMap))
+	})
+
+	assert.Zero(t, allocations)
 }


### PR DESCRIPTION
## Description

This PR makes fit-error diagnostics belong to the final authoritative Allocate result instead of allowing allocation simulations and discarded node-set alternatives to mutate `PodGroupInfo`.

It:

- Collects task and job diagnostics locally while evaluating allocation alternatives.
- Selects the failed alternative that allocated the most tasks; the first alternative wins ties.
- Publishes only that selected failure from a non-pipeline `AllocateJob` call.
- Prevents Reclaim, Preempt, Consolidation, and other pipeline-only simulations from changing user-facing fit errors.
- Preserves unrelated task and job diagnostics through additive publication.
- Makes topology filtering return structured diagnostics instead of mutating the job.
- Avoids constructing topology diagnostics when collection is disabled.

This PR deliberately keeps the existing per-node `TasksFitErrors` representation. Compact retention and lazy detailed recomputation are handled by #1922.

### Pre-fix regression checkpoint

Commit `cc392caa` adds the four ownership regression tests before the filtering refactor and fix. It intentionally compiles and fails all four tests against the old behavior:

```bash
git checkout cc392caa
go test ./pkg/scheduler/actions/integration_tests/allocate \
  -run "Test(AllocateJob(DiscardsFailedAlternativeDiagnosticsAfterSuccess|PublishesBestFailedAlternative|FailurePreservesExistingFitErrors)|PipelineOnlyAllocateJobDoesNotMutateFitErrors)$" \
  -count=1
git switch fit-error-allocation-ownership
```

The final branch head makes the same command pass.

## Related Issues

Related to #1827

Related to #1653

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [x] Added changie fragment

## Breaking Changes

No user-facing breaking changes.

`AllocateJob` returns `bool` again. `Session.FittingNode` continues returning the fit decision and optional diagnostic separately.

## Additional Notes

Validation performed:

- Focused ownership, allocation, topology, framework, and common-info tests
- `go test ./pkg/scheduler/... -count=1`
- `make validate`

`make test` reached the Helm chart target but the chart container could not read the bind-mounted worktree (`stat .: permission denied`). Scheduler tests and validation passed.

The full-cycle benchmark remains in the independent benchmark PR #1920.
