### PR TITLE
perf(scheduler): retain compact task fit errors

### DIFF
--- a/.changes/unreleased/Fixed-20260718-004752.yaml
+++ b/.changes/unreleased/Fixed-20260718-004752.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+kind: Fixed
+body: Reduce retained scheduler memory with compact fit-error counts and on-demand details.
+time: 2026-07-18T00:47:52+02:00
+custom:
+    Author: enoodle
+    Issue: "1827"

--- a/docs/operator/scheduler-config-customization.md
+++ b/docs/operator/scheduler-config-customization.md
@@ -8,6 +8,30 @@ User overrides are merged with defaults:
 - `arguments` fully replaces the default arguments when specified.
 - New plugins/actions added by future KAI upgrades are automatically included.
 
+## Scheduler arguments
+
+The default `SchedulingShard` also accepts scheduler command-line arguments through its `args` field. When using Helm, configure the same arguments under `scheduler.args`.
+
+### Detailed fit errors
+
+Set `detailed-fit-errors` to `"true"` to include node-by-node fit diagnostics in unschedulable pod status and events. Detailed PodGroup errors can also include job-level diagnostics, such as topology-domain constraints.
+
+```yaml
+# SchedulingShard
+spec:
+  args:
+    detailed-fit-errors: "true"
+```
+
+```yaml
+# Helm values
+scheduler:
+  args:
+    detailed-fit-errors: "true"
+```
+
+This option is disabled by default. Enable it when investigating unschedulable workloads, then disable it after collecting the needed diagnostics. Generating detailed errors re-evaluates failed tasks against candidate nodes during status reporting. On large clusters with many pending unschedulable tasks, this adds scheduler CPU work and can increase scheduling-cycle latency.
+
 ## Default Plugins
 
 | Plugin | Priority | Description |

--- a/pkg/scheduler/api/common_info/pod_errors.go
+++ b/pkg/scheduler/api/common_info/pod_errors.go
@@ -170,45 +170,73 @@ func (f *TasksFitError) Error() string {
 }
 
 type TasksFitErrors struct {
-	nodes map[string]*TasksFitError
-	err   string
+	reasonCounts map[string]int
+	err          string
 }
 
 func NewFitErrors() *TasksFitErrors {
-	f := new(TasksFitErrors)
-	f.nodes = make(map[string]*TasksFitError)
-	return f
+	return &TasksFitErrors{reasonCounts: make(map[string]int)}
 }
 
 func (f *TasksFitErrors) SetError(err string) {
 	f.err = err
 }
 
-func (f *TasksFitErrors) SetNodeError(nodeName string, err error) {
-	var fe *TasksFitError
-	switch obj := err.(type) {
-	case *TasksFitError:
-		obj.NodeName = nodeName
-		fe = obj
-	default:
-		fe = NewFitError("", "", nodeName, err.Error())
+func (f *TasksFitErrors) AddReasonCounts(errors *TasksFitErrors) {
+	if errors == nil {
+		return
 	}
-
-	f.nodes[nodeName] = fe
-}
-
-func (f *TasksFitErrors) AddNodeErrors(errors *TasksFitErrors) {
-	for nodeName, fitError := range errors.nodes {
-		f.nodes[nodeName] = fitError
+	if f.reasonCounts == nil {
+		f.reasonCounts = make(map[string]int)
+	}
+	for reason, count := range errors.reasonCounts {
+		f.reasonCounts[reason] += count
 	}
 }
 
-func (f *TasksFitErrors) DetailedError() string {
-	if f.err == "" {
-		f.err = ResourcesWereNotFoundMsg
+func (f *TasksFitErrors) AddNodeError(err error) {
+	if err == nil {
+		return
 	}
-	reasonMessages := []string{"\n" + f.err + "."}
-	for _, node := range f.nodes {
+	if f.reasonCounts == nil {
+		f.reasonCounts = make(map[string]int)
+	}
+	var reasons []string
+	if fitError, ok := err.(*TasksFitError); ok {
+		if fitError == nil {
+			return
+		}
+		reasons = fitError.Reasons
+	} else {
+		reasons = []string{err.Error()}
+	}
+	for _, reason := range reasons {
+		f.reasonCounts[reason]++
+	}
+}
+
+func (f *TasksFitErrors) HasNodeErrors() bool {
+	return len(f.reasonCounts) != 0
+}
+
+func (f *TasksFitErrors) ReasonCount(reason string) int {
+	return f.reasonCounts[reason]
+}
+
+func (f *TasksFitErrors) UniqueReasonCount() int {
+	return len(f.reasonCounts)
+}
+
+func (f *TasksFitErrors) DetailedError(nodeErrors []*TasksFitError) string {
+	baseError := f.err
+	if baseError == "" {
+		baseError = ResourcesWereNotFoundMsg
+	}
+	reasonMessages := []string{"\n" + baseError + "."}
+	if len(nodeErrors) == 0 {
+		return strings.Join(reasonMessages, "")
+	}
+	for _, node := range nodeErrors {
 		reasonMessages = append(reasonMessages,
 			fmt.Sprintf("\n<%v>: %v.", node.NodeName, strings.Join(node.DetailedReasons, ", ")))
 	}
@@ -217,32 +245,20 @@ func (f *TasksFitErrors) DetailedError() string {
 }
 
 func (f *TasksFitErrors) Error() string {
-	reasons := make(map[string]int)
-
-	sortReasonsHistogram := func() []string {
-		for _, node := range f.nodes {
-			for _, reason := range node.Reasons {
-				reasons[reason]++
-			}
-		}
-
-		var reasonStrings []string
-		for k, v := range reasons {
-			reasonStrings = append(reasonStrings, fmt.Sprintf("%v %v", v, k))
-		}
-		sort.Strings(reasonStrings)
-		return reasonStrings
+	reasonStrings := make([]string, 0, len(f.reasonCounts))
+	for reason, count := range f.reasonCounts {
+		reasonStrings = append(reasonStrings, fmt.Sprintf("%v %v", count, reason))
 	}
-	if f.err == "" {
-		f.err = ResourcesWereNotFoundMsg
-	}
-	reasonMsg := f.err
+	sort.Strings(reasonStrings)
 
-	nodeReasonsHistogram := sortReasonsHistogram()
-	if len(nodeReasonsHistogram) > 0 {
-		reasonMsg += fmt.Sprintf(": %v.", strings.Join(nodeReasonsHistogram, ". \n"))
+	baseError := f.err
+	if baseError == "" {
+		baseError = ResourcesWereNotFoundMsg
 	}
-	return reasonMsg
+	if len(reasonStrings) > 0 {
+		baseError += fmt.Sprintf(": %v.", strings.Join(reasonStrings, ". \n"))
+	}
+	return baseError
 }
 
 type NotFoundError struct {

--- a/pkg/scheduler/api/common_info/pod_errors_test.go
+++ b/pkg/scheduler/api/common_info/pod_errors_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestFitErrors_Error(t *testing.T) {
 	type fields struct {
-		nodes map[string]*TasksFitError
-		err   string
+		err string
 	}
 	tests := []struct {
 		name   string
@@ -31,13 +30,125 @@ func TestFitErrors_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &TasksFitErrors{
-				nodes: tt.fields.nodes,
-				err:   tt.fields.err,
+				err: tt.fields.err,
 			}
 			if got := f.Error(); got != tt.want {
 				t.Errorf("Error() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFitErrorsAddNodeErrorIgnoresTypedNil(t *testing.T) {
+	fitErrors := NewFitErrors()
+	var fitError *TasksFitError
+
+	fitErrors.AddNodeError(fitError)
+
+	if got := fitErrors.Error(); got != ResourcesWereNotFoundMsg {
+		t.Fatalf("Error() = %q, want %q", got, ResourcesWereNotFoundMsg)
+	}
+}
+
+func TestFitErrorsAggregatesNodeReasons(t *testing.T) {
+	fitErrors := NewFitErrors()
+	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
+		"pod", "namespace", "node-a",
+		[]string{"node(s) didn't have enough resources: GPUs"},
+		"Node didn't have enough resources: GPUs, requested: 1, used: 8, capacity: 8",
+	))
+	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
+		"pod", "namespace", "node-b",
+		[]string{
+			"node(s) didn't have enough resources: GPUs",
+			"node(s) didn't match Pod's node affinity/selector",
+		},
+		"Node didn't have enough resources: GPUs, requested: 1, used: 8, capacity: 8",
+		"node(s) didn't match Pod's node affinity/selector",
+	))
+	want := "no nodes with enough resources were found: 1 node(s) didn't match Pod's node affinity/selector. \n" +
+		"2 node(s) didn't have enough resources: GPUs."
+	if got := fitErrors.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestFitErrorsStoresCompactReasonCounts(t *testing.T) {
+	fitErrors := NewFitErrors()
+	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
+		"pod", "namespace", "node-a",
+		[]string{"MissingGPU"},
+		"node-a detailed GPU message",
+	))
+	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
+		"pod", "namespace", "node-b",
+		[]string{"MissingGPU", "NoStorage"},
+		"node-b detailed GPU message",
+		"node-b detailed storage message",
+	))
+
+	if got := fitErrors.ReasonCount("MissingGPU"); got != 2 {
+		t.Fatalf("ReasonCount(MissingGPU) = %d, want 2", got)
+	}
+	if got := fitErrors.ReasonCount("NoStorage"); got != 1 {
+		t.Fatalf("ReasonCount(NoStorage) = %d, want 1", got)
+	}
+	if got := fitErrors.UniqueReasonCount(); got != 2 {
+		t.Fatalf("UniqueReasonCount() = %d, want 2", got)
+	}
+	if !fitErrors.HasNodeErrors() {
+		t.Fatal("HasNodeErrors() = false, want true")
+	}
+
+	want := "no nodes with enough resources were found: 1 NoStorage. \n2 MissingGPU."
+	if got := fitErrors.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestFitErrorsDetailedErrorUsesTransientNodeErrors(t *testing.T) {
+	fitErrors := NewFitErrors()
+	fitErrors.AddNodeError(NewFitError("pod", "namespace", "node-a", "MissingGPU"))
+
+	nodeErrors := []*TasksFitError{
+		NewFitErrorWithDetailedMessage(
+			"pod", "namespace", "node-b", []string{"NoStorage"}, "node-b detailed storage message"),
+		NewFitErrorWithDetailedMessage(
+			"pod", "namespace", "node-a", []string{"MissingGPU"}, "node-a detailed GPU message"),
+	}
+	want := "\n<node-a>: node-a detailed GPU message." +
+		"\n<node-b>: node-b detailed storage message." +
+		"\nno nodes with enough resources were found."
+	if got := fitErrors.DetailedError(nodeErrors); got != want {
+		t.Fatalf("DetailedError() = %q, want %q", got, want)
+	}
+	if got := fitErrors.ReasonCount("MissingGPU"); got != 1 {
+		t.Fatalf("ReasonCount(MissingGPU) after DetailedError = %d, want 1", got)
+	}
+}
+
+func TestAddNodeErrorDoesNotFormatStructuredFitError(t *testing.T) {
+	fitErrors := NewFitErrors()
+	fitError := NewFitError("pod", "namespace", "node-a", "MissingGPU")
+	fitErrors.AddNodeError(fitError)
+
+	allocations := testing.AllocsPerRun(100, func() {
+		fitErrors.AddNodeError(fitError)
+	})
+	if allocations != 0 {
+		t.Fatalf("AddNodeError() allocations = %v, want 0", allocations)
+	}
+}
+
+func TestAddNodeErrorIgnoresTypedNilFitError(t *testing.T) {
+	fitErrors := NewFitErrors()
+	var fitError *TasksFitError
+	var err error = fitError
+
+	fitErrors.AddNodeError(err)
+
+	if fitErrors.HasNodeErrors() {
+		t.Fatal("HasNodeErrors() = true after typed nil error, want false")
 	}
 }
 

--- a/pkg/scheduler/api/common_info/pod_errors_test.go
+++ b/pkg/scheduler/api/common_info/pod_errors_test.go
@@ -39,17 +39,6 @@ func TestFitErrors_Error(t *testing.T) {
 	}
 }
 
-func TestFitErrorsAddNodeErrorIgnoresTypedNil(t *testing.T) {
-	fitErrors := NewFitErrors()
-	var fitError *TasksFitError
-
-	fitErrors.AddNodeError(fitError)
-
-	if got := fitErrors.Error(); got != ResourcesWereNotFoundMsg {
-		t.Fatalf("Error() = %q, want %q", got, ResourcesWereNotFoundMsg)
-	}
-}
-
 func TestFitErrorsAggregatesNodeReasons(t *testing.T) {
 	fitErrors := NewFitErrors()
 	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
@@ -71,38 +60,14 @@ func TestFitErrorsAggregatesNodeReasons(t *testing.T) {
 	if got := fitErrors.Error(); got != want {
 		t.Fatalf("Error() = %q, want %q", got, want)
 	}
-}
-
-func TestFitErrorsStoresCompactReasonCounts(t *testing.T) {
-	fitErrors := NewFitErrors()
-	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
-		"pod", "namespace", "node-a",
-		[]string{"MissingGPU"},
-		"node-a detailed GPU message",
-	))
-	fitErrors.AddNodeError(NewFitErrorWithDetailedMessage(
-		"pod", "namespace", "node-b",
-		[]string{"MissingGPU", "NoStorage"},
-		"node-b detailed GPU message",
-		"node-b detailed storage message",
-	))
-
-	if got := fitErrors.ReasonCount("MissingGPU"); got != 2 {
-		t.Fatalf("ReasonCount(MissingGPU) = %d, want 2", got)
-	}
-	if got := fitErrors.ReasonCount("NoStorage"); got != 1 {
-		t.Fatalf("ReasonCount(NoStorage) = %d, want 1", got)
+	if got := fitErrors.ReasonCount("node(s) didn't have enough resources: GPUs"); got != 2 {
+		t.Fatalf("ReasonCount(GPUs) = %d, want 2", got)
 	}
 	if got := fitErrors.UniqueReasonCount(); got != 2 {
 		t.Fatalf("UniqueReasonCount() = %d, want 2", got)
 	}
 	if !fitErrors.HasNodeErrors() {
 		t.Fatal("HasNodeErrors() = false, want true")
-	}
-
-	want := "no nodes with enough resources were found: 1 NoStorage. \n2 MissingGPU."
-	if got := fitErrors.Error(); got != want {
-		t.Fatalf("Error() = %q, want %q", got, want)
 	}
 }
 
@@ -149,6 +114,9 @@ func TestAddNodeErrorIgnoresTypedNilFitError(t *testing.T) {
 
 	if fitErrors.HasNodeErrors() {
 		t.Fatal("HasNodeErrors() = true after typed nil error, want false")
+	}
+	if got := fitErrors.Error(); got != ResourcesWereNotFoundMsg {
+		t.Fatalf("Error() = %q, want %q", got, ResourcesWereNotFoundMsg)
 	}
 }
 

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -613,7 +613,7 @@ func (pgi *PodGroupInfo) String() string {
 func (pgi *PodGroupInfo) AddTaskFitErrors(task *pod_info.PodInfo, fitErrors *common_info.TasksFitErrors) {
 	existingFitErrors, found := pgi.TasksFitErrors[task.UID]
 	if found {
-		existingFitErrors.AddNodeErrors(fitErrors)
+		existingFitErrors.AddReasonCounts(fitErrors)
 	} else {
 		pgi.TasksFitErrors[task.UID] = fitErrors
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -53,6 +53,7 @@ import (
 	draversionawareclient "github.com/kai-scheduler/KAI-scheduler/pkg/common/resources/dra_version_aware_client"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/bindrequest_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -424,8 +425,14 @@ func (sc *SchedulerCache) String() string {
 }
 
 // RecordJobStatusEvent records related events according to job status.
-func (sc *SchedulerCache) RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error {
-	return sc.StatusUpdater.RecordJobStatusEvent(job)
+func (sc *SchedulerCache) RecordJobStatusEvent(
+	job *podgroup_info.PodGroupInfo,
+	resolveDetailedFitErrors func(
+		*podgroup_info.PodGroupInfo,
+		*pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error),
+) error {
+	return sc.StatusUpdater.RecordJobStatusEvent(job, resolveDetailedFitErrors)
 }
 
 func (sc *SchedulerCache) TaskPipelined(task *pod_info.PodInfo, message string) {

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -14,6 +14,7 @@ import (
 
 	v1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	api "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	common_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	eviction_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	pod_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	podgroup_info "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -135,17 +136,17 @@ func (mr *MockCacheMockRecorder) KubeInformerFactory() *gomock.Call {
 }
 
 // RecordJobStatusEvent mocks base method.
-func (m *MockCache) RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error {
+func (m *MockCache) RecordJobStatusEvent(job *podgroup_info.PodGroupInfo, resolveDetailedFitErrors func(*podgroup_info.PodGroupInfo, *pod_info.PodInfo) ([]*common_info.TasksFitError, error)) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordJobStatusEvent", job)
+	ret := m.ctrl.Call(m, "RecordJobStatusEvent", job, resolveDetailedFitErrors)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordJobStatusEvent indicates an expected call of RecordJobStatusEvent.
-func (mr *MockCacheMockRecorder) RecordJobStatusEvent(job any) *gomock.Call {
+func (mr *MockCacheMockRecorder) RecordJobStatusEvent(job, resolveDetailedFitErrors any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordJobStatusEvent", reflect.TypeOf((*MockCache)(nil).RecordJobStatusEvent), job)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordJobStatusEvent", reflect.TypeOf((*MockCache)(nil).RecordJobStatusEvent), job, resolveDetailedFitErrors)
 }
 
 // Run mocks base method.

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -27,6 +27,7 @@ import (
 
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
@@ -40,7 +41,13 @@ type Cache interface {
 	WaitForCacheSync(stopCh <-chan struct{})
 	Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, predictedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error
 	Evict(ssnPod *v1.Pod, job *podgroup_info.PodGroupInfo, evictionMetadata eviction_info.EvictionMetadata, message string) error
-	RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error
+	RecordJobStatusEvent(
+		job *podgroup_info.PodGroupInfo,
+		resolveDetailedFitErrors func(
+			*podgroup_info.PodGroupInfo,
+			*pod_info.PodInfo,
+		) ([]*common_info.TasksFitError, error),
+	) error
 	TaskPipelined(task *pod_info.PodInfo, message string)
 	KubeClient() kubernetes.Interface
 	KubeInformerFactory() informers.SharedInformerFactory

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -356,7 +356,7 @@ func TestRecordJobStatusEvent(t *testing.T) {
 				fitErrors := common_info.NewFitErrors()
 				for node, msg := range nodeErrors {
 					fitError := common_info.NewFitError(string(podID), "namespace-1", node, msg)
-					fitErrors.SetNodeError(node, fitError)
+					fitErrors.AddNodeError(fitError)
 				}
 				podGroupInfo.AddTaskFitErrors(podGroupInfo.GetAllPodsMap()[podID], fitErrors)
 			}
@@ -371,7 +371,7 @@ func TestRecordJobStatusEvent(t *testing.T) {
 				podGroupInfo.AddSimpleJobFitError(explanation.Reason, explanation.Message)
 			}
 
-			err := cache.RecordJobStatusEvent(podGroupInfo)
+			err := cache.RecordJobStatusEvent(podGroupInfo, nil)
 			assert.Nil(t, err)
 
 			newPodGroupObj, err := waitForCondition(func() (runtime.Object, error) {
@@ -519,7 +519,7 @@ func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
 	job.AddTaskInfo(pod_info.NewTaskInfo(validPod, vectorMap))
 	job.AddTaskInfo(pod_info.NewTaskInfo(invalidPod, vectorMap))
 
-	err := cache.RecordJobStatusEvent(job)
+	err := cache.RecordJobStatusEvent(job, nil)
 	assert.NoError(t, err)
 
 	invalidPodObj, err := waitForCondition(func() (runtime.Object, error) {

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -23,6 +23,7 @@ import (
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/k8s_internal"
@@ -195,7 +196,13 @@ func (su *defaultStatusUpdater) PatchPodLabels(pod *v1.Pod, labels map[string]an
 	)
 }
 
-func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error {
+func (su *defaultStatusUpdater) RecordJobStatusEvent(
+	job *podgroup_info.PodGroupInfo,
+	resolveDetailedFitErrors func(
+		*podgroup_info.PodGroupInfo,
+		*pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error),
+) error {
 	var err error
 	var patchData []byte
 	if patchData, err = su.updatePodGroupAnnotations(job); err != nil {
@@ -204,7 +211,7 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 	if job.StalenessInfo.Stale {
 		su.recordStaleJobEvent(job)
 	}
-	if err := su.recordInvalidSubGroupPodsEvents(job); err != nil {
+	if err := su.recordInvalidSubGroupPodsEvents(job, resolveDetailedFitErrors); err != nil {
 		return err
 	}
 
@@ -214,7 +221,7 @@ func (su *defaultStatusUpdater) RecordJobStatusEvent(job *podgroup_info.PodGroup
 			su.recordJobNotReadyEvent(job)
 			return nil
 		}
-		if err := su.recordUnschedulablePodsEvents(job); err != nil {
+		if err := su.recordUnschedulablePodsEvents(job, resolveDetailedFitErrors); err != nil {
 			return err
 		}
 		updatePodgroupStatus = su.recordUnschedulablePodGroup(job)
@@ -346,7 +353,13 @@ func (su *defaultStatusUpdater) updatePodCondition(pod *v1.Pod, condition *v1.Po
 	return nil
 }
 
-func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info.PodGroupInfo) error {
+func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(
+	job *podgroup_info.PodGroupInfo,
+	resolveDetailedFitErrors func(
+		*podgroup_info.PodGroupInfo,
+		*pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error),
+) error {
 	// Update podCondition for tasks Allocated and Pending before job discarded
 	var errs []error
 	for _, taskInfo := range job.PodStatusIndex[pod_status.Pending] {
@@ -357,13 +370,7 @@ func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info
 		msg := common_info.DefaultPodError
 		fitError := job.TasksFitErrors[taskInfo.UID]
 		if fitError != nil {
-			msg = fitError.Error()
-
-			if su.detailedFitErrors {
-				msg = fitError.DetailedError()
-			} else {
-				log.InfraLogger.V(6).Infof("Full fit error: %s", fitError.DetailedError())
-			}
+			msg = su.taskFitErrorMessage(job, taskInfo, fitError, resolveDetailedFitErrors)
 		} else if len(job.JobFitErrors) > 0 {
 			msg = fmt.Sprintf("%s", common_info.JobFitErrorsToMessage(job.JobFitErrors))
 		}
@@ -380,16 +387,60 @@ func (su *defaultStatusUpdater) recordUnschedulablePodsEvents(job *podgroup_info
 	return errors.Join(errs...)
 }
 
-func (su *defaultStatusUpdater) recordInvalidSubGroupPodsEvents(job *podgroup_info.PodGroupInfo) error {
+func (su *defaultStatusUpdater) taskFitErrorMessage(
+	job *podgroup_info.PodGroupInfo,
+	task *pod_info.PodInfo,
+	fitError *common_info.TasksFitErrors,
+	resolveDetailedFitErrors func(
+		*podgroup_info.PodGroupInfo,
+		*pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error),
+) string {
+	compactMessage := fitError.Error()
+	if !fitError.HasNodeErrors() {
+		if su.detailedFitErrors {
+			return fitError.DetailedError(nil)
+		}
+		return compactMessage
+	}
+
+	if su.detailedFitErrors {
+		if resolveDetailedFitErrors == nil {
+			return compactMessage
+		}
+		nodeErrors, err := resolveDetailedFitErrors(job, task)
+		if err != nil || len(nodeErrors) == 0 {
+			return compactMessage
+		}
+		return fitError.DetailedError(nodeErrors)
+	}
+
+	log.InfraLogger.V(6).Do(func() {
+		if resolveDetailedFitErrors == nil {
+			return
+		}
+		nodeErrors, err := resolveDetailedFitErrors(job, task)
+		if err != nil || len(nodeErrors) == 0 {
+			return
+		}
+		log.InfraLogger.V(6).Infof("Full fit error: %s", fitError.DetailedError(nodeErrors))
+	})
+	return compactMessage
+}
+
+func (su *defaultStatusUpdater) recordInvalidSubGroupPodsEvents(
+	job *podgroup_info.PodGroupInfo,
+	resolveDetailedFitErrors func(
+		*podgroup_info.PodGroupInfo,
+		*pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error),
+) error {
 	var errs []error
 
 	for _, taskInfo := range job.GetInvalidSubGroupTasks() {
 		msg := common_info.DefaultPodError
 		if fitError := job.TasksFitErrors[taskInfo.UID]; fitError != nil {
-			msg = fitError.Error()
-			if su.detailedFitErrors {
-				msg = fitError.DetailedError()
-			}
+			msg = su.taskFitErrorMessage(job, taskInfo, fitError, resolveDetailedFitErrors)
 		}
 
 		msg = su.addNodePoolPrefixIfNeeded(job, msg)

--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info/subgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
@@ -646,7 +647,7 @@ func TestDefaultStatusUpdater_RecordJobStatusEvent(t *testing.T) {
 			stopCh := make(chan struct{})
 			statusUpdater.Run(stopCh)
 
-			statusUpdater.RecordJobStatusEvent(jobInfos["test-job"])
+			statusUpdater.RecordJobStatusEvent(jobInfos["test-job"], nil)
 
 			events := []string{}
 			close(recorder.Events)
@@ -807,6 +808,113 @@ func TestDefaultStatusUpdater_RetryAfterError(t *testing.T) {
 
 	// Wait for a retry after error
 	assert.NoError(t, waitForIncrease(&updateCalls), "update was not retried after error")
+}
+
+func TestTaskFitErrorMessageDoesNotResolveCompactMessage(t *testing.T) {
+	su := &defaultStatusUpdater{detailedFitErrors: false}
+	job, task, fitErrors := taskFitErrorMessageFixture()
+	resolverCalls := 0
+	resolve := func(
+		*podgroup_info.PodGroupInfo, *pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error) {
+		resolverCalls++
+		return nil, nil
+	}
+
+	message := su.taskFitErrorMessage(job, task, fitErrors, resolve)
+
+	assert.Equal(t, "no nodes with enough resources were found: 1 MissingGPU.", message)
+	assert.Zero(t, resolverCalls)
+}
+
+func TestTaskFitErrorMessageResolvesDetailedMessage(t *testing.T) {
+	su := &defaultStatusUpdater{detailedFitErrors: true}
+	job, task, fitErrors := taskFitErrorMessageFixture()
+	resolverCalls := 0
+	resolve := func(
+		*podgroup_info.PodGroupInfo, *pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error) {
+		resolverCalls++
+		return []*common_info.TasksFitError{
+			common_info.NewFitErrorWithDetailedMessage(
+				task.Name, task.Namespace, "node-a", []string{"MissingGPU"}, "node-a GPU details"),
+		}, nil
+	}
+
+	message := su.taskFitErrorMessage(job, task, fitErrors, resolve)
+
+	assert.Equal(t, "\n<node-a>: node-a GPU details.\nno nodes with enough resources were found.", message)
+	assert.Equal(t, 1, resolverCalls)
+}
+
+func TestTaskFitErrorMessageFallsBackWhenDetailedResolutionFails(t *testing.T) {
+	su := &defaultStatusUpdater{detailedFitErrors: true}
+	job, task, fitErrors := taskFitErrorMessageFixture()
+	resolve := func(
+		*podgroup_info.PodGroupInfo, *pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error) {
+		return nil, errors.New("recompute failed")
+	}
+
+	message := su.taskFitErrorMessage(job, task, fitErrors, resolve)
+
+	assert.Equal(t, "no nodes with enough resources were found: 1 MissingGPU.", message)
+}
+
+func TestTaskFitErrorMessageResolvesOnlyForEnabledVerboseLog(t *testing.T) {
+	require.NoError(t, log.InitLoggers(6, false))
+	t.Cleanup(func() {
+		require.NoError(t, log.InitLoggers(3, false))
+	})
+
+	su := &defaultStatusUpdater{detailedFitErrors: false}
+	job, task, fitErrors := taskFitErrorMessageFixture()
+	resolverCalls := 0
+	resolve := func(
+		*podgroup_info.PodGroupInfo, *pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error) {
+		resolverCalls++
+		return []*common_info.TasksFitError{
+			common_info.NewFitErrorWithDetailedMessage(
+				task.Name, task.Namespace, "node-a", []string{"MissingGPU"}, "node-a GPU details"),
+		}, nil
+	}
+
+	message := su.taskFitErrorMessage(job, task, fitErrors, resolve)
+
+	assert.Equal(t, "no nodes with enough resources were found: 1 MissingGPU.", message)
+	assert.Equal(t, 1, resolverCalls)
+}
+
+func TestTaskFitErrorMessageKeepsDirectDetailedError(t *testing.T) {
+	su := &defaultStatusUpdater{detailedFitErrors: true}
+	job, task, _ := taskFitErrorMessageFixture()
+	fitErrors := common_info.NewFitErrors()
+	fitErrors.SetError("direct pre-filter error")
+	resolverCalls := 0
+	resolve := func(
+		*podgroup_info.PodGroupInfo, *pod_info.PodInfo,
+	) ([]*common_info.TasksFitError, error) {
+		resolverCalls++
+		return nil, nil
+	}
+
+	message := su.taskFitErrorMessage(job, task, fitErrors, resolve)
+
+	assert.Equal(t, "\ndirect pre-filter error.", message)
+	assert.Zero(t, resolverCalls)
+}
+
+func taskFitErrorMessageFixture() (
+	*podgroup_info.PodGroupInfo, *pod_info.PodInfo, *common_info.TasksFitErrors,
+) {
+	task := pod_info.NewTaskInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "namespace", UID: "pod"},
+	}, resource_info.NewResourceVectorMap())
+	job := podgroup_info.NewPodGroupInfo("job", task)
+	fitErrors := common_info.NewFitErrors()
+	fitErrors.AddNodeError(common_info.NewFitError(task.Name, task.Namespace, "node-a", "MissingGPU"))
+	return job, task, fitErrors
 }
 
 func waitForIncrease(callCount *int) error {

--- a/pkg/scheduler/cache/status_updater/interface.go
+++ b/pkg/scheduler/cache/status_updater/interface.go
@@ -7,7 +7,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	enginev2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/eviction_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 )
 
@@ -22,7 +24,13 @@ type Interface interface {
 	Bound(pod *v1.Pod, hostname string, bindError error, nodePoolName string) error
 	Pipelined(pod *v1.Pod, message string)
 	PatchPodLabels(pod *v1.Pod, labels map[string]interface{})
-	RecordJobStatusEvent(job *podgroup_info.PodGroupInfo) error
+	RecordJobStatusEvent(
+		job *podgroup_info.PodGroupInfo,
+		resolveDetailedFitErrors func(
+			*podgroup_info.PodGroupInfo,
+			*pod_info.PodInfo,
+		) ([]*common_info.TasksFitError, error),
+	) error
 
 	Run(stopCh <-chan struct{})
 }

--- a/pkg/scheduler/cache/status_updater/pod_group_status_sync_test.go
+++ b/pkg/scheduler/cache/status_updater/pod_group_status_sync_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Status Updater - Pod Groups Syncing", func() {
 				job.StalenessInfo.Stale = true
 				job.LastStartTimestamp = ptr.To(time.Now())
 			}
-			Expect(statusUpdater.RecordJobStatusEvent(job)).To(Succeed())
+			Expect(statusUpdater.RecordJobStatusEvent(job, nil)).To(Succeed())
 		}
 	})
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -236,7 +236,7 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 	allocatable, fitError := ssn.isTaskAllocatableOnNode(task, job, node, writeFittingDelta)
 	if !allocatable {
 		if fitError != nil && writeFittingDelta {
-			fitErrors.SetNodeError(node.Name, fitError)
+			fitErrors.AddNodeError(fitError)
 			job.AddTaskFitErrors(task, fitErrors)
 		}
 		return false
@@ -248,7 +248,7 @@ func (ssn *Session) FittingNode(task *pod_info.PodInfo, node *node_info.NodeInfo
 		log.InfraLogger.V(6).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
 			task.Namespace, task.Name, node.Name, err)
 		if writeFittingDelta {
-			fitErrors.SetNodeError(node.Name, err)
+			fitErrors.AddNodeError(err)
 			job.AddTaskFitErrors(task, fitErrors)
 		}
 		return false
@@ -338,6 +338,47 @@ func (ssn *Session) isTaskAllocatableOnNode(task *pod_info.PodInfo, job *podgrou
 		}
 	}
 	return allocatable, fitError
+}
+
+func (ssn *Session) RecomputeDetailedFitErrors(
+	job *podgroup_info.PodGroupInfo, task *pod_info.PodInfo,
+) ([]*common_info.TasksFitError, error) {
+	if err := ssn.PrePredicateFn(task, job); err != nil {
+		return nil, nil
+	}
+
+	nodeErrors := make([]*common_info.TasksFitError, 0)
+	for _, node := range ssn.ClusterInfo.Nodes {
+		allocatable, fitError := ssn.isTaskAllocatableOnNode(task, job, node, true)
+		if !allocatable {
+			if fitError != nil {
+				nodeErrors = append(nodeErrors, fitError)
+			}
+			continue
+		}
+		if err := ssn.PredicateFn(task, job, node); err != nil {
+			if fitError := taskFitErrorFromError(task, node, err); fitError != nil {
+				nodeErrors = append(nodeErrors, fitError)
+			}
+		}
+	}
+	return nodeErrors, nil
+}
+
+func taskFitErrorFromError(
+	task *pod_info.PodInfo, node *node_info.NodeInfo, err error,
+) *common_info.TasksFitError {
+	if fitError, ok := err.(*common_info.TasksFitError); ok {
+		if fitError == nil {
+			return nil
+		}
+		fitErrorCopy := *fitError
+		fitErrorCopy.NodeName = node.Name
+		fitErrorCopy.Reasons = append([]string(nil), fitError.Reasons...)
+		fitErrorCopy.DetailedReasons = append([]string(nil), fitError.DetailedReasons...)
+		return &fitErrorCopy
+	}
+	return common_info.NewFitError(task.Name, task.Namespace, node.Name, err.Error())
 }
 
 func (ssn *Session) String() string {
@@ -475,8 +516,9 @@ func closeSession(ssn *Session) {
 		ssn.ID, len(ssn.ClusterInfo.PodGroupInfos), len(ssn.ClusterInfo.Queues))
 
 	// Push all jobs for status update into the channel
+	resolveDetailedFitErrors := ssn.RecomputeDetailedFitErrors
 	for _, job := range ssn.ClusterInfo.PodGroupInfos {
-		if err := ssn.Cache.RecordJobStatusEvent(job); err != nil {
+		if err := ssn.Cache.RecordJobStatusEvent(job, resolveDetailedFitErrors); err != nil {
 			log.InfraLogger.Errorf("Failed to record job status event for job <%s>: %v", job.Name, err)
 		}
 	}

--- a/pkg/scheduler/framework/session_fit_errors_test.go
+++ b/pkg/scheduler/framework/session_fit_errors_test.go
@@ -99,6 +99,10 @@ func TestRecomputeDetailedFitErrorsBuildsCurrentResourceDetails(t *testing.T) {
 	for _, node := range ssn.ClusterInfo.Nodes {
 		node.IdleVector.Set(resource_info.GPUIndex, 0)
 		node.UsedVector.Set(resource_info.GPUIndex, 1)
+		require.False(t, ssn.FittingNode(task, node, true))
+
+		node.IdleVector.Set(resource_info.GPUIndex, 0.5)
+		node.UsedVector.Set(resource_info.GPUIndex, 0.5)
 	}
 
 	nodeErrors, err := ssn.RecomputeDetailedFitErrors(job, task)
@@ -107,8 +111,9 @@ func TestRecomputeDetailedFitErrorsBuildsCurrentResourceDetails(t *testing.T) {
 	for _, fitError := range nodeErrors {
 		require.Len(t, fitError.DetailedReasons, 1)
 		require.True(t, strings.Contains(fitError.DetailedReasons[0], "requested: 1"))
-		require.True(t, strings.Contains(fitError.DetailedReasons[0], "used: 1"))
+		require.True(t, strings.Contains(fitError.DetailedReasons[0], "used: 0.5"))
 		require.True(t, strings.Contains(fitError.DetailedReasons[0], "capacity: 1"))
+		require.NotContains(t, fitError.DetailedReasons[0], "used: 1")
 	}
 }
 

--- a/pkg/scheduler/framework/session_fit_errors_test.go
+++ b/pkg/scheduler/framework/session_fit_errors_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package framework_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
+)
+
+func TestFittingNodeAggregatesCompactReasonCounts(t *testing.T) {
+	ssn, job, task := buildDetailedFitErrorSession(t)
+	ssn.AddPredicateFn(func(
+		task *pod_info.PodInfo,
+		_ *podgroup_info.PodGroupInfo,
+		node *node_info.NodeInfo,
+	) error {
+		if node.Name == "node-a" {
+			return common_info.NewFitError(task.Name, task.Namespace, node.Name, "NodeAffinityMismatch")
+		}
+		return common_info.NewFitError(task.Name, task.Namespace, node.Name, "NoStorage")
+	})
+
+	for _, nodeName := range []string{"node-a", "node-b"} {
+		require.False(t, ssn.FittingNode(task, ssn.ClusterInfo.Nodes[nodeName], true))
+	}
+
+	fitErrors := job.TasksFitErrors[task.UID]
+	require.NotNil(t, fitErrors)
+	require.Equal(t, 1, fitErrors.ReasonCount("NodeAffinityMismatch"))
+	require.Equal(t, 1, fitErrors.ReasonCount("NoStorage"))
+	require.Equal(t, 2, fitErrors.UniqueReasonCount())
+}
+
+func TestRecomputeDetailedFitErrorsRunsPredicatesForEveryNode(t *testing.T) {
+	ssn, job, task := buildDetailedFitErrorSession(t)
+	ssn.AddPredicateFn(func(
+		task *pod_info.PodInfo,
+		_ *podgroup_info.PodGroupInfo,
+		node *node_info.NodeInfo,
+	) error {
+		if node.Name == "node-a" {
+			return common_info.NewFitErrorWithDetailedMessage(
+				task.Name, task.Namespace, node.Name,
+				[]string{"NodeAffinityMismatch"}, "node-a affinity details")
+		}
+		return common_info.NewFitErrorWithDetailedMessage(
+			task.Name, task.Namespace, node.Name,
+			[]string{"NoStorage"}, "node-b storage details")
+	})
+
+	nodeErrors, err := ssn.RecomputeDetailedFitErrors(job, task)
+	require.NoError(t, err)
+	require.Len(t, nodeErrors, 2)
+
+	detailsByNode := make(map[string][]string, len(nodeErrors))
+	for _, fitError := range nodeErrors {
+		detailsByNode[fitError.NodeName] = fitError.DetailedReasons
+	}
+	require.Equal(t, []string{"node-a affinity details"}, detailsByNode["node-a"])
+	require.Equal(t, []string{"node-b storage details"}, detailsByNode["node-b"])
+}
+
+func TestRecomputeDetailedFitErrorsStopsAtPrePredicate(t *testing.T) {
+	ssn, job, task := buildDetailedFitErrorSession(t)
+	ssn.AddPrePredicateFn(func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo) error {
+		return &common_info.NotFoundError{Name: "missing-pvc"}
+	})
+	predicateCalls := 0
+	ssn.AddPredicateFn(func(*pod_info.PodInfo, *podgroup_info.PodGroupInfo, *node_info.NodeInfo) error {
+		predicateCalls++
+		return nil
+	})
+
+	nodeErrors, err := ssn.RecomputeDetailedFitErrors(job, task)
+	require.NoError(t, err)
+	require.Empty(t, nodeErrors)
+	require.Zero(t, predicateCalls)
+}
+
+func TestRecomputeDetailedFitErrorsBuildsCurrentResourceDetails(t *testing.T) {
+	ssn, job, task := buildDetailedFitErrorSession(t)
+	for _, node := range ssn.ClusterInfo.Nodes {
+		node.IdleVector.Set(resource_info.GPUIndex, 0)
+		node.UsedVector.Set(resource_info.GPUIndex, 1)
+	}
+
+	nodeErrors, err := ssn.RecomputeDetailedFitErrors(job, task)
+	require.NoError(t, err)
+	require.Len(t, nodeErrors, 2)
+	for _, fitError := range nodeErrors {
+		require.Len(t, fitError.DetailedReasons, 1)
+		require.True(t, strings.Contains(fitError.DetailedReasons[0], "requested: 1"))
+		require.True(t, strings.Contains(fitError.DetailedReasons[0], "used: 1"))
+		require.True(t, strings.Contains(fitError.DetailedReasons[0], "capacity: 1"))
+	}
+}
+
+func TestRecomputeDetailedFitErrorsSkipsTypedNilFitError(t *testing.T) {
+	ssn, job, task := buildDetailedFitErrorSession(t)
+	ssn.AddPredicateFn(func(
+		task *pod_info.PodInfo,
+		_ *podgroup_info.PodGroupInfo,
+		node *node_info.NodeInfo,
+	) error {
+		if node.Name == "node-a" {
+			return common_info.NewFitError(task.Name, task.Namespace, node.Name, "NodeAffinityMismatch")
+		}
+		var fitError *common_info.TasksFitError
+		return fitError
+	})
+
+	nodeErrors, err := ssn.RecomputeDetailedFitErrors(job, task)
+
+	require.NoError(t, err)
+	require.Len(t, nodeErrors, 1)
+	require.Equal(t, "node-a", nodeErrors[0].NodeName)
+}
+
+func buildDetailedFitErrorSession(
+	t *testing.T,
+) (*framework.Session, *podgroup_info.PodGroupInfo, *pod_info.PodInfo) {
+	t.Helper()
+	test_utils.InitTestingInfrastructure()
+	ctrl := gomock.NewController(t)
+	ssn := test_utils.BuildSession(test_utils.TestTopologyBasic{
+		Name: "detailed fit error recomputation",
+		Jobs: []*jobs_fake.TestJobBasic{{
+			Name:                "pending-job",
+			RequiredGPUsPerTask: 1,
+			Priority:            constants.PriorityTrainNumber,
+			QueueName:           "queue",
+			Tasks:               []*tasks_fake.TestTaskBasic{{State: pod_status.Pending}},
+		}},
+		Nodes: map[string]nodes_fake.TestNodeBasic{
+			"node-a": {GPUs: 1},
+			"node-b": {GPUs: 1},
+		},
+		Queues: []test_utils.TestQueueBasic{{Name: "queue", DeservedGPUs: 2}},
+	}, ctrl)
+	job := ssn.ClusterInfo.PodGroupInfos[common_info.PodGroupID("pending-job")]
+	task := job.GetAllPodsMap()[common_info.PodID("pending-job-0")]
+	return ssn, job, task
+}


### PR DESCRIPTION
## Description

Benchmark harness and baseline evidence come from the independent benchmark PR #1920.

This PR bounds scheduler memory retained for node-fit errors when many pending tasks fail across many candidate nodes.

Previously, each pending task retained a complete fit error for every rejected node, so retained memory scaled as `pending tasks × candidate nodes`. This PR retains aggregated reason counts per task instead, making retained task-fit-error memory scale as `pending tasks × unique reasons`.

It:

- Stores compact reason counts instead of per-node error objects.
- Preserves compact unschedulable messages, reason counts, ordering, and default messages.
- Recomputes complete per-node details from current-session pre-filters and filters only when detailed reporting or enabled V(6) logging requests them.
- Passes the detailed resolver as a normal function during status recording; no resolver state is retained.
- Preserves direct pre-filter errors without unnecessary node recomputation.
- Falls back to the compact message if detailed recomputation cannot produce diagnostics.
- Safely ignores empty and typed-nil fit diagnostics.
- Removes obsolete per-node fit-error storage APIs.

This standalone implementation is based directly on `main`. It preserves the existing `Session.FittingNode` API and immediate fit-error publication semantics; it does not depend on the allocation ownership changes in #1921.

Scheduling decisions, node-fit behavior, task transitions, and user-facing compact and detailed error output remain unchanged.

### 500-node full-cycle reclaim benchmark

| Metric | `origin/main` | This PR | Change |
|---|---:|---:|---:|
| Live heap after Allocate | 597.6 MB | 73.2 MB | -87.8% |
| Live heap after full cycle | 612.2 MB | 87.8 MB | -85.7% |
| Bytes/op | 14.13 GB | 13.93 GB | -1.4% |
| Allocations/op | 397.5 M | 397.4 M | effectively unchanged |
| Tasks with fit errors after Allocate | 4,000 | 4,000 | unchanged |

The unchanged fit-error task count verifies that the retained-memory reduction does not come from skipping failed-task diagnostics. Total allocation churn remains near `main`; the improvement is the amount of fit-error data retained across the scheduling cycle.

## Related Issues

Fixes #1827

Related to #1653

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [x] Added changie fragment

## Breaking Changes

No user-facing breaking changes.

The internal cache/status-updater fit-error path accepts a function that recomputes transient detailed node errors from the current scheduling session.

## Additional Notes

Validation performed:

- Focused common-info, podgroup-info, framework, and cache tests
- `go test ./pkg/scheduler/... -count=1`
- `make validate`
- `BenchmarkReclaimManySingleGPUJobsFullCycle_500Node` with `-benchmem -benchtime=1x -count=1`

Latest benchmark result:

- `73,165,728` bytes live after Allocate
- `87,770,120` bytes live after full cycle
- `13,930,262,256 B/op`
- `397,448,456 allocs/op`

The expensive 500-node benchmark remains outside the default CI benchmark regex.
