### PR TITLE
feat(scheduler): add PDB support for scheduler replicas

### DIFF
--- a/.changes/unreleased/Added-20260715-120000.yaml
+++ b/.changes/unreleased/Added-20260715-120000.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Added support for configuring scheduler Pod Disruption Budget via Helm values (`scheduler.podDisruptionBudget`) when running multiple replicas per scheduling shard.
+custom:
+  Issue: "1624"
+  Author: dttung2905

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -283,6 +283,13 @@ spec:
       affinity:
         {{- toYaml .Values.scheduler.affinity | nindent 8 }}
       {{- end }}
+      podDisruptionBudget:
+        {{- if hasKey .Values.scheduler.podDisruptionBudget "enabled" }}
+        enabled: {{ .Values.scheduler.podDisruptionBudget.enabled }}
+        {{- end }}
+        {{- if hasKey .Values.scheduler.podDisruptionBudget "maxUnavailable" }}
+        maxUnavailable: {{ .Values.scheduler.podDisruptionBudget.maxUnavailable }}
+        {{- end }}
     {{- if and .Values.scheduler.ports .Values.scheduler.ports.metricsPort }}
     schedulerService:
       port: {{ .Values.scheduler.ports.metricsPort }}

--- a/deployments/kai-scheduler/tests/scheduler_pdb_test.yaml
+++ b/deployments/kai-scheduler/tests/scheduler_pdb_test.yaml
@@ -1,0 +1,35 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: scheduler podDisruptionBudget in kai-config
+
+set:
+  kaiConfigDeployer:
+    enabled: false
+  kaiConfig:
+    render: true
+
+templates:
+  - kai-config.yaml
+tests:
+  - it: renders scheduler podDisruptionBudget from values
+    set:
+      scheduler.podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.scheduler.service.podDisruptionBudget.enabled
+          value: true
+      - equal:
+          path: spec.scheduler.service.podDisruptionBudget.maxUnavailable
+          value: 1
+
+  - it: renders disabled PDB without maxUnavailable when only enabled is set in test values
+    set:
+      scheduler.podDisruptionBudget:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.scheduler.service.podDisruptionBudget.enabled
+          value: false

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -163,6 +163,11 @@ scheduler:
   actions: {}
   # Alpha/experimental scenario search time budgets. Values are Go duration strings.
   scenarioSearchBudgets: {}
+  # PDB is created only when scheduler replicas > 1 (global.replicaCount / scheduler.replicas).
+  # For HA: set operator.replicaCount: 2 (or override scheduler.replicas in Config).
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
 
 # defaultShard controls the chart-managed "default" SchedulingShard CR,
 # whose spec is populated from the scheduler.* values above.

--- a/pkg/operator/operands/common/common.go
+++ b/pkg/operator/operands/common/common.go
@@ -36,6 +36,7 @@ const (
 // PodDisruptionBudgetImplementedServices lists operand resource names with operator-side PDB creation.
 var PodDisruptionBudgetImplementedServices = map[string]struct{}{
 	"admission": {},
+	"scheduler": {},
 }
 
 func PodDisruptionBudgetImplemented(serviceName string) bool {

--- a/pkg/operator/operands/common/common_test.go
+++ b/pkg/operator/operands/common/common_test.go
@@ -538,9 +538,9 @@ var _ = Describe("PodDisruptionBudgetForKAIConfig", func() {
 
 var _ = Describe("PodDisruptionBudgetImplementedServices", func() {
 	It("only lists operands with operator-side PDB creation", func() {
-		Expect(PodDisruptionBudgetImplementedServices).To(HaveLen(1))
+		Expect(PodDisruptionBudgetImplementedServices).To(HaveLen(2))
 		Expect(PodDisruptionBudgetImplemented("admission")).To(BeTrue())
+		Expect(PodDisruptionBudgetImplemented("scheduler")).To(BeTrue())
 		Expect(PodDisruptionBudgetImplemented("binder")).To(BeFalse())
-		Expect(PodDisruptionBudgetImplemented("scheduler")).To(BeFalse())
 	})
 })

--- a/pkg/operator/operands/scheduler/resources_for_shard.go
+++ b/pkg/operator/operands/scheduler/resources_for_shard.go
@@ -375,6 +375,21 @@ func DeploymentName(config *kaiv1.Config, shard *kaiv1.SchedulingShard) string {
 	return fmt.Sprintf("%s-%s", *config.Spec.Global.SchedulerName, shard.Name)
 }
 
+func (s *SchedulerForShard) podDisruptionBudgetForShard(
+	ctx context.Context, readerClient client.Reader,
+	kaiConfig *kaiv1.Config, shard *kaiv1.SchedulingShard,
+) (client.Object, error) {
+	config := kaiConfig.Spec.Scheduler
+	return common.PodDisruptionBudgetForKAIConfig(
+		ctx,
+		readerClient,
+		kaiConfig.Spec.Namespace,
+		DeploymentName(kaiConfig, shard),
+		config.Replicas,
+		config.Service,
+	)
+}
+
 // serviceName for the per-shard scheduler Service.
 func serviceName(config *kaiv1.Config, shard *kaiv1.SchedulingShard) string {
 	return fmt.Sprintf("%s-%s", *config.Spec.Global.SchedulerName, shard.Name)

--- a/pkg/operator/operands/scheduler/resources_test.go
+++ b/pkg/operator/operands/scheduler/resources_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kai-scheduler/KAI-scheduler/cmd/scheduler/app/options"
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/common"
 	kaiprometheus "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/prometheus"
 	kaiv1qc "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/queue_controller"
 	kaiv1scheduler "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/scheduler"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1410,6 +1412,84 @@ func TestGetUsageDBConfig(t *testing.T) {
 					tt.validate(t, result)
 				}
 			}
+		})
+	}
+}
+
+func TestPodDisruptionBudgetForShard(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientBuilder().Build()
+
+	shard := &kaiv1.SchedulingShard{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	shard.Spec.SetDefaultsWhereNeeded()
+
+	tests := []struct {
+		name              string
+		replicas          int32
+		pdbEnabled        bool
+		maxUnavailable    int32
+		expectPDBCreation bool
+	}{
+		{
+			name:              "skip PDB when replicas is one",
+			replicas:          1,
+			pdbEnabled:        true,
+			maxUnavailable:    1,
+			expectPDBCreation: false,
+		},
+		{
+			name:              "create PDB when replicas greater than one and enabled",
+			replicas:          2,
+			pdbEnabled:        true,
+			maxUnavailable:    1,
+			expectPDBCreation: true,
+		},
+		{
+			name:              "skip PDB when disabled",
+			replicas:          3,
+			pdbEnabled:        false,
+			maxUnavailable:    1,
+			expectPDBCreation: false,
+		},
+		{
+			name:              "custom maxUnavailable",
+			replicas:          2,
+			pdbEnabled:        true,
+			maxUnavailable:    2,
+			expectPDBCreation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &kaiv1.Config{}
+			config.Spec.SetDefaultsWhereNeeded()
+			config.Spec.Scheduler.Replicas = ptr.To(tt.replicas)
+			config.Spec.Scheduler.Service.PodDisruptionBudget = &common.PodDisruptionBudget{
+				Enabled:        ptr.To(tt.pdbEnabled),
+				MaxUnavailable: ptr.To(tt.maxUnavailable),
+			}
+
+			s := NewSchedulerForShard(shard)
+			obj, err := s.podDisruptionBudgetForShard(ctx, client, config, shard)
+			require.NoError(t, err)
+
+			if !tt.expectPDBCreation {
+				assert.Nil(t, obj)
+				return
+			}
+
+			require.NotNil(t, obj)
+			pdb, ok := obj.(*policyv1.PodDisruptionBudget)
+			require.True(t, ok, "object should be PodDisruptionBudget")
+			assert.Equal(t, "kai-scheduler-default", pdb.Name)
+			assert.Equal(t, constants.DefaultKAINamespace, pdb.Namespace)
+			require.NotNil(t, pdb.Spec.MaxUnavailable)
+			assert.Equal(t, tt.maxUnavailable, pdb.Spec.MaxUnavailable.IntVal)
+			require.NotNil(t, pdb.Spec.Selector)
+			assert.Equal(t, "kai-scheduler-default", pdb.Spec.Selector.MatchLabels["app"])
 		})
 	}
 }

--- a/pkg/operator/operands/scheduler/scheduler.go
+++ b/pkg/operator/operands/scheduler/scheduler.go
@@ -58,6 +58,7 @@ func (s *SchedulerForShard) DesiredState(
 	objects := []client.Object{}
 	for _, resourceFunc := range []resourceForShard{
 		s.deploymentForShard,
+		s.podDisruptionBudgetForShard,
 		s.configMapForShard,
 		s.serviceForShard,
 		s.endpointSliceForShard,

--- a/pkg/operator/operands/scheduler/scheduler_test.go
+++ b/pkg/operator/operands/scheduler/scheduler_test.go
@@ -11,8 +11,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/common"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,6 +130,80 @@ var _ = Describe("Scheduler", func() {
 		services := &v1.ServiceList{}
 		Expect(fakeClient.List(ctx, services, client.InNamespace(kaiConfig.Spec.Namespace))).To(Succeed())
 		Expect(len(services.Items)).To(Equal(2))
+	})
+
+	It("Should create one PDB per shard when HA and PDB enabled", func(ctx context.Context) {
+		kaiConfig.Spec.Scheduler.Replicas = ptr.To(int32(2))
+		kaiConfig.Spec.Scheduler.Service.PodDisruptionBudget = &common.PodDisruptionBudget{
+			Enabled:        ptr.To(true),
+			MaxUnavailable: ptr.To(int32(1)),
+		}
+
+		desiredState, err := schedulerOperandForShard.DesiredState(ctx, fakeClient, kaiConfig)
+		Expect(err).To(BeNil())
+		for _, obj := range desiredState {
+			Expect(fakeClient.Create(ctx, obj)).To(Succeed())
+		}
+
+		otherShard := &kaiv1.SchedulingShard{
+			ObjectMeta: metav1.ObjectMeta{Name: "other"},
+		}
+		otherShard.Spec.SetDefaultsWhereNeeded()
+		otherDesiredState, err := NewSchedulerForShard(otherShard).DesiredState(ctx, fakeClient, kaiConfig)
+		Expect(err).To(BeNil())
+		for _, obj := range otherDesiredState {
+			Expect(fakeClient.Create(ctx, obj)).To(Succeed())
+		}
+
+		pdbs := &policyv1.PodDisruptionBudgetList{}
+		Expect(fakeClient.List(ctx, pdbs, client.InNamespace(kaiConfig.Spec.Namespace))).To(Succeed())
+		Expect(pdbs.Items).To(HaveLen(2))
+		pdbNames := []string{pdbs.Items[0].Name, pdbs.Items[1].Name}
+		Expect(pdbNames).To(ConsistOf("kai-scheduler-default", "kai-scheduler-other"))
+	})
+
+	Context("PodDisruptionBudget DesiredState", func() {
+		It("includes PDB when HA and enabled", func(ctx context.Context) {
+			kaiConfig.Spec.Scheduler.Replicas = ptr.To(int32(2))
+			kaiConfig.Spec.Scheduler.Service.PodDisruptionBudget = &common.PodDisruptionBudget{
+				Enabled: ptr.To(true),
+			}
+
+			desiredState, err := schedulerOperandForShard.DesiredState(ctx, fakeClient, kaiConfig)
+			Expect(err).To(BeNil())
+			Expect(desiredState).To(HaveLen(5))
+
+			var pdbCount int
+			for _, obj := range desiredState {
+				if _, ok := obj.(*policyv1.PodDisruptionBudget); ok {
+					pdbCount++
+				}
+			}
+			Expect(pdbCount).To(Equal(1))
+		})
+
+		It("omits PDB when HA but disabled", func(ctx context.Context) {
+			kaiConfig.Spec.Scheduler.Replicas = ptr.To(int32(2))
+			kaiConfig.Spec.Scheduler.Service.PodDisruptionBudget = &common.PodDisruptionBudget{
+				Enabled: ptr.To(false),
+			}
+
+			desiredState, err := schedulerOperandForShard.DesiredState(ctx, fakeClient, kaiConfig)
+			Expect(err).To(BeNil())
+			Expect(desiredState).To(HaveLen(4))
+
+			for _, obj := range desiredState {
+				Expect(obj).NotTo(BeAssignableToTypeOf(&policyv1.PodDisruptionBudget{}))
+			}
+		})
+
+		It("returns empty desired state when scheduler disabled", func(ctx context.Context) {
+			kaiConfig.Spec.Scheduler.Service.Enabled = ptr.To(false)
+
+			desiredState, err := schedulerOperandForShard.DesiredState(ctx, fakeClient, kaiConfig)
+			Expect(err).To(BeNil())
+			Expect(desiredState).To(BeEmpty())
+		})
 	})
 
 	Context("ConfigMap", func() {


### PR DESCRIPTION
## Description

Adds configurable Pod Disruption Budgets for scheduler replicas running across multiple shards. PDBs are created per-shard only when high availability (multiple replicas) is configured and the feature is enabled via Helm values.

Closes #1624 by applying the requested changes from the original PR (rebased on main, replaced direct `CHANGELOG.md` edit with a changie fragment).

## Related Issues

Fixes #1477

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None

## Additional Notes

Original PR by @dttung2905. This PR rebases the work on main (after the changie migration in #1839) and replaces the old `CHANGELOG.md` direct edit with a proper changie fragment under `.changes/unreleased/`.