### PR TITLE
docs(gpu-sharing): fix hami-core install flags to match chart values

### DIFF
--- a/docs/gpu-sharing/hami/README.md
+++ b/docs/gpu-sharing/hami/README.md
@@ -41,8 +41,8 @@ KAI Scheduler's GPU sharing feature allows multiple pods to share a single GPU, 
 
   ```bash
   helm install kai-scheduler oci://ghcr.io/nvidia/kai-scheduler \
-    --set scheduler.gpuSharing.enabled=true \
-    --set scheduler.gpuSharing.hamicoreEnabled=true \
+    --set global.gpuSharing=true \
+    --set binder.plugins.hamicore.enabled=true \
     --namespace kai-scheduler --create-namespace
   ```
 


### PR DESCRIPTION
the docs enable hami-core with `--set scheduler.gpuSharing.enabled=true --set scheduler.gpuSharing.hamicoreEnabled=true`, but those keys don't exist in the kai-scheduler chart (checked v0.16.0 through main), so helm silently ignores them and nothing gets enabled.

fix: use the real values `--set global.gpuSharing=true --set binder.plugins.hamicore.enabled=true`. verified with `helm template`.

fixes #1912