### PR TITLE
fix: correct 'Sucesfully' → 'Successfully' typo in consolidation log

### DIFF
--- a/pkg/scheduler/actions/consolidation/consolidation.go
+++ b/pkg/scheduler/actions/consolidation/consolidation.go
@@ -123,7 +123,7 @@ func attemptToConsolidatePreemptor(
 	isScenarioFeasible, stmt, victimsTasksNames, searchResult := solver.SolveWithResult(ssn, preemptor)
 	if isScenarioFeasible {
 		log.InfraLogger.V(3).Infof(
-			"Sucesfully consolidated for job: <%s/%s>, and about to reallocate victims: <%v>",
+			"Successfully consolidated for job: <%s/%s>, and about to reallocate victims: <%v>",
 			preemptor.Namespace, preemptor.Name, victimsTasksNames)
 		return true, stmt, searchResult
 	}


### PR DESCRIPTION
## Summary
Corrected a typo in consolidation scheduler log message: `Sucesfully` → `Successfully`

## Fix
Single character typo fix (removes extra 'e'). Code logic unchanged.