### PR TITLE
Fix: admission and scheduler PDB reconciliation loop

### DIFF
--- a/.changes/unreleased/Fixed-20260718-212943.yaml
+++ b/.changes/unreleased/Fixed-20260718-212943.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed admission and scheduler PodDisruptionBudget reconciliation, including drift recovery and cleanup when no longer desired.
+time: 2026-07-18T21:29:43.130860557+01:00
+custom:
+    Author: dttung2905
+    Issue: "1477"

--- a/pkg/operator/controller/integration_tests/config_controller_test.go
+++ b/pkg/operator/controller/integration_tests/config_controller_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
+	kaiv1admission "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/admission"
 	kaiv1binder "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/binder"
+	kaiv1scheduler "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1/scheduler"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,6 +18,8 @@ import (
 	nvidiav1 "github.com/kai-scheduler/KAI-scheduler/third_party/nvidia/gpu-operator/api/nvidia/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -112,6 +116,171 @@ var _ = Describe("KAIConfigController", Ordered, func() {
 					}
 				}
 				return false
+			}, "10s", "200ms").Should(BeTrue())
+		})
+	})
+
+	Context("Reconciling the admission PodDisruptionBudget", Ordered, func() {
+		const pdbName = "admission"
+
+		updateAdmissionPDBConfig := func(ctx context.Context, replicas int32, enabled bool) {
+			Eventually(func() error {
+				currentConfig := &kaiv1.Config{}
+				if err := k8sClient.Get(
+					ctx,
+					types.NamespacedName{Name: constants.DefaultKAIConfigSingeltonInstanceName},
+					currentConfig,
+				); err != nil {
+					return err
+				}
+				currentConfig.Spec.Admission = &kaiv1admission.Admission{
+					Replicas: ptr.To(replicas),
+					Service: &v1common.Service{
+						Enabled: ptr.To(true),
+						PodDisruptionBudget: &v1common.PodDisruptionBudget{
+							Enabled:        ptr.To(enabled),
+							MaxUnavailable: ptr.To(int32(1)),
+						},
+					},
+				}
+				return k8sClient.Update(ctx, currentConfig)
+			}, "10s", "200ms").Should(Succeed())
+		}
+
+		getPDB := func(ctx context.Context) (*policyv1.PodDisruptionBudget, error) {
+			pdb := &policyv1.PodDisruptionBudget{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      pdbName,
+				Namespace: kaiConfig.Spec.Namespace,
+			}, pdb)
+			return pdb, err
+		}
+
+		It("creates and watches the PDB", func(ctx context.Context) {
+			updateAdmissionPDBConfig(ctx, 2, true)
+
+			Eventually(func(g Gomega) {
+				pdb, err := getPDB(ctx)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(metav1.GetControllerOf(pdb)).NotTo(BeNil())
+				g.Expect(metav1.GetControllerOf(pdb).Kind).To(Equal("Config"))
+			}, "10s", "200ms").Should(Succeed())
+
+			pdb, err := getPDB(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, pdb)).To(Succeed())
+
+			Eventually(func() error {
+				_, err := getPDB(ctx)
+				return err
+			}, "10s", "200ms").Should(Succeed())
+		})
+
+		It("removes the PDB after scaling admission down to one replica", func(ctx context.Context) {
+			updateAdmissionPDBConfig(ctx, 1, true)
+
+			Eventually(func() bool {
+				_, err := getPDB(ctx)
+				return apierrors.IsNotFound(err)
+			}, "10s", "200ms").Should(BeTrue())
+		})
+
+		It("removes the PDB when it is disabled", func(ctx context.Context) {
+			updateAdmissionPDBConfig(ctx, 2, true)
+			Eventually(func() error {
+				_, err := getPDB(ctx)
+				return err
+			}, "10s", "200ms").Should(Succeed())
+
+			updateAdmissionPDBConfig(ctx, 2, false)
+			Eventually(func() bool {
+				_, err := getPDB(ctx)
+				return apierrors.IsNotFound(err)
+			}, "10s", "200ms").Should(BeTrue())
+		})
+	})
+
+	Context("Reconciling the scheduler PodDisruptionBudget", Ordered, func() {
+		const (
+			shardName = "pdb-test"
+			pdbName   = "kai-scheduler-" + shardName
+		)
+
+		updateSchedulerPDBConfig := func(ctx context.Context, replicas int32, enabled bool) {
+			Eventually(func() error {
+				currentConfig := &kaiv1.Config{}
+				if err := k8sClient.Get(
+					ctx,
+					types.NamespacedName{Name: constants.DefaultKAIConfigSingeltonInstanceName},
+					currentConfig,
+				); err != nil {
+					return err
+				}
+				currentConfig.Spec.Scheduler = &kaiv1scheduler.Scheduler{
+					Replicas: ptr.To(replicas),
+					Service: &v1common.Service{
+						Enabled: ptr.To(true),
+						PodDisruptionBudget: &v1common.PodDisruptionBudget{
+							Enabled:        ptr.To(enabled),
+							MaxUnavailable: ptr.To(int32(1)),
+						},
+					},
+				}
+				return k8sClient.Update(ctx, currentConfig)
+			}, "10s", "200ms").Should(Succeed())
+		}
+
+		getPDB := func(ctx context.Context) (*policyv1.PodDisruptionBudget, error) {
+			pdb := &policyv1.PodDisruptionBudget{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      pdbName,
+				Namespace: kaiConfig.Spec.Namespace,
+			}, pdb)
+			return pdb, err
+		}
+
+		BeforeAll(func(ctx context.Context) {
+			updateSchedulerPDBConfig(ctx, 2, true)
+			Expect(k8sClient.Create(ctx, &kaiv1.SchedulingShard{
+				ObjectMeta: metav1.ObjectMeta{Name: shardName},
+			})).To(Succeed())
+		})
+
+		AfterAll(func(ctx context.Context) {
+			shard := &kaiv1.SchedulingShard{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: shardName}, shard)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, shard)).To(Succeed())
+			} else {
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}
+		})
+
+		It("creates and watches one PDB for the shard", func(ctx context.Context) {
+			Eventually(func(g Gomega) {
+				pdb, err := getPDB(ctx)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(metav1.GetControllerOf(pdb)).NotTo(BeNil())
+				g.Expect(metav1.GetControllerOf(pdb).Kind).To(Equal("SchedulingShard"))
+				g.Expect(metav1.GetControllerOf(pdb).Name).To(Equal(shardName))
+			}, "10s", "200ms").Should(Succeed())
+
+			pdb, err := getPDB(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, pdb)).To(Succeed())
+
+			Eventually(func() error {
+				_, err := getPDB(ctx)
+				return err
+			}, "10s", "200ms").Should(Succeed())
+		})
+
+		It("removes the shard PDB after scheduler scales down", func(ctx context.Context) {
+			updateSchedulerPDBConfig(ctx, 1, true)
+
+			Eventually(func() bool {
+				_, err := getPDB(ctx)
+				return apierrors.IsNotFound(err)
 			}, "10s", "200ms").Should(BeTrue())
 		})
 	})

--- a/pkg/operator/controller/integration_tests/suite_test.go
+++ b/pkg/operator/controller/integration_tests/suite_test.go
@@ -33,7 +33,10 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,6 +76,9 @@ var _ = BeforeSuite(func() {
 	Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 	Expect(apiserver.AddToScheme(scheme)).To(Succeed())
 	Expect(admissionv1.AddToScheme(scheme)).To(Succeed())
+	Expect(coordinationv1.AddToScheme(scheme)).To(Succeed())
+	Expect(discoveryv1.AddToScheme(scheme)).To(Succeed())
+	Expect(policyv1.AddToScheme(scheme)).To(Succeed())
 	Expect(apiextensionsv1.AddToScheme(scheme)).To(Succeed())
 
 	By("bootstrapping test environment")
@@ -123,6 +129,14 @@ var _ = BeforeSuite(func() {
 	}
 	configReconciler.SetOperands(controller.ConfigReconcilerOperands)
 	err = configReconciler.SetupWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	shardReconciler := controller.NewSchedulingShardReconciler(
+		k8sManager.GetClient(),
+		k8sManager.GetScheme(),
+	)
+	shardReconciler.SetOperands(controller.OperandsForShard)
+	err = shardReconciler.SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/pkg/operator/operands/deployable/deployable_test.go
+++ b/pkg/operator/operands/deployable/deployable_test.go
@@ -19,7 +19,9 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -54,6 +56,7 @@ var _ = Describe("Deployable", func() {
 		Expect(kaiv1.AddToScheme(testScheme)).To(Succeed())
 		Expect(apiextensionsv1.AddToScheme(testScheme)).To(Succeed())
 		Expect(monitoringv1.AddToScheme(testScheme)).To(Succeed())
+		Expect(policyv1.AddToScheme(testScheme)).To(Succeed())
 		Expect(vpav1.AddToScheme(testScheme)).To(Succeed())
 
 		fakeClientBuilder = fake.NewClientBuilder().
@@ -213,6 +216,77 @@ var _ = Describe("Deployable", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(createCalls).To(Equal(1))
 				Expect(updateCalls).To(Equal(1))
+			})
+		})
+
+		Context("PodDisruptionBudget lifecycle", func() {
+			var existingPDB *policyv1.PodDisruptionBudget
+
+			BeforeEach(func() {
+				existingPDB = &policyv1.PodDisruptionBudget{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "PodDisruptionBudget",
+						APIVersion: policyv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admission",
+						Namespace: "kai-scheduler",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: kaiv1.GroupVersion.String(),
+							Kind:       "Config",
+							Name:       kaiConfig.Name,
+							UID:        kaiConfig.UID,
+							Controller: ptr.To(true),
+						}},
+					},
+				}
+			})
+
+			It("collects an existing PDB instead of attempting to create it again", func() {
+				pdbCreateCalls := 0
+				builder := fakeClientBuilder.
+					WithObjects(existingPDB).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(
+							ctx context.Context,
+							runtimeClient client.WithWatch,
+							obj client.Object,
+							opts ...client.CreateOption,
+						) error {
+							if _, ok := obj.(*policyv1.PodDisruptionBudget); ok {
+								pdbCreateCalls++
+							}
+							return runtimeClient.Create(ctx, obj, opts...)
+						},
+					})
+				fakeClient := getFakeClient(builder, known_types.KAIConfigRegisteredCollectible)
+				deployable := New(
+					[]operands.Operand{&fakePDBOperand{enabled: true}},
+					known_types.KAIConfigRegisteredCollectible,
+				)
+
+				Expect(deployable.Deploy(context.Background(), fakeClient, kaiConfig, kaiConfig)).To(Succeed())
+				Expect(pdbCreateCalls).To(BeZero())
+			})
+
+			It("deletes an owned PDB when it is no longer desired", func() {
+				fakeClient := getFakeClient(
+					fakeClientBuilder.WithObjects(existingPDB),
+					known_types.KAIConfigRegisteredCollectible,
+				)
+				deployable := New(
+					[]operands.Operand{&fakePDBOperand{enabled: false}},
+					known_types.KAIConfigRegisteredCollectible,
+				)
+
+				Expect(deployable.Deploy(context.Background(), fakeClient, kaiConfig, kaiConfig)).To(Succeed())
+
+				err := fakeClient.Get(
+					context.Background(),
+					client.ObjectKeyFromObject(existingPDB),
+					&policyv1.PodDisruptionBudget{},
+				)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 	})
@@ -440,6 +514,53 @@ var _ = Describe("Deployable", func() {
 type fakeOperand struct {
 	isDeployed, isAvailable bool
 	name                    string
+}
+
+type fakePDBOperand struct {
+	enabled bool
+}
+
+func (f *fakePDBOperand) DesiredState(
+	ctx context.Context,
+	runtimeClient client.Reader,
+	_ *kaiv1.Config,
+) ([]client.Object, error) {
+	if !f.enabled {
+		return nil, nil
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := runtimeClient.Get(ctx, client.ObjectKey{Name: "admission", Namespace: "kai-scheduler"}, pdb)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	pdb.TypeMeta = metav1.TypeMeta{
+		Kind:       "PodDisruptionBudget",
+		APIVersion: policyv1.SchemeGroupVersion.String(),
+	}
+	pdb.Name = "admission"
+	pdb.Namespace = "kai-scheduler"
+	return []client.Object{pdb}, nil
+}
+
+func (f *fakePDBOperand) IsDeployed(context.Context, client.Reader) (bool, error) {
+	return true, nil
+}
+
+func (f *fakePDBOperand) IsAvailable(context.Context, client.Reader) (bool, error) {
+	return true, nil
+}
+
+func (f *fakePDBOperand) Monitor(context.Context, client.Reader, *kaiv1.Config) error {
+	return nil
+}
+
+func (f *fakePDBOperand) HasMissingDependencies(context.Context, client.Reader, *kaiv1.Config) (string, error) {
+	return "", nil
+}
+
+func (f *fakePDBOperand) Name() string {
+	return "fakePDBOperand"
 }
 
 func (f *fakeOperand) DesiredState(_ context.Context, _ client.Reader, _ *kaiv1.Config) ([]client.Object, error) {

--- a/pkg/operator/operands/known_types/known_types.go
+++ b/pkg/operator/operands/known_types/known_types.go
@@ -49,6 +49,7 @@ func init() {
 	registerCustomResourceDefinitions()
 	registerPrometheus()
 	registerVerticalPodAutoscalers()
+	registerPodDisruptionBudgets()
 }
 
 func SetupKAIConfigOwned(fn *Collectable) {

--- a/pkg/operator/operands/known_types/known_types_test.go
+++ b/pkg/operator/operands/known_types/known_types_test.go
@@ -4,14 +4,18 @@
 package known_types
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kaiv1 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/kai/v1"
 )
@@ -79,6 +83,103 @@ var _ = Describe("vpaIndexer", func() {
 		keys := vpaIndexer(vpa)
 		Expect(keys).To(BeNil())
 	})
+})
+
+var _ = Describe("PodDisruptionBudget collection", func() {
+	It("indexes PDBs controlled by KAI resources", func() {
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: kaiv1.GroupVersion.String(),
+					Kind:       "Config",
+					Name:       SingletonInstanceName,
+					Controller: ptrBool(true),
+				}},
+			},
+		}
+
+		Expect(podDisruptionBudgetIndexer(pdb)).To(Equal([]string{
+			GetKey(kaiv1.GroupVersion.WithKind("Config"), "", SingletonInstanceName),
+		}))
+	})
+
+	It("does not index unowned or non-KAI PDBs", func() {
+		Expect(podDisruptionBudgetIndexer(&policyv1.PodDisruptionBudget{})).To(BeNil())
+
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "scheduler",
+					Controller: ptrBool(true),
+				}},
+			},
+		}
+		Expect(podDisruptionBudgetIndexer(pdb)).To(BeNil())
+	})
+
+	DescribeTable("collects only PDBs owned by the reconciled resource",
+		func(ownerKind string) {
+			scheme := runtime.NewScheme()
+			Expect(kaiv1.AddToScheme(scheme)).To(Succeed())
+			Expect(policyv1.AddToScheme(scheme)).To(Succeed())
+
+			reconcilerName := SingletonInstanceName
+			if ownerKind == "SchedulingShard" {
+				reconcilerName = "default"
+			}
+			reconciler := &kaiv1.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kaiv1.GroupVersion.String(),
+					Kind:       ownerKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: reconcilerName},
+			}
+
+			ownedPDB := &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "owned",
+					Namespace: "kai-scheduler",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: kaiv1.GroupVersion.String(),
+						Kind:       ownerKind,
+						Name:       reconcilerName,
+						Controller: ptrBool(true),
+					}},
+				},
+			}
+			otherPDB := &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other",
+					Namespace: "kai-scheduler",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: kaiv1.GroupVersion.String(),
+						Kind:       ownerKind,
+						Name:       "other-owner",
+						Controller: ptrBool(true),
+					}},
+				},
+			}
+
+			runtimeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(ownedPDB, otherPDB).
+				WithIndex(&policyv1.PodDisruptionBudget{}, CollectableOwnerKey, podDisruptionBudgetIndexer).
+				Build()
+
+			state, err := getCurrentPodDisruptionBudgetsState(context.Background(), runtimeClient, reconciler)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(HaveLen(1))
+			Expect(state).To(HaveKey(GetKey(
+				policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget"),
+				ownedPDB.Namespace,
+				ownedPDB.Name,
+			)))
+		},
+		Entry("for Config owners", "Config"),
+		Entry("for SchedulingShard owners", "SchedulingShard"),
+	)
 })
 
 var _ = Describe("VPAFieldInherit", func() {

--- a/pkg/operator/operands/known_types/poddisruptionbudgets.go
+++ b/pkg/operator/operands/known_types/poddisruptionbudgets.go
@@ -1,0 +1,74 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package known_types
+
+import (
+	"context"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func podDisruptionBudgetIndexer(object client.Object) []string {
+	pdb := object.(*policyv1.PodDisruptionBudget)
+	owner := metav1.GetControllerOf(pdb)
+	if !checkOwnerType(owner) {
+		return nil
+	}
+	return []string{getOwnerKey(owner)}
+}
+
+func registerPodDisruptionBudgets() {
+	collectable := &Collectable{
+		Collect: getCurrentPodDisruptionBudgetsState,
+		InitWithManager: func(ctx context.Context, mgr manager.Manager) error {
+			return mgr.GetFieldIndexer().IndexField(
+				ctx,
+				&policyv1.PodDisruptionBudget{},
+				CollectableOwnerKey,
+				podDisruptionBudgetIndexer,
+			)
+		},
+		InitWithBuilder: func(builder *builder.Builder) *builder.Builder {
+			return builder.Owns(&policyv1.PodDisruptionBudget{})
+		},
+		InitWithFakeClientBuilder: func(fakeClientBuilder *fake.ClientBuilder) {
+			fakeClientBuilder.WithIndex(
+				&policyv1.PodDisruptionBudget{},
+				CollectableOwnerKey,
+				podDisruptionBudgetIndexer,
+			)
+		},
+	}
+	SetupKAIConfigOwned(collectable)
+	SetupSchedulingShardOwned(collectable)
+}
+
+func getCurrentPodDisruptionBudgetsState(
+	ctx context.Context,
+	runtimeClient client.Client,
+	reconciler client.Object,
+) (map[string]client.Object, error) {
+	result := map[string]client.Object{}
+	pdbs := &policyv1.PodDisruptionBudgetList{}
+	reconcilerKey := getReconcilerKey(reconciler)
+
+	err := runtimeClient.List(ctx, pdbs, client.MatchingFields{CollectableOwnerKey: reconcilerKey})
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := schema.GroupVersionKind{Group: policyv1.GroupName, Version: "v1", Kind: "PodDisruptionBudget"}
+	for i := range pdbs.Items {
+		pdb := &pdbs.Items[i]
+		result[GetKey(gvk, pdb.Namespace, pdb.Name)] = pdb
+	}
+
+	return result, nil
+}


### PR DESCRIPTION


## Description

Adds PodDisruptionBudget resources to the operator reconciliation loop for KAI admission and scheduler.

Previously, existing PDBs were not collected or watched by the operator. This prevented normal cleanup when PDBs were disabled or replicas were reduced, and external deletion did not trigger reconciliation.

This PR registers Config-owned admission PDBs and SchedulingShard-owned scheduler PDBs so they are updated, recreated, and removed according to the desired configuration.

## Related Issues

Related to https://github.com/kai-scheduler/KAI-Scheduler/issues/1477

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes
nil

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
