### PR TITLE
fix(scheduler): Fixed numa behavior for non-QoS-guaranteed pods with device request

### DIFF
--- a/.changes/unreleased/Fixed-20260721-213513.yaml
+++ b/.changes/unreleased/Fixed-20260721-213513.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  NUMA plugin now aligns non-Guaranteed pods that request GPUs, matching the kubelet's device manager (device alignment is QoS-independent).

--- a/docs/developer/designs/numa-topology/README.md
+++ b/docs/developer/designs/numa-topology/README.md
@@ -3,8 +3,9 @@
 ## Summary
 
 This document describes a v1 design for making KAI-Scheduler aware of per-NUMA-node
-resource topology, so that **Guaranteed-QoS workloads** are placed only on nodes where the
-kubelet's Topology Manager can actually align their resources.
+resource topology, so that workloads are placed only on nodes where the kubelet's Topology Manager
+can actually align their resources (devices/GPUs for any QoS class; cpu/memory only for
+Guaranteed-QoS pods).
 
 The scheduler consumes the [`NodeResourceTopology`][nrt-api] (NRT) CRD, which is published
 per-node by an external exporter (NFD topology-updater or the resource-topology-exporter).
@@ -226,12 +227,19 @@ the kubelet, which aligns them only for Guaranteed QoS.)
 
 ### `shouldHandle` gate
 
-The plugin engages for a task only when **both** hold (otherwise the predicate passes
-through):
+The plugin engages for a task on a `single-numa-node`/`restricted` node when the kubelet would
+NUMA-align any of its resources:
 
-- the node has a `NumaTopology` whose policy is `single-numa-node` or `restricted`, and
-- `task.Pod.Status.QOSClass == Guaranteed` — the QoS for which the kubelet Topology Manager runs
-  alignment at all.
+- **devices** (GPUs and other topology device-plugin resources) are aligned for **all** QoS classes,
+  so a non-Guaranteed task that requests one *is* handled (`requestsAlignedDevice` checks its
+  request vector against the node's non-cpu/memory `AwareIndices`); and
+- **cpu / memory / hugepages** are aligned only for **Guaranteed** pods.
+
+So `shouldHandle` engages a Guaranteed task unconditionally (it aligns on cpu at least) and a
+non-Guaranteed task iff it requests a topology-aware device. `alignedAware` then drops the
+cpu/memory/hugepages indices for non-Guaranteed tasks, so the evaluator constrains only what the
+kubelet actually aligns — exactly the `suitable(qos, r, ...)` rule below. (Gating the whole pod on
+`QOSClass == Guaranteed` was a bug: a Burstable GPU pod is kubelet-aligned but was passed through.)
 
 At this stage, aligning the GPU *fraction* (where relevant) itself is out of scope (see *Non-Goals*),
 but is feasible in the future.

--- a/pkg/scheduler/plugins/numa/evaluator.go
+++ b/pkg/scheduler/plugins/numa/evaluator.go
@@ -30,6 +30,25 @@ func (pp *numaPlugin) effectiveAware(node *node_info.NodeInfo) []int {
 	return pp.effectiveAwareByNode[node.Name]
 }
 
+// alignedAware returns the aware indices the kubelet aligns for this task: effectiveAware for a
+// Guaranteed task, and for a non-Guaranteed task the same minus the cpu/memory/hugepages indices
+// (those align only for Guaranteed pods; devices align for every QoS class).
+func (pp *numaPlugin) alignedAware(task *pod_info.PodInfo, node *node_info.NodeInfo) []int {
+	aware := pp.effectiveAware(node)
+	if isGuaranteed(task) {
+		return aware
+	}
+	topo := node.NumaTopology
+	out := make([]int, 0, len(aware))
+	for _, idx := range aware {
+		if isQoSGatedResource(topo.AwareNames[idx]) {
+			continue
+		}
+		out = append(out, idx)
+	}
+	return out
+}
+
 // allocatable reports whether the kubelet Topology Manager would align the task on the node. A task
 // the plugin does not constrain passes through as true.
 func (pp *numaPlugin) allocatable(task *pod_info.PodInfo, node *node_info.NodeInfo) bool {
@@ -54,7 +73,7 @@ func (pp *numaPlugin) solveTask(task *pod_info.PodInfo, node *node_info.NodeInfo
 		return true
 	}
 	topo := node.NumaTopology
-	aware := pp.effectiveAware(node)
+	aware := pp.alignedAware(task, node)
 	concurrent, serial := pp.numaRequestsFor(task, topo.VectorMap).forScope(topo.Scope)
 	return solve(topo, aware, concurrent, serial, alloc)
 }

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -236,15 +236,46 @@ func parseIgnoreList(arguments framework.PluginArguments) sets.Set[v1.ResourceNa
 	return ignoreList
 }
 
-// shouldHandle engages the plugin for any Guaranteed task on a rejecting-policy node: the
-// kubelet aligns every Guaranteed pod (fractional/MIG included, on cpu/memory). The request
-// intersection in the evaluator decides which resources actually constrain each task.
+// shouldHandle engages the plugin on a rejecting-policy node for any task the kubelet would
+// NUMA-align. Guaranteed tasks are always handled. A non-Guaranteed task is handled if it requests a
+// topology-aware device.
 func (pp *numaPlugin) shouldHandle(task *pod_info.PodInfo, topo *node_info.NumaTopology) bool {
-	if topo == nil || !isModeledPolicy(topo.Policy) {
+	if topo == nil || !isModeledPolicy(topo.Policy) || task.Pod == nil {
 		return false
 	}
+	if isGuaranteed(task) {
+		return true
+	}
+	return pp.requestsAlignedDevice(task, topo)
+}
 
+// isGuaranteed reports whether the task's pod is Guaranteed QoS.
+func isGuaranteed(task *pod_info.PodInfo) bool {
 	return task.Pod != nil && task.Pod.Status.QOSClass == v1.PodQOSGuaranteed
+}
+
+// isQoSGatedResource reports whether a resource is NUMA-aligned by the kubelet only for Guaranteed
+// pods (cpu via CPU Manager, memory/hugepages via Memory Manager).
+func isQoSGatedResource(name v1.ResourceName) bool {
+	return name == v1.ResourceCPU || name == v1.ResourceMemory ||
+		strings.HasPrefix(string(name), string(v1.ResourceHugePagesPrefix))
+}
+
+// requestsAlignedDevice reports whether the task requests a topology-aware device resource the node
+// tracks per zone (a non cpu/memory/hugepages aware resource, minus the ignoreList). The kubelet's
+// device manager aligns these regardless of QoS, so a non-Guaranteed task that requests one must be
+// evaluated. Reads the task's precomputed request vector by shared-map index.
+func (pp *numaPlugin) requestsAlignedDevice(task *pod_info.PodInfo, topo *node_info.NumaTopology) bool {
+	for _, idx := range topo.AwareIndices {
+		name := topo.AwareNames[idx]
+		if isQoSGatedResource(name) || pp.ignoreList.Has(name) {
+			continue
+		}
+		if task.ResReqVector.Get(idx) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // isModeledPolicy reports whether the plugin engages for a node with this policy.

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -90,20 +90,48 @@ func TestParseIgnoreList(t *testing.T) {
 	}
 }
 
+// testVectorMap is the shared resource-vector map used to project test task requests; the core
+// indices (cpu/memory/gpu/pods) are seeded by NewResourceVectorMap, matching a topology's fresh map.
+var testVectorMap = resource_info.NewResourceVectorMap()
+
 // makeTask builds a minimal task with the given QoS, request type and whole-GPU count.
 func makeTask(qos v1.PodQOSClass, reqType pod_info.ResourceRequestType, gpus float64) *pod_info.PodInfo {
+	requests := v1.ResourceList{}
+	if gpus > 0 {
+		requests[gpu] = *resource.NewQuantity(int64(gpus), resource.DecimalSI)
+	}
 	return &pod_info.PodInfo{
 		ResourceRequestType: reqType,
 		GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(gpus, 0),
-		Pod:                 &v1.Pod{Status: v1.PodStatus{QOSClass: qos}},
+		VectorMap:           testVectorMap,
+		ResReqVector:        resource_info.NewResourceVectorFromResourceList(requests, testVectorMap),
+		Pod: &v1.Pod{
+			Status: v1.PodStatus{QOSClass: qos},
+			Spec:   v1.PodSpec{Containers: []v1.Container{{Resources: v1.ResourceRequirements{Requests: requests, Limits: requests}}}},
+		},
+	}
+}
+
+// burstableTask builds a Burstable pod (requests only) with the given container requests.
+func burstableTask(requests v1.ResourceList) *pod_info.PodInfo {
+	return &pod_info.PodInfo{
+		VectorMap:    testVectorMap,
+		ResReqVector: resource_info.NewResourceVectorFromResourceList(requests, testVectorMap),
+		Pod: &v1.Pod{
+			Status: v1.PodStatus{QOSClass: v1.PodQOSBurstable},
+			Spec:   v1.PodSpec{Containers: []v1.Container{{Resources: v1.ResourceRequirements{Requests: requests}}}},
+		},
 	}
 }
 
 func TestShouldHandle(t *testing.T) {
 	plugin := &numaPlugin{}
-	singleNUMA := &node_info.NumaTopology{Policy: node_info.TopologyPolicySingleNUMANode}
-	restricted := &node_info.NumaTopology{Policy: node_info.TopologyPolicyRestricted}
-	bestEffort := &node_info.NumaTopology{Policy: node_info.TopologyPolicyBestEffort}
+	gpuCPUZones := []node_info.NumaZoneSpec{numaZone("node-0", map[string]string{gpu: "4", "cpu": "8"})}
+	singleNUMA := numaTopology(node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod, gpuCPUZones...)
+	restricted := numaTopology(node_info.TopologyPolicyRestricted, node_info.TopologyScopePod, gpuCPUZones...)
+	bestEffort := numaTopology(node_info.TopologyPolicyBestEffort, node_info.TopologyScopePod, gpuCPUZones...)
+	cpuOnlyNode := numaTopology(node_info.TopologyPolicyRestricted, node_info.TopologyScopePod,
+		numaZone("node-0", map[string]string{"cpu": "8"}))
 
 	tests := map[string]struct {
 		task     *pod_info.PodInfo
@@ -122,8 +150,14 @@ func TestShouldHandle(t *testing.T) {
 		"best-effort policy passes through": {
 			task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1), topo: bestEffort, expected: false,
 		},
-		"non-guaranteed QoS passes through": {
-			task: makeTask(v1.PodQOSBurstable, pod_info.RequestTypeRegular, 1), topo: singleNUMA, expected: false,
+		"non-guaranteed GPU pod is handled (device alignment is QoS-independent)": {
+			task: makeTask(v1.PodQOSBurstable, pod_info.RequestTypeRegular, 1), topo: singleNUMA, expected: true,
+		},
+		"non-guaranteed cpu-only pod passes through (cpu aligns only for Guaranteed)": {
+			task: burstableTask(v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}), topo: restricted, expected: false,
+		},
+		"non-guaranteed GPU pod on a node that doesn't track gpu per-zone passes through": {
+			task: makeTask(v1.PodQOSBurstable, pod_info.RequestTypeRegular, 1), topo: cpuOnlyNode, expected: false,
 		},
 		"best-effort QoS passes through": {
 			task: makeTask(v1.PodQOSBestEffort, pod_info.RequestTypeRegular, 0), topo: singleNUMA, expected: false,
@@ -190,6 +224,25 @@ func gPod(uid string, requests map[string]string) *pod_info.PodInfo {
 			Spec:   v1.PodSpec{Containers: []v1.Container{{Resources: v1.ResourceRequirements{Requests: rl}}}},
 		},
 	}
+}
+
+// TestNonGuaranteedIgnoresCPU verifies the evaluator drops cpu/memory for a non-Guaranteed task (the
+// kubelet aligns them only for Guaranteed pods) and constrains only devices: a GPU+cpu request whose
+// widths disagree rejects as Guaranteed but admits as Burstable, where only the GPU is aligned.
+func TestNonGuaranteedIgnoresCPU(t *testing.T) {
+	pp, _, node := wiredPlugin(numaTopology(node_info.TopologyPolicyRestricted, node_info.TopologyScopePod,
+		numaZone("node-0", map[string]string{gpu: "4", "cpu": "8"}),
+		numaZone("node-1", map[string]string{gpu: "4", "cpu": "8"}),
+	))
+
+	t.Run("guaranteed rejects on gpu/cpu width disagreement", func(t *testing.T) {
+		// 6 GPU -> width 2, 4 cpu -> width 1: no common width.
+		assert.False(t, pp.allocatable(gPod("g", map[string]string{gpu: "6", "cpu": "4"}), node))
+	})
+	t.Run("burstable admits: cpu is not kubelet-aligned, only gpu constrains", func(t *testing.T) {
+		assert.True(t, pp.allocatable(burstableTask(req(gpu, "6", "cpu", "4")), node),
+			"cpu must be ignored for a non-Guaranteed pod, leaving only the width-2 GPU request")
+	})
 }
 
 func TestBuildNumaRequests(t *testing.T) {

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -112,8 +112,8 @@ func makeTask(qos v1.PodQOSClass, reqType pod_info.ResourceRequestType, gpus flo
 	}
 }
 
-// burstableTask builds a Burstable pod (requests only) with the given container requests.
-func burstableTask(requests v1.ResourceList) *pod_info.PodInfo {
+// makeBurstableTask builds a Burstable pod (requests only) with the given container requests.
+func makeBurstableTask(requests v1.ResourceList) *pod_info.PodInfo {
 	return &pod_info.PodInfo{
 		VectorMap:    testVectorMap,
 		ResReqVector: resource_info.NewResourceVectorFromResourceList(requests, testVectorMap),
@@ -154,7 +154,7 @@ func TestShouldHandle(t *testing.T) {
 			task: makeTask(v1.PodQOSBurstable, pod_info.RequestTypeRegular, 1), topo: singleNUMA, expected: true,
 		},
 		"non-guaranteed cpu-only pod passes through (cpu aligns only for Guaranteed)": {
-			task: burstableTask(v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}), topo: restricted, expected: false,
+			task: makeBurstableTask(v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}), topo: restricted, expected: false,
 		},
 		"non-guaranteed GPU pod on a node that doesn't track gpu per-zone passes through": {
 			task: makeTask(v1.PodQOSBurstable, pod_info.RequestTypeRegular, 1), topo: cpuOnlyNode, expected: false,
@@ -207,8 +207,8 @@ func TestOnSessionOpenRegistersWithoutState(t *testing.T) {
 	), "node without topology is a pass-through")
 }
 
-// gPod builds a Guaranteed single-container task on node-a with the given requests.
-func gPod(uid string, requests map[string]string) *pod_info.PodInfo {
+// makeGuaranteedTask builds a Guaranteed single-container task on node-a with the given requests.
+func makeGuaranteedTask(uid string, requests map[string]string) *pod_info.PodInfo {
 	rl := v1.ResourceList{}
 	for name, qty := range requests {
 		rl[v1.ResourceName(name)] = resource.MustParse(qty)
@@ -237,10 +237,10 @@ func TestNonGuaranteedIgnoresCPU(t *testing.T) {
 
 	t.Run("guaranteed rejects on gpu/cpu width disagreement", func(t *testing.T) {
 		// 6 GPU -> width 2, 4 cpu -> width 1: no common width.
-		assert.False(t, pp.allocatable(gPod("g", map[string]string{gpu: "6", "cpu": "4"}), node))
+		assert.False(t, pp.allocatable(makeGuaranteedTask("g", map[string]string{gpu: "6", "cpu": "4"}), node))
 	})
 	t.Run("burstable admits: cpu is not kubelet-aligned, only gpu constrains", func(t *testing.T) {
-		assert.True(t, pp.allocatable(burstableTask(req(gpu, "6", "cpu", "4")), node),
+		assert.True(t, pp.allocatable(makeBurstableTask(req(gpu, "6", "cpu", "4")), node),
 			"cpu must be ignored for a non-Guaranteed pod, leaving only the width-2 GPU request")
 	})
 }
@@ -331,11 +331,11 @@ func TestPredicate(t *testing.T) {
 		numaZone("node-1", map[string]string{"cpu": "4"}),
 	))
 
-	assert.NoError(t, pp.predicate(gPod("fits", map[string]string{"cpu": "3"}), nil, node))
-	assert.Error(t, pp.predicate(gPod("too-big", map[string]string{"cpu": "5"}), nil, node),
+	assert.NoError(t, pp.predicate(makeGuaranteedTask("fits", map[string]string{"cpu": "3"}), nil, node))
+	assert.Error(t, pp.predicate(makeGuaranteedTask("too-big", map[string]string{"cpu": "5"}), nil, node),
 		"5 cpu cannot fit a single 4-cpu NUMA zone under single-numa-node")
 
-	assert.NoError(t, pp.predicate(gPod("nonode", map[string]string{"cpu": "5"}), nil, &node_info.NodeInfo{Name: "no-topology"}),
+	assert.NoError(t, pp.predicate(makeGuaranteedTask("nonode", map[string]string{"cpu": "5"}), nil, &node_info.NodeInfo{Name: "no-topology"}),
 		"nodes without NRT pass through")
 }
 
@@ -345,13 +345,13 @@ func TestInCycleReservation(t *testing.T) {
 	))
 	avail := func() int64 { return zoneAvail(node.NumaTopology, 0, "cpu") }
 
-	first := gPod("first", map[string]string{"cpu": "3"})
+	first := makeGuaranteedTask("first", map[string]string{"cpu": "3"})
 	first.NUMAPlacement = pp.placement(first, node) // stamped before the op, as the allocation path does
 	pp.allocate(&framework.Event{Task: first})
 	assert.Equal(t, int64(1), avail(), "zone charged by the first pod")
 	assert.Equal(t, []int{0}, first.NUMAPlacement.ZoneIndices(), "placement recorded on the task (zone 0)")
 
-	second := gPod("second", map[string]string{"cpu": "3"})
+	second := makeGuaranteedTask("second", map[string]string{"cpu": "3"})
 	assert.Error(t, pp.predicate(second, nil, node), "only 1 cpu left in the single zone")
 
 	pp.deallocate(&framework.Event{Task: first})
@@ -367,7 +367,7 @@ func TestAllocateReusesExistingPlacement(t *testing.T) {
 		numaZone("node-0", map[string]string{"cpu": "4"}),
 		numaZone("node-1", map[string]string{"cpu": "4"}),
 	))
-	task := gPod("seeded", map[string]string{"cpu": "3"})
+	task := makeGuaranteedTask("seeded", map[string]string{"cpu": "3"})
 	task.NUMAPlacement = pod_info.NUMAPlacement{
 		{ZoneIndex: 1, Amount: v1.ResourceList{"cpu": resource.MustParse("3")}},
 	}
@@ -460,27 +460,27 @@ func TestSeedObservedPlacements(t *testing.T) {
 	)
 
 	// Seeded from the observed annotation.
-	withObserved := gPod("observed", map[string]string{"cpu": "2"})
+	withObserved := makeGuaranteedTask("observed", map[string]string{"cpu": "2"})
 	withObserved.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
 
 	// Seeded from the BindRequest (no annotation), read via the session's clone-independent map.
-	fromBindRequest := gPod("from-bind-request", map[string]string{"cpu": "2"})
+	fromBindRequest := makeGuaranteedTask("from-bind-request", map[string]string{"cpu": "2"})
 	fromBindRequest.Pod.Namespace, fromBindRequest.Pod.Name = "ns", "from-bind-request"
 
-	alreadyPlaced := gPod("already", map[string]string{"cpu": "2"})
+	alreadyPlaced := makeGuaranteedTask("already", map[string]string{"cpu": "2"})
 	alreadyPlaced.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
 	alreadyPlaced.NUMAPlacement = pod_info.NUMAPlacement{{ZoneIndex: 0, Amount: v1.ResourceList{"cpu": resource.MustParse("2")}}}
 
-	noRecord := gPod("none", map[string]string{"cpu": "2"})
+	noRecord := makeGuaranteedTask("none", map[string]string{"cpu": "2"})
 
-	unknownZone := gPod("unknown-zone", map[string]string{"cpu": "2"})
+	unknownZone := makeGuaranteedTask("unknown-zone", map[string]string{"cpu": "2"})
 	unknownZone.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-9", "2"))}
 
-	burstable := gPod("burstable", map[string]string{"cpu": "2"})
+	burstable := makeGuaranteedTask("burstable", map[string]string{"cpu": "2"})
 	burstable.Pod.Status.QOSClass = v1.PodQOSBurstable
 	burstable.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
 
-	pending := gPod("pending", map[string]string{"cpu": "2"})
+	pending := makeGuaranteedTask("pending", map[string]string{"cpu": "2"})
 	pending.NodeName = ""
 	pending.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
 

--- a/pkg/scheduler/plugins/numa/reconstruct_test.go
+++ b/pkg/scheduler/plugins/numa/reconstruct_test.go
@@ -41,22 +41,22 @@ func TestReconstructNodeAvailable(t *testing.T) {
 	)
 
 	// Bound pod observed on node-1 (cpu 2) → subtracted.
-	bound := gPod("bound", map[string]string{"cpu": "2"})
+	bound := makeGuaranteedTask("bound", map[string]string{"cpu": "2"})
 	bound.Status = pod_status.Running
 	bound.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-1", "2"))}
 
 	// Pipelined pod (scheduler-committed, incoming) with a record → counted (active-allocated).
-	pipelined := gPod("pipelined", map[string]string{"cpu": "2"})
+	pipelined := makeGuaranteedTask("pipelined", map[string]string{"cpu": "2"})
 	pipelined.Status = pod_status.Pipelined
 	pipelined.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-0", "2"))}
 
 	// Pending pod (not active-allocated) with a record → ignored.
-	pending := gPod("pending", map[string]string{"cpu": "1"})
+	pending := makeGuaranteedTask("pending", map[string]string{"cpu": "1"})
 	pending.Status = pod_status.Pending
 	pending.Pod.Annotations = map[string]string{commonconstants.NumaPlacementObserved: observedAnnotation(observedZone("node-0", "1"))}
 
 	// Active pod with no record → contributes nothing (never guess a zone).
-	noRecord := gPod("norecord", map[string]string{"cpu": "2"})
+	noRecord := makeGuaranteedTask("norecord", map[string]string{"cpu": "2"})
 	noRecord.Status = pod_status.Running
 
 	node := &node_info.NodeInfo{


### PR DESCRIPTION
## Description

This PR fixes the NUMA plugin behavior for non-QoS-Guaranteed pods that request devices such as GPU. Our initial wrong understanding of NUMA in k8s assumed that only Guaranteed pods are NUMA aligned, but extended resources such as GPUs can be aligned for Burstable or BestEffort pods.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
