### PR TITLE
test(scheduler): fix repeated live-heap benchmark samples

### DIFF
--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_benchmark_test.go
@@ -39,8 +39,6 @@ var reclaimLargeJobNodeLocalGreedyBudget = flag.String(
 	"optional NodeLocalGreedy generator budget override for BenchmarkReclaimLargeJobs",
 )
 
-var manySingleGPUJobsBenchmarkKeepAlive *framework.Session
-
 func init() {
 	test_utils.InitTestingInfrastructure()
 }
@@ -126,21 +124,21 @@ func benchmarkReclaimManySingleGPUJobsFullCycleWithParams(
 			action.Execute(ssn)
 			if measureLiveHeap && actionIndex == 0 {
 				fitErrorTasks += countManySingleGPUFitErrorTasks(ssn)
-				manySingleGPUJobsBenchmarkKeepAlive = ssn
 				b.StopTimer()
 				runtime.GC()
 				var after runtime.MemStats
 				runtime.ReadMemStats(&after)
+				runtime.KeepAlive(ssn)
 				heapAfterAllocate += heapDelta(before.HeapAlloc, after.HeapAlloc)
 				b.StartTimer()
 			}
 		}
 		if measureLiveHeap {
-			manySingleGPUJobsBenchmarkKeepAlive = ssn
 			b.StopTimer()
 			runtime.GC()
 			var after runtime.MemStats
 			runtime.ReadMemStats(&after)
+			runtime.KeepAlive(ssn)
 			heapAfterCycle += heapDelta(before.HeapAlloc, after.HeapAlloc)
 			b.StartTimer()
 		}


### PR DESCRIPTION
## Description

The full-cycle reclaim benchmark retained its measured session in a package global. Repeated benchmark samples included that previous session in the next baseline and reported zero live-heap growth.

Replace the global with `runtime.KeepAlive` at each heap snapshot. This keeps the current session reachable during measurement without contaminating later samples.

## Related Issues

Related to #1922

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None.

## Additional Notes

Validation performed:

- `go test ./pkg/scheduler/actions/integration_tests/reclaim -run 'TestManySingleGPUJobs' -count=1`
- Two iterations across two benchmark repetitions using the 10-node topology with live-heap measurement temporarily enabled; every `heap_live_*` result remained non-zero.

Apply the `skip-changelog` label because this changes benchmark measurement only.
