### PR TITLE
fix(podgrouper): use minSubGroup on parent SubGroups for PyTorch and …

### DIFF
--- a/.changes/unreleased/Fixed-20260721-174844.yaml
+++ b/.changes/unreleased/Fixed-20260721-174844.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Segmented PyTorch and LWS PodGrouper now uses minSubGroup on parent SubGroups, fixing admission webhook rejection.
+time: 2026-07-21T17:48:44.000000000Z
+custom:
+    Issue: "1927"

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper.go
@@ -170,6 +170,15 @@ func buildWorkerSubGroups(
 			numSegments, maxAllowedSegmentation)
 	}
 
+	// No segment children — keep worker as a leaf so webhook leaf rules apply.
+	if numSegments == 0 {
+		return []*podgroup.SubGroupMetadata{{
+			Name:           strings.ToLower(replicaTypeWorker),
+			MinAvailable:   workerMinAvailable,
+			PodsReferences: podReferences,
+		}}, nil
+	}
+
 	segmentIndex, err := getPodSegmentIndex(pod, segmentSize)
 	if err != nil {
 		return nil, err
@@ -177,9 +186,10 @@ func buildWorkerSubGroups(
 
 	topologyConstraints := getSegmentTopologyConstraints(pod, replicaSpecs, topOwner)
 
+	// Parent SubGroups must use MinSubGroup (webhook rejects minMember on non-leaf).
 	subGroups := []*podgroup.SubGroupMetadata{{
-		Name:         strings.ToLower(replicaTypeWorker),
-		MinAvailable: workerMinAvailable,
+		Name:        strings.ToLower(replicaTypeWorker),
+		MinSubGroup: ptr.To(int32(numSegments)),
 	}}
 	for i := range numSegments {
 		subGroup := &podgroup.SubGroupMetadata{

--- a/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/kubeflow/pytorch/pytorch_grouper_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgroup"
@@ -388,6 +390,8 @@ func TestGetPodGroupMetadata_Segments_HappyFlow_4Workers_2PerSegment(t *testing.
 
 	workerSubgroup := findSubGroupByName(metadata.SubGroups, strings.ToLower(replicaTypeWorker))
 	assert.NotNil(t, workerSubgroup)
+	assert.Equal(t, int32(0), workerSubgroup.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), workerSubgroup.MinSubGroup)
 
 	workerSegment0 := findSubGroupByName(metadata.SubGroups, "worker-0")
 	assert.NotNil(t, workerSegment0)
@@ -466,6 +470,11 @@ func TestGetPodGroupMetadata_Segments_5Workers_2PerSegment(t *testing.T) {
 	assert.Equal(t, 5, len(metadata.SubGroups))
 	masterSubGroup := findSubGroupByName(metadata.SubGroups, strings.ToLower(replicaTypeMaster))
 	assert.NotNil(t, masterSubGroup)
+
+	workerParent := findSubGroupByName(metadata.SubGroups, strings.ToLower(replicaTypeWorker))
+	assert.NotNil(t, workerParent)
+	assert.Equal(t, int32(0), workerParent.MinAvailable)
+	assert.Equal(t, ptr.To(int32(3)), workerParent.MinSubGroup)
 
 	workerSegment0 := findSubGroupByName(metadata.SubGroups, "worker-0")
 	assert.NotNil(t, workerSegment0)
@@ -912,4 +921,35 @@ func TestGetPodGroupMetadata_Segments_TopologyFromTemplate(t *testing.T) {
 	assert.NotNil(t, workerSegment0.TopologyConstraints)
 	assert.Equal(t, "cluster-topology", workerSegment0.TopologyConstraints.Topology)
 	assert.Equal(t, "rack", workerSegment0.TopologyConstraints.RequiredTopologyLevel)
+}
+
+// workers=0 with segmentation configured produces no segment children, so the worker
+// subgroup must stay a leaf (MinAvailable set, MinSubGroup nil) to satisfy webhook
+// leaf rules. This path is only reachable when runPolicy.schedulingPolicy.minAvailable
+// is set (bypassing the calcJobNumOfPods zero-check).
+func TestGetPodGroupMetadata_Segments_ZeroWorkersFallsBackToLeaf(t *testing.T) {
+	pytorchJob := getPytorchJobWithSegments(1, 0, "2")
+	require.NoError(t,
+		unstructured.SetNestedField(pytorchJob.Object, int64(1), "spec", "runPolicy", "schedulingPolicy", "minAvailable"))
+	grouper := newTestPyTorchGrouper()
+
+	masterPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job-master-0",
+			Namespace: "test_namespace",
+			Labels: map[string]string{
+				replicaTypeLabel:                      "master",
+				"training.kubeflow.org/replica-index": "0",
+			},
+			Annotations: map[string]string{
+				"kai.scheduler/segment-size": "2",
+			},
+		},
+	}
+	metadata, err := grouper.GetPodGroupMetadata(pytorchJob, masterPod)
+	require.NoError(t, err)
+
+	workerSubgroup := findSubGroupByName(metadata.SubGroups, strings.ToLower(replicaTypeWorker))
+	require.NotNil(t, workerSubgroup)
+	assert.Nil(t, workerSubgroup.MinSubGroup, "workers=0 must not turn the leaf worker subgroup into a parent")
 }

--- a/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper.go
@@ -424,6 +424,11 @@ func handleLeaderInFirstSegment(
 	var segmentSubGroups []*podgroup.SubGroupMetadata
 	segmentSubGroups, setPodSubgroupReference = addLeaderAndWorkersSubgroupsForSegment(firstSegmentSubGroup.Name,
 		firstSegmentSubGroup.MinAvailable, pod, podSegment)
+
+	// Parent SubGroups must use MinSubGroup (webhook rejects minMember on non-leaf).
+	firstSegmentSubGroup.MinSubGroup = ptr.To(int32(len(segmentSubGroups)))
+	firstSegmentSubGroup.MinAvailable = 0
+
 	subGroups = append(subGroups, segmentSubGroups...)
 	return subGroups, setPodSubgroupReference
 }

--- a/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/leaderworkerset/lws_grouper_test.go
@@ -306,7 +306,8 @@ func TestBuildSubGroups_Segmentation_Divisible_LeaderPod(t *testing.T) {
 
 	seg0 := findSubGroupByName(subGroups, "segment-0")
 	assert.NotNil(t, seg0)
-	assert.Equal(t, int32(3), seg0.MinAvailable) // segmentSize(2) + leader(1)
+	assert.Equal(t, int32(0), seg0.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), seg0.MinSubGroup) // leader + workers
 	assert.Empty(t, seg0.PodsReferences)
 
 	seg1 := findSubGroupByName(subGroups, "segment-1")
@@ -340,7 +341,8 @@ func TestBuildSubGroups_Segmentation_Divisible_WorkerInFirstSegment(t *testing.T
 	assert.Len(t, subGroups, 4)
 
 	seg0 := findSubGroupByName(subGroups, "segment-0")
-	assert.Equal(t, int32(3), seg0.MinAvailable) // segmentSize(2) + leader(1)
+	assert.Equal(t, int32(0), seg0.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), seg0.MinSubGroup)
 	assert.Empty(t, seg0.PodsReferences)
 
 	seg1 := findSubGroupByName(subGroups, "segment-1")
@@ -372,7 +374,8 @@ func TestBuildSubGroups_Segmentation_Divisible_WorkerInLaterSegment(t *testing.T
 
 	seg0 := findSubGroupByName(subGroups, "segment-0")
 	assert.NotNil(t, seg0)
-	assert.Equal(t, int32(3), seg0.MinAvailable) // segmentSize(2) + leader(1)
+	assert.Equal(t, int32(0), seg0.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), seg0.MinSubGroup)
 	assert.Empty(t, seg0.PodsReferences)
 
 	seg1 := findSubGroupByName(subGroups, "segment-1")
@@ -404,7 +407,8 @@ func TestBuildSubGroups_Segmentation_NotDivisible_LeaderPod(t *testing.T) {
 	assert.Len(t, subGroups, 4) // segment-0, segment-1, leader, workers
 
 	seg0 := findSubGroupByName(subGroups, "segment-0")
-	assert.Equal(t, int32(2), seg0.MinAvailable) // not expanded
+	assert.Equal(t, int32(0), seg0.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), seg0.MinSubGroup)
 	assert.Empty(t, seg0.PodsReferences)
 
 	seg1 := findSubGroupByName(subGroups, "segment-1")
@@ -493,7 +497,8 @@ func TestBuildSubGroups_Segmentation_TopologyPreferredOnly_LeaderIncluded_NotDiv
 
 	seg0 := findSubGroupByName(subGroups, "segment-0")
 	assert.NotNil(t, seg0)
-	assert.Equal(t, int32(3), seg0.MinAvailable) // not expanded (not divisible)
+	assert.Equal(t, int32(0), seg0.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), seg0.MinSubGroup)
 	assert.Equal(t, topology, seg0.TopologyConstraints)
 
 	seg1 := findSubGroupByName(subGroups, "segment-1")
@@ -584,7 +589,8 @@ func TestBuildSubGroups_SegmentSizeFromWorkerTemplateAnnotation(t *testing.T) {
 
 	seg0 := findSubGroupByName(subGroups, "segment-0")
 	assert.NotNil(t, seg0)
-	assert.Equal(t, int32(3), seg0.MinAvailable) // segmentSize(2) + leader(1)
+	assert.Equal(t, int32(0), seg0.MinAvailable)
+	assert.Equal(t, ptr.To(int32(2)), seg0.MinSubGroup)
 	assert.Equal(t, expectedTopology, seg0.TopologyConstraints)
 
 	seg1 := findSubGroupByName(subGroups, "segment-1")


### PR DESCRIPTION
## Description

Segmented PyTorch and LWS grouper plugins were setting `MinAvailable` on parent SubGroups, which `handler.go` converts to `minMember`. The admission webhook rejects `minMember` on non-leaf SubGroups. Fix aligns with the pattern from #1642 (Grove): set `MinSubGroup` on parent SubGroups instead.

## Related Issues

Fixes #1927

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

N/A

## Additional Notes

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed segmented PyTorch and LeaderWorkerSet workloads being rejected by admission validation.
  - Corrected subgroup metadata to use minimum subgroup requirements for segmented workloads.
  - Improved handling of PyTorch configurations with zero workers by treating them as single leaf groups.

- **Tests**
  - Added regression coverage for zero-worker PyTorch workloads.
  - Updated segmentation checks for corrected subgroup availability metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->