### PR TITLE
chore(release): prepare changelog for v0.16.6

### DIFF
--- a/.changes/unreleased/Fixed-20260721-174844.yaml
+++ b/.changes/unreleased/Fixed-20260721-174844.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Segmented PyTorch and LWS PodGrouper now uses minSubGroup on parent SubGroups, fixing admission webhook rejection.
-time: 2026-07-21T17:48:44.000000000Z
-custom:
-    Issue: "1927"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.16.6] - 2026-07-23
+
+### Fixed
+- Segmented PyTorch and LWS PodGrouper now uses minSubGroup on parent SubGroups, fixing admission webhook rejection. [#1927](https://github.com/kai-scheduler/KAI-Scheduler/issues/1927)
+
 ## [v0.16.5] - 2026-07-23
 
 ### Changed


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.16.6]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.16.6` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.16.6]` section for accuracy.
- Target branch: `v0.16`.
