### PR TITLE
ci: skip build and test for changelog-only PRs

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -32,10 +32,12 @@ jobs:
             docs:
               - '**/*.md'
               - 'docs/**'
+              - '.changes/**'
             code:
               - '**'
               - '!**/*.md'
               - '!docs/**'
+              - '!.changes/**'
             scale_tests:
               - 'docs/scale-tests/**'
 


### PR DESCRIPTION
## Description

CI Build and Validate&Test currently run on changelog-only PRs (e.g. the release-prepare PRs that only touch `CHANGELOG.md` and a `.changes/unreleased/*.yaml` fragment).

The `code` paths-filter uses `predicate-quantifier: every`, so a file counts as "code" when it matches `**` and none of the negations. `CHANGELOG.md` is already excluded (`!**/*.md`), but the `.changes/unreleased/*.yaml` fragment matched nothing excluding it, so it was treated as code and triggered the full build/test/e2e pipeline.

This adds `.changes/**` to the `docs` group and `!.changes/**` to the `code` group so changelog fragments no longer count as code on their own.

**Effect:**
- Changelog-only PRs (`CHANGELOG.md` + `.changes/**`) → `code=false`, build/test/e2e skipped.
- Normal PRs that add a fragment alongside real code → the code files still count, so build/test still run.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). CI-only change — `skip-changelog` applies.

## Additional Notes

CI-only change; no changelog fragment needed.
