### PR TITLE
feat(scheduler): Implement node scoring in NUMA plugin

### DIFF
--- a/.changes/unreleased/added-20260723-175006.yaml
+++ b/.changes/unreleased/added-20260723-175006.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: |-
+  NUMA-aware node scoring preferring fewest-NUMA-zone placement

--- a/docs/developer/designs/numa-topology/README.md
+++ b/docs/developer/designs/numa-topology/README.md
@@ -601,38 +601,59 @@ regardless; Appendix A is the in-plugin fallback if the assumption proves insuff
 
 ## v2: Optimization & scoring
 
-v1 decides *feasibility* — can this node host the pod without a `TopologyAffinityError`. v2
-decides *which feasible node is best*, via a node score (`AddNodeOrderFn`, a new band in
-`scores/scores.go`). It reuses v1's evaluators and per-zone model unchanged: it only **ranks**
-nodes, never alters the admit decision.
+v2 adds scoring based on NUMA placement: nodes that can fit a NUMA-sensitive task in fewer zones
+are ranked higher. Nodes that can't admit the task are ranked lower. This enables us to support
+`best-effort` mode better.
+
+The upstream scheduler numa plugin supports different scoring strategies - `LeastNUMANodes`, 
+`BalancedAllocation`, `LeastAllocated` and `MostAllocated` - the last three are only relevant to 
+`single-numa-node` mode. `LeastNUMANodes` seems the most relevant for our use cases, but we can
+support more modes, and welcome community feedback on this.
 
 ### What scoring adds
 
 - **Optimize `best-effort` performance.** On a `best-effort` node the kubelet never rejects — it
   silently runs the pod *unaligned* when it can't fit a NUMA node, costing throughput. v1 does
   nothing for `best-effort` (there is no admission error to prevent). v2 **scores** `best-effort`
-  nodes by whether the pod's resources *can* be aligned there, steering it toward a node where
-  the kubelet's best-effort alignment will actually succeed — turning a silent performance loss
-  into a good placement. This is the primary motivation for v2.
-- **Prefer tighter, less-fragmented fit** on feasible `single-numa-node` / `restricted` nodes, so
-  later pods still find aligned room, and multi-NUMA pods span the fewest zones.
+  nodes by how few zones the pod's resources *can* be aligned to there, steering it toward a node
+  where the kubelet's best-effort alignment will actually succeed. This is the primary motivation for v2.
+- **Prefer tighter, fewer-zone fit** on feasible `restricted` nodes, where the kubelet forces the
+  pod to span its preferred width `w` (which differs per node by per-zone `Allocatable`): rank
+  nodes by `w` so a pod that aligns to one zone on node A beats spanning two on node B.
+- **Sink infeasible nodes so the predicate short-circuits.** `OrderedNodesByTask` scores *every*
+  candidate node — including ones the predicate will reject — and the action then runs `FittingNode`
+  (the predicate) lazily **in score order**, stopping at the first fit. So ranking a node the
+  kubelet can't NUMA-align *below* one it can makes the predicate hit a feasible node first and skip
+  evaluating the infeasible ones. This applies to **`single-numa-node`** too: its feasible span is
+  always 1, but feasibility itself is a ranking signal, so scoring is *not* a no-op there — it
+  front-loads the alignable nodes. (Correctness still rests on the predicate; the score only reorders.)
 
-### Scoring strategies
+### The fewest-zones span, per policy
 
-Reusing the upstream NodeResourceTopology scoring vocabulary, computed over the plugin's per-zone
-model:
+Scoring routes every candidate node through one reusable function, `alignmentSpan(task, node) →
+(zones int, aligned bool)`, and the score is a function of **both** outputs: `aligned=false` sinks
+the node (worst score), and among aligned nodes fewer `zones` scores higher.
 
-- **LeastNUMANodes** (policy-agnostic) — prefer nodes where the pod spans the fewest NUMA nodes
-  (ideally one). This is the core `best-effort` steering and the multi-NUMA-span minimizer.
-- **LeastAllocated / MostAllocated / BalancedAllocation** — spread vs. bin-pack vs. balance
-  per-zone utilization, for fragmentation control on the aligned policies; selectable via config.
+| Policy | `alignmentSpan` when aligned | `aligned=false` when | Predicate outcome |
+| --- | --- | --- | --- |
+| `single-numa-node` | `1` | no single zone fits by `Available` | rejects (filtered) |
+| `restricted` | the forced preferred width `w` | preferred widths disagree, or no width-`w` mask fits | rejects (filtered) |
+| `best-effort` | greedy narrowest zone mask that fits by `Available` (width = span) | even all N zones can't cover the request (pod runs unaligned) | passes (best-effort never rejects) |
+
+For the two rejecting policies, `aligned` is the *same bit the predicate computes*, so a sunk node
+is one the predicate would filter — the score just reorders the funnel. For `best-effort`,
+`aligned=false` is the unaligned case: still selectable (worst-but-finite score), because
+`best-effort` offers no other node any guarantee.
 
 ### Notes
 
 - Scoring runs on the same predicted per-zone state as v1, so the prediction caveats carry over —
   but a score is only a *preference*, so a misprediction costs ranking quality, never correctness.
-- `best-effort` scoring is the one place the plugin touches `best-effort` nodes at all; v1 leaves
-  them untouched, and the admit decision for `single-numa-node` / `restricted` is unchanged.
+- The span metric is pure zone-count and policy-agnostic, so span-1 scores identically across
+  `single-numa-node`, `restricted`, and `best-effort` — a mixed-policy candidate set ranks coherently.
+- **No NUMA-distance awareness in v2.** The score is zone *count* only; inter-zone distance
+  (`Zone.Costs`) is not ingested and no scoring seam is reserved for it. A distance metric (e.g. a
+  v3 "minimax") would be a separate axis added later if pursued.
 
 ## v3: Pod-level NUMA policy (scheduler-enforced)
 

--- a/pkg/scheduler/plugins/nodeplacement/pack.go
+++ b/pkg/scheduler/plugins/nodeplacement/pack.go
@@ -26,7 +26,7 @@ func (pp *nodePlacementPlugin) nodeResourcePack(resourceName v1.ResourceName) ap
 		score := getScoreOfCurrentNode(podAllocationRange.minAllocatable, podAllocationRange.maxAllocatable,
 			currentNodeNonAllocated, nodeOverall)
 		log.InfraLogger.V(7).Infof("Estimating Task: <%v/%v> Job: <%v> for node: <%s> "+
-			"that has <%f> non allocated %v. Score: %f",
+			"that has <%f> non al located %v. Score: %f",
 			task.Namespace, task.Name, task.Job, node.Name, currentNodeNonAllocated, resourceName, score)
 		return score, nil
 	}

--- a/pkg/scheduler/plugins/nodeplacement/pack.go
+++ b/pkg/scheduler/plugins/nodeplacement/pack.go
@@ -26,7 +26,7 @@ func (pp *nodePlacementPlugin) nodeResourcePack(resourceName v1.ResourceName) ap
 		score := getScoreOfCurrentNode(podAllocationRange.minAllocatable, podAllocationRange.maxAllocatable,
 			currentNodeNonAllocated, nodeOverall)
 		log.InfraLogger.V(7).Infof("Estimating Task: <%v/%v> Job: <%v> for node: <%s> "+
-			"that has <%f> non al located %v. Score: %f",
+			"that has <%f> non allocated %v. Score: %f",
 			task.Namespace, task.Name, task.Job, node.Name, currentNodeNonAllocated, resourceName, score)
 		return score, nil
 	}

--- a/pkg/scheduler/plugins/numa/evaluator.go
+++ b/pkg/scheduler/plugins/numa/evaluator.go
@@ -4,6 +4,7 @@
 package numa
 
 import (
+	"math"
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
@@ -14,8 +15,11 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
-// stackZones bounds the mask/scratch stack buffers; nodes with more NUMA zones fall back to heap.
-const stackZones = 16
+// stackZones and stackAware bound the mask/scratch stack buffers; larger nodes fall back to heap.
+const (
+	stackZones = 16
+	stackAware = 16
+)
 
 // zoneAllocation accumulates, per zone index, the amounts to place there (as a ResourceVector delta).
 // placementFromAllocation materializes it into a pod_info.NUMAPlacement.
@@ -49,15 +53,21 @@ func (pp *numaPlugin) alignedAware(task *pod_info.PodInfo, node *node_info.NodeI
 	return out
 }
 
-// allocatable reports whether the kubelet Topology Manager would align the task on the node. A task
-// the plugin does not constrain passes through as true.
+// allocatable reports whether the kubelet Topology Manager would align the task on the node (the
+// predicate). A task the plugin does not filter passes through as true.
 func (pp *numaPlugin) allocatable(task *pod_info.PodInfo, node *node_info.NodeInfo) bool {
+	if node == nil || !pp.shouldFilter(task, node.NumaTopology) {
+		return true
+	}
 	return pp.solveTask(task, node, nil)
 }
 
 // evaluate returns the task's expected per-zone allocation on the node (nil for a task the plugin
-// does not constrain). Used by the placement path; the predicate uses allocatable (feasibility only).
+// does not account for). Used by the placement and scoring paths.
 func (pp *numaPlugin) evaluate(task *pod_info.PodInfo, node *node_info.NodeInfo) (zoneAllocation, bool) {
+	if node == nil || !pp.shouldScore(task, node.NumaTopology) {
+		return nil, true
+	}
 	alloc := zoneAllocation{}
 	if !pp.solveTask(task, node, alloc) {
 		return nil, false
@@ -65,13 +75,9 @@ func (pp *numaPlugin) evaluate(task *pod_info.PodInfo, node *node_info.NodeInfo)
 	return alloc, true
 }
 
-// solveTask resolves the task's requests and scope for the node and runs solve. A task the plugin
-// does not constrain passes through as admitted. When alloc is non-nil, solve records the placement
-// into it; when nil, it only decides feasibility (zero-allocation).
+// solveTask runs the evaluator on a node the caller has already gated. When alloc is non-nil, solve
+// records the placement into it; when nil, it only decides feasibility (zero-allocation).
 func (pp *numaPlugin) solveTask(task *pod_info.PodInfo, node *node_info.NodeInfo, alloc zoneAllocation) bool {
-	if node == nil || !pp.shouldHandle(task, node.NumaTopology) {
-		return true
-	}
 	topo := node.NumaTopology
 	aware := pp.alignedAware(task, node)
 	concurrent, serial := pp.numaRequestsFor(task, topo.VectorMap).forScope(topo.Scope)
@@ -118,10 +124,14 @@ func solve(topo *node_info.NumaTopology, aware []int, concurrent, serial []resou
 // feasibleMask picks the mask the policy's evaluator would choose for one request, under the current
 // availability view (Available minus consumed).
 func feasibleMask(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, maskBuf []int) ([]int, bool) {
-	if topo.Policy == node_info.TopologyPolicySingleNUMANode {
+	switch topo.Policy {
+	case node_info.TopologyPolicySingleNUMANode:
 		return singleNUMAEvaluator{}.fit(topo, aware, req, consumed, width, maskBuf)
+	case node_info.TopologyPolicyBestEffort:
+		return bestEffortEvaluator{}.fit(topo, aware, req, consumed, width, maskBuf)
+	default:
+		return restrictedEvaluator{}.fit(topo, aware, req, consumed, width, maskBuf)
 	}
-	return restrictedEvaluator{}.fit(topo, aware, req, consumed, width, maskBuf)
 }
 
 // singleNUMAEvaluator (single-numa-node) requires each request to fit entirely within one NUMA zone,
@@ -135,6 +145,72 @@ func (singleNUMAEvaluator) fit(topo *node_info.NumaTopology, aware []int, req re
 		}
 	}
 	return nil, false
+}
+
+// bestEffortEvaluator (best-effort) greedily builds the narrowest zone mask whose summed Available
+// covers the request, adding at each step the zone that covers the most unmet demand. best-effort
+// never rejects, so the result feeds scoring and the in-cycle ledger, not an admit decision; the
+// greedy width approximates the kubelet's best-effort span (exact when one resource dominates).
+type bestEffortEvaluator struct{}
+
+func (bestEffortEvaluator) fit(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, maskBuf []int) ([]int, bool) {
+	var remArr [stackAware]float64
+	remaining := remArr[:0]
+	if len(aware) > stackAware {
+		remaining = make([]float64, 0, len(aware))
+	}
+	for _, idx := range aware {
+		remaining = append(remaining, req.Get(idx))
+	}
+	var usedArr [stackZones]bool
+	used := usedArr[:len(topo.Zones)]
+	if len(topo.Zones) > stackZones {
+		used = make([]bool, len(topo.Zones))
+	}
+
+	mask := maskBuf[:0]
+	for len(mask) < len(topo.Zones) {
+		if allMet(remaining) {
+			return mask, true
+		}
+		best, bestCover := -1, 0.0
+		for z := range topo.Zones {
+			if used[z] {
+				continue
+			}
+			cover := 0.0
+			for i, idx := range aware {
+				if remaining[i] <= 0 {
+					continue
+				}
+				cover += math.Min(remaining[i], availableAt(topo, consumed, width, z, idx))
+			}
+			if cover > bestCover {
+				best, bestCover = z, cover
+			}
+		}
+		if best < 0 {
+			break
+		}
+		used[best] = true
+		mask = append(mask, best)
+		for i, idx := range aware {
+			remaining[i] -= availableAt(topo, consumed, width, best, idx)
+		}
+	}
+	if allMet(remaining) {
+		return mask, true
+	}
+	return nil, false
+}
+
+func allMet(remaining []float64) bool {
+	for _, r := range remaining {
+		if r > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // restrictedEvaluator reproduces the kubelet hint merge: all per-resource preferred widths (from

--- a/pkg/scheduler/plugins/numa/evaluator.go
+++ b/pkg/scheduler/plugins/numa/evaluator.go
@@ -147,12 +147,19 @@ func (singleNUMAEvaluator) fit(topo *node_info.NumaTopology, aware []int, req re
 	return nil, false
 }
 
-// bestEffortEvaluator (best-effort) greedily builds the narrowest zone mask whose summed Available
-// covers the request, adding at each step the zone that covers the most unmet demand. best-effort
-// never rejects, so the result feeds scoring and the in-cycle ledger, not an admit decision; the
-// greedy width approximates the kubelet's best-effort span (exact when one resource dominates).
+// bestEffortEvaluator implements the best-effort policy, which never rejects, so its result feeds
+// scoring and the in-cycle ledger, never an admit decision.
 type bestEffortEvaluator struct{}
 
+// fit greedily grows a zone mask until it covers the request, returning the mask and whether it fits:
+//  1. Start with no zones; the unmet demand is the full request.
+//  2. Each round, add the unused zone that covers the most unmet demand (the sum, over
+//     still-needed resources, of min(remaining, available in that zone)), then subtract that zone's
+//     availability from the demand.
+//  3. Stop when every resource is met (fits) or no remaining zone can help (does not fit).
+//
+// The number of zones picked is the span. Taking the most-covering zone first yields the fewest
+// zones exactly when one resource dominates.
 func (bestEffortEvaluator) fit(topo *node_info.NumaTopology, aware []int, req resource_info.ResourceVector, consumed []float64, width int, maskBuf []int) ([]int, bool) {
 	var remArr [stackAware]float64
 	remaining := remArr[:0]

--- a/pkg/scheduler/plugins/numa/evaluator.go
+++ b/pkg/scheduler/plugins/numa/evaluator.go
@@ -163,7 +163,7 @@ func (bestEffortEvaluator) fit(topo *node_info.NumaTopology, aware []int, req re
 		remaining = append(remaining, req.Get(idx))
 	}
 	var usedArr [stackZones]bool
-	used := usedArr[:len(topo.Zones)]
+	used := usedArr[:]
 	if len(topo.Zones) > stackZones {
 		used = make([]bool, len(topo.Zones))
 	}

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/scores"
 )
 
 var errNotNumaAligned = errors.New("node cannot NUMA-align the pod's resources under its Topology Manager policy")
@@ -51,6 +52,12 @@ type numaPlugin struct {
 	// hasModeledNodes is false when no node carries a modeled-policy topology, letting the
 	// PrePredicateFn skip all per-task precompute.
 	hasModeledNodes bool
+	// maxZones is the largest per-node NUMA-zone count in the cluster; the assumed span for a node
+	// with no NRT. Zero when no node reports topology, disabling scoring.
+	maxZones int
+	// awareDeviceIndices is the union, over scored nodes, of the shared-map indices of per-zone
+	// device resources (non cpu/memory/hugepages, minus ignoreList); drives wantsNuma.
+	awareDeviceIndices sets.Set[int]
 }
 
 func New(arguments framework.PluginArguments) framework.Plugin {
@@ -85,6 +92,8 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddPrePredicateFn(pp.prePredicate)
 	ssn.AddPredicateFn(pp.predicate)
 	ssn.AddNumaPlacementFn(pp.placement)
+	ssn.AddNodePreOrderFn(pp.nodePreOrder)
+	ssn.AddNodeOrderFn(pp.nodeScore)
 	ssn.AddEventHandler(&framework.EventHandler{
 		AllocateFunc:   pp.allocate,
 		DeallocateFunc: pp.deallocate,
@@ -96,8 +105,10 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 func (pp *numaPlugin) initCaches(ssn *framework.Session) {
 	pp.numaRequestCache = map[common_info.PodID]*podNumaRequests{}
 	pp.ignoreIndices = sets.New[int]()
+	pp.awareDeviceIndices = sets.New[int]()
 	pp.effectiveAwareByNode = nil
 	pp.hasModeledNodes = false
+	pp.maxZones = 0
 
 	vectorMap := ssn.ClusterInfo.ResourceVectorMap
 	for name := range pp.ignoreList {
@@ -111,12 +122,27 @@ func (pp *numaPlugin) initCaches(ssn *framework.Session) {
 	}
 	for _, node := range ssn.ClusterInfo.Nodes {
 		topo := node.NumaTopology
-		if topo == nil || !isModeledPolicy(topo.Policy) {
+		if topo == nil {
 			continue
 		}
-		pp.hasModeledNodes = true
+		if len(topo.Zones) > pp.maxZones {
+			pp.maxZones = len(topo.Zones)
+		}
+		if !isScoredPolicy(topo.Policy) {
+			continue
+		}
+		if isModeledPolicy(topo.Policy) {
+			pp.hasModeledNodes = true
+		}
 		if pp.effectiveAwareByNode != nil {
 			pp.effectiveAwareByNode[node.Name] = filterAware(topo.AwareIndices, pp.ignoreIndices)
+		}
+		for _, idx := range topo.AwareIndices {
+			name := topo.AwareNames[idx]
+			if isQoSGatedResource(name) || pp.ignoreList.Has(name) {
+				continue
+			}
+			pp.awareDeviceIndices.Insert(idx)
 		}
 	}
 }
@@ -141,6 +167,68 @@ func (pp *numaPlugin) prePredicate(task *pod_info.PodInfo, _ *podgroup_info.PodG
 	}
 	pp.numaRequestsFor(task, vectorMap)
 	return nil
+}
+
+// nodePreOrder it warms per-task scoring state. Skipped for non-NUMA-sensitive tasks.
+func (pp *numaPlugin) nodePreOrder(task *pod_info.PodInfo, _ []*node_info.NodeInfo) error {
+	vectorMap := pp.ssn.ClusterInfo.ResourceVectorMap
+	if pp.maxZones == 0 || vectorMap == nil || !pp.wantsNuma(task) {
+		return nil
+	}
+	pp.numaRequestsFor(task, vectorMap)
+	return nil
+}
+
+// nodeScore is the NodeOrderFn: it prefers nodes where the task spans the fewest NUMA zones, scoring
+// 1/span. Skipped for non-NUMA-sensitive tasks and when no node reports topology.
+func (pp *numaPlugin) nodeScore(task *pod_info.PodInfo, node *node_info.NodeInfo) (float64, error) {
+	if pp.maxZones == 0 || !pp.wantsNuma(task) {
+		return 0, nil
+	}
+	span, ok := pp.assumedSpan(task, node)
+	if !ok {
+		return 0, nil
+	}
+	return scores.Numa / float64(span), nil
+}
+
+// assumedSpan returns the number of NUMA zones the task is expected to occupy on the node. ok is
+// false for an infeasible modeled node, which must sink below every scorable node (score 0). Nodes
+// with no topology assume the cluster's worst zone count; unmanaged (none) or not-aligned-here nodes
+// assume worst-case full spread.
+func (pp *numaPlugin) assumedSpan(task *pod_info.PodInfo, node *node_info.NodeInfo) (int, bool) {
+	topo := node.NumaTopology
+	if topo == nil || len(topo.Zones) == 0 {
+		return pp.maxZones, true
+	}
+	if topo.Policy == node_info.TopologyPolicyNone || !pp.shouldScore(task, topo) {
+		return len(topo.Zones), true
+	}
+	alloc, ok := pp.evaluate(task, node)
+	if !ok {
+		return 0, false
+	}
+	if len(alloc) == 0 {
+		return 1, true
+	}
+	return len(alloc), true
+}
+
+// wantsNuma reports whether the task should be NUMA-scored: a Guaranteed pod, or one requesting a
+// NUMA-aligned device reported by some scored node.
+func (pp *numaPlugin) wantsNuma(task *pod_info.PodInfo) bool {
+	if task.Pod == nil {
+		return false
+	}
+	if isGuaranteed(task) {
+		return true
+	}
+	for idx := range pp.awareDeviceIndices {
+		if task.ResReqVector.Get(idx) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // placement is the session NumaPlacementFn: the task's expected NUMA placement on the node. Called
@@ -236,11 +324,22 @@ func parseIgnoreList(arguments framework.PluginArguments) sets.Set[v1.ResourceNa
 	return ignoreList
 }
 
-// shouldHandle engages the plugin on a rejecting-policy node for any task the kubelet would
-// NUMA-align. Guaranteed tasks are always handled. A non-Guaranteed task is handled if it requests a
-// topology-aware device.
-func (pp *numaPlugin) shouldHandle(task *pod_info.PodInfo, topo *node_info.NumaTopology) bool {
-	if topo == nil || !isModeledPolicy(topo.Policy) || task.Pod == nil {
+// shouldFilter gates the predicate: the plugin filters only on the rejecting policies. A Guaranteed
+// task is filtered always, a non-Guaranteed task only if it requests a topology-aware device.
+func (pp *numaPlugin) shouldFilter(task *pod_info.PodInfo, topo *node_info.NumaTopology) bool {
+	if topo == nil || task.Pod == nil || !isModeledPolicy(topo.Policy) {
+		return false
+	}
+	if isGuaranteed(task) {
+		return true
+	}
+	return pp.requestsAlignedDevice(task, topo)
+}
+
+// shouldScore gates placement, the in-cycle ledger, and scoring: the rejecting policies plus
+// best-effort. Same task criterion as shouldFilter, wider policy set.
+func (pp *numaPlugin) shouldScore(task *pod_info.PodInfo, topo *node_info.NumaTopology) bool {
+	if topo == nil || task.Pod == nil || !isScoredPolicy(topo.Policy) {
 		return false
 	}
 	if isGuaranteed(task) {
@@ -278,8 +377,13 @@ func (pp *numaPlugin) requestsAlignedDevice(task *pod_info.PodInfo, topo *node_i
 	return false
 }
 
-// isModeledPolicy reports whether the plugin engages for a node with this policy.
-// Only single-numa-node and restricted are supported at this point.
+// isModeledPolicy reports whether the plugin filters (predicts kubelet rejection) for this policy.
 func isModeledPolicy(policy node_info.TopologyManagerPolicy) bool {
 	return policy == node_info.TopologyPolicySingleNUMANode || policy == node_info.TopologyPolicyRestricted
+}
+
+// isScoredPolicy reports whether the plugin accounts for and scores this policy: the modeled
+// policies plus best-effort (which never rejects but is steered toward aligned placements).
+func isScoredPolicy(policy node_info.TopologyManagerPolicy) bool {
+	return isModeledPolicy(policy) || policy == node_info.TopologyPolicyBestEffort
 }

--- a/pkg/scheduler/plugins/numa/numa.go
+++ b/pkg/scheduler/plugins/numa/numa.go
@@ -169,7 +169,7 @@ func (pp *numaPlugin) prePredicate(task *pod_info.PodInfo, _ *podgroup_info.PodG
 	return nil
 }
 
-// nodePreOrder it warms per-task scoring state. Skipped for non-NUMA-sensitive tasks.
+// nodePreOrder warms per-task scoring state. Skipped for non-NUMA-sensitive tasks.
 func (pp *numaPlugin) nodePreOrder(task *pod_info.PodInfo, _ []*node_info.NodeInfo) error {
 	vectorMap := pp.ssn.ClusterInfo.ResourceVectorMap
 	if pp.maxZones == 0 || vectorMap == nil || !pp.wantsNuma(task) {
@@ -193,9 +193,8 @@ func (pp *numaPlugin) nodeScore(task *pod_info.PodInfo, node *node_info.NodeInfo
 }
 
 // assumedSpan returns the number of NUMA zones the task is expected to occupy on the node. ok is
-// false for an infeasible modeled node, which must sink below every scorable node (score 0). Nodes
-// with no topology assume the cluster's worst zone count; unmanaged (none) or not-aligned-here nodes
-// assume worst-case full spread.
+// false for an infeasible modeled node. Nodes with no topology assume the cluster's worst zone
+// count; unmanaged (none) or not-aligned-here nodes assume worst-case full spread.
 func (pp *numaPlugin) assumedSpan(task *pod_info.PodInfo, node *node_info.NodeInfo) (int, bool) {
 	topo := node.NumaTopology
 	if topo == nil || len(topo.Zones) == 0 {

--- a/pkg/scheduler/plugins/numa/numa_test.go
+++ b/pkg/scheduler/plugins/numa/numa_test.go
@@ -124,7 +124,7 @@ func makeBurstableTask(requests v1.ResourceList) *pod_info.PodInfo {
 	}
 }
 
-func TestShouldHandle(t *testing.T) {
+func TestShouldFilter(t *testing.T) {
 	plugin := &numaPlugin{}
 	gpuCPUZones := []node_info.NumaZoneSpec{numaZone("node-0", map[string]string{gpu: "4", "cpu": "8"})}
 	singleNUMA := numaTopology(node_info.TopologyPolicySingleNUMANode, node_info.TopologyScopePod, gpuCPUZones...)
@@ -175,7 +175,7 @@ func TestShouldHandle(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, plugin.shouldHandle(test.task, test.topo))
+			assert.Equal(t, test.expected, plugin.shouldFilter(test.task, test.topo))
 		})
 	}
 }
@@ -197,11 +197,11 @@ func TestOnSessionOpenRegistersWithoutState(t *testing.T) {
 	plugin.OnSessionOpen(ssn)
 	plugin.OnSessionClose(ssn)
 
-	assert.True(t, plugin.shouldHandle(
+	assert.True(t, plugin.shouldFilter(
 		makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1),
 		nodes["with-single-numa"].NumaTopology,
 	))
-	assert.False(t, plugin.shouldHandle(
+	assert.False(t, plugin.shouldFilter(
 		makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1),
 		nodes["without-nrt"].NumaTopology,
 	), "node without topology is a pass-through")

--- a/pkg/scheduler/plugins/numa/reconstruct.go
+++ b/pkg/scheduler/plugins/numa/reconstruct.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
 )
 
-// reconstructNodeAvailable discards each modeled node's NRT-reported per-zone Available and
+// reconstructNodeAvailable discards each scored node's NRT-reported per-zone Available and
 // recomputes it as Allocatable minus the placements of the pods currently consuming the node. NRT
 // Available lags across cycles (the exporter republishes on a delay, in both directions — missing a
 // just-bound pod or still counting a just-deleted one); Allocatable is static and the pod set is read
@@ -20,7 +20,7 @@ import (
 func (pp *numaPlugin) reconstructNodeAvailable(ssn *framework.Session) {
 	for _, node := range ssn.ClusterInfo.Nodes {
 		topo := node.NumaTopology
-		if topo == nil || !isModeledPolicy(topo.Policy) {
+		if topo == nil || !isScoredPolicy(topo.Policy) {
 			continue
 		}
 		resetAvailableToAllocatable(topo)

--- a/pkg/scheduler/plugins/numa/scoring_test.go
+++ b/pkg/scheduler/plugins/numa/scoring_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package numa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	schedapi "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/scores"
+)
+
+// scoringPlugin wires a plugin over nodes and runs the session-open precompute (maxZones, aware
+// devices), so nodeScore/wantsNuma see the same state they would in a real session.
+func scoringPlugin(nodes map[string]*node_info.NodeInfo) *numaPlugin {
+	ssn := &framework.Session{ClusterInfo: &schedapi.ClusterInfo{Nodes: nodes}}
+	pp := &numaPlugin{ignoreList: sets.New[v1.ResourceName](), ssn: ssn}
+	pp.initCaches(ssn)
+	return pp
+}
+
+func TestBestEffortEvaluatorSpan(t *testing.T) {
+	// Four NUMA zones, one GPU each: the greedy span is the number of GPUs requested.
+	node := numaTopology(node_info.TopologyPolicyBestEffort, node_info.TopologyScopeContainer,
+		numaZone("node-0", map[string]string{gpu: "1"}),
+		numaZone("node-1", map[string]string{gpu: "1"}),
+		numaZone("node-2", map[string]string{gpu: "1"}),
+		numaZone("node-3", map[string]string{gpu: "1"}),
+	)
+
+	tests := map[string]struct {
+		gpus      string
+		wantSpan  int
+		wantAdmit bool
+	}{
+		"single zone":         {gpus: "1", wantSpan: 1, wantAdmit: true},
+		"spans two zones":     {gpus: "2", wantSpan: 2, wantAdmit: true},
+		"full spread":         {gpus: "4", wantSpan: 4, wantAdmit: true},
+		"over total capacity": {gpus: "5", wantSpan: 0, wantAdmit: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			placement, ok := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, test.gpus)})
+			assert.Equal(t, test.wantAdmit, ok)
+			assert.Len(t, placement, test.wantSpan)
+		})
+	}
+}
+
+func TestNodeScoreTiers(t *testing.T) {
+	nodes := map[string]*node_info.NodeInfo{
+		"aligned": {Name: "aligned", NumaTopology: numaTopology(node_info.TopologyPolicySingleNUMANode,
+			node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{gpu: "4", "cpu": "16"}),
+			numaZone("node-1", map[string]string{gpu: "4", "cpu": "16"}))},
+		"restricted-span2": {Name: "restricted-span2", NumaTopology: numaTopology(node_info.TopologyPolicyRestricted,
+			node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{gpu: "1"}),
+			numaZone("node-1", map[string]string{gpu: "1"}))},
+		"best-effort": {Name: "best-effort", NumaTopology: numaTopology(node_info.TopologyPolicyBestEffort,
+			node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{gpu: "1"}),
+			numaZone("node-1", map[string]string{gpu: "1"}))},
+		"none-4zone": {Name: "none-4zone", NumaTopology: numaTopology(node_info.TopologyPolicyNone,
+			node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{gpu: "1"}),
+			numaZone("node-1", map[string]string{gpu: "1"}),
+			numaZone("node-2", map[string]string{gpu: "1"}),
+			numaZone("node-3", map[string]string{gpu: "1"}))},
+		"no-nrt": {Name: "no-nrt"},
+	}
+
+	// maxZones is 4 (the none node), the anchor for the no-NRT worst case.
+	tests := map[string]struct {
+		task  *pod_info.PodInfo
+		node  string
+		score float64
+	}{
+		"aligned single zone":       {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1), node: "aligned", score: scores.Numa / 1},
+		"restricted forced span 2":  {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 2), node: "restricted-span2", score: scores.Numa / 2},
+		"restricted infeasible":     {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 3), node: "restricted-span2", score: 0},
+		"best-effort aligned":       {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1), node: "best-effort", score: scores.Numa / 1},
+		"best-effort full spread":   {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 2), node: "best-effort", score: scores.Numa / 2},
+		"none worst-case full span": {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1), node: "none-4zone", score: scores.Numa / 4},
+		"no-nrt uses maxZones":      {task: makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 1), node: "no-nrt", score: scores.Numa / 4},
+		"non-numa task is silent":   {task: makeTask(v1.PodQOSBestEffort, pod_info.RequestTypeRegular, 0), node: "aligned", score: 0},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pp := scoringPlugin(nodes)
+			score, err := pp.nodeScore(test.task, nodes[test.node])
+			assert.NoError(t, err)
+			assert.Equal(t, test.score, score)
+		})
+	}
+}
+
+func TestWantsNuma(t *testing.T) {
+	pp := scoringPlugin(map[string]*node_info.NodeInfo{
+		"gpu-node": {Name: "gpu-node", NumaTopology: singleNUMANodeTopology(node_info.TopologyScopeContainer,
+			numaZone("node-0", map[string]string{gpu: "4", "cpu": "16"}))},
+	})
+
+	assert.True(t, pp.wantsNuma(makeTask(v1.PodQOSGuaranteed, pod_info.RequestTypeRegular, 0)), "guaranteed is sensitive")
+	assert.True(t, pp.wantsNuma(makeTask(v1.PodQOSBurstable, pod_info.RequestTypeRegular, 1)), "burstable requesting a gpu is sensitive")
+	assert.False(t, pp.wantsNuma(makeBurstableTask(req("cpu", "2"))), "burstable cpu-only is not sensitive")
+	assert.False(t, pp.wantsNuma(makeTask(v1.PodQOSBestEffort, pod_info.RequestTypeRegular, 0)), "best-effort qos without devices is not sensitive")
+}

--- a/pkg/scheduler/plugins/numa/scoring_test.go
+++ b/pkg/scheduler/plugins/numa/scoring_test.go
@@ -4,6 +4,7 @@
 package numa
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,19 @@ func TestBestEffortEvaluatorSpan(t *testing.T) {
 			assert.Len(t, placement, test.wantSpan)
 		})
 	}
+}
+
+func TestBestEffortEvaluatorMoreThanStackZones(t *testing.T) {
+	zones := make([]node_info.NumaZoneSpec, stackZones+1)
+	for i := range zones {
+		zones[i] = numaZone(fmt.Sprintf("node-%d", i), map[string]string{gpu: "1"})
+	}
+	node := numaTopology(node_info.TopologyPolicyBestEffort, node_info.TopologyScopeContainer, zones...)
+
+	placement, ok := evalPlacement(node, noIgnoreList, []v1.ResourceList{req(gpu, fmt.Sprintf("%d", len(zones)))})
+
+	assert.True(t, ok)
+	assert.Len(t, placement, len(zones))
 }
 
 func TestNodeScoreTiers(t *testing.T) {

--- a/pkg/scheduler/plugins/numa/seed_placements.go
+++ b/pkg/scheduler/plugins/numa/seed_placements.go
@@ -36,7 +36,7 @@ func (pp *numaPlugin) seedPlacements(ssn *framework.Session) {
 				continue
 			}
 			node := ssn.ClusterInfo.Nodes[task.NodeName]
-			if node == nil || !pp.shouldHandle(task, node.NumaTopology) {
+			if node == nil || !pp.shouldScore(task, node.NumaTopology) {
 				continue
 			}
 			record := resolvePlacementRecord(task.Pod, bindRequestZones(ssn, task.Pod))

--- a/pkg/scheduler/plugins/scores/scores.go
+++ b/pkg/scheduler/plugins/scores/scores.go
@@ -6,9 +6,10 @@ package scores
 const (
 	MaxHighDensity = 9
 	ResourceType   = 10
-	Availability   = 100
-	GpuSharing     = 1000
-	Topology       = 10000
-	K8sPlugins     = 100000
-	NominatedNode  = 1000000
+	Numa           = 100
+	Availability   = 1000
+	GpuSharing     = 10000
+	Topology       = 100000
+	K8sPlugins     = 1000000
+	NominatedNode  = 10000000
 )


### PR DESCRIPTION
## Description

This PR adds node scoring to the NUMA plugin, thus extending support to `BestEffort` mode.

Notes:
- The plugin strictly prefers minimizing the zones a pod will allocate on
- Only `LeastNUMANodes` strategy was implemented for now - more can be added according to user feedback
- The plugin score is lower than network topology and gpu sharing
- A significant performance improvement was observed when testing the preempt scenario mentioned in #1911 - presumably because the lower scoring of unfeasible nodes increases the chances of finding a fit in FittingNodes. The scenario now finishes in ~65s vs ~187s (a ~64% improvement)

## Related Issues

Implements #1756 

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
