### PR TITLE
docs: fix snapshot capture guide for HA installs and ZIP naming

### DIFF
--- a/docs/plugins/snapshot.md
+++ b/docs/plugins/snapshot.md
@@ -31,19 +31,44 @@ The snapshot plugin is a framework plugin that provides an HTTP endpoint to capt
 
 The plugin registers an HTTP endpoint `/get-snapshot` that returns a ZIP file containing a JSON snapshot of the cluster state.
 
-To capture a snapshot, port-forward to the scheduler pod and call the endpoint:
+The endpoint is served only by the **leader** replica. The route is registered when a scheduling
+session opens, and only the leader opens sessions — a standby replica answers on the same port but
+returns `404 page not found`. On an HA install (`global.leaderElection: true` with more than one
+replica), port-forwarding to the Deployment reaches an arbitrary ready pod, so resolve the leader
+from the scheduler lease first:
+
+```bash
+LEADER=$(kubectl get lease -n kai-scheduler kai-scheduler \
+           -o jsonpath='{.spec.holderIdentity}' | cut -d'_' -f1)
+
+kubectl port-forward -n kai-scheduler "pod/$LEADER" 8081:8081 &
+sleep 2
+curl -sSf "localhost:8081/get-snapshot" -o snapshot.zip
+```
+
+The lease is named after the scheduler (`kai-scheduler` by default). A shard that sets
+`partitionLabelValue` uses `<scheduler-name>-<partition-label-value>` instead — for example
+`kai-scheduler-dra`.
+
+On a single-replica install with leader election disabled, port-forwarding to the Deployment is
+equivalent:
+
 ```bash
 kubectl port-forward -n kai-scheduler deployment/kai-scheduler-default 8081 &
 sleep 2
-curl -vv "localhost:8081/get-snapshot" > snapshot.gzip
+curl -sSf "localhost:8081/get-snapshot" -o snapshot.zip
 ```
 
 ### Analyzing a Snapshot
 
 Use the snapshot tool to analyze a captured snapshot:
 ```bash
-./bin/snapshot-tool-amd64 --filename snapshot.gzip --verbosity 8
+./bin/snapshot-tool-amd64 --filename snapshot.zip --verbosity 8
 ```
+
+Build the tool first with `make build-go SERVICE_NAME=snapshot-tool` — see
+[Building from Source](../developer/building-from-source.md). There is no published
+`snapshot-tool` release artifact.
 
 See the [Snapshot Tool](#snapshot-tool) section below for more details.
 

--- a/docs/plugins/snapshot.md
+++ b/docs/plugins/snapshot.md
@@ -31,11 +31,18 @@ The snapshot plugin is a framework plugin that provides an HTTP endpoint to capt
 
 The plugin registers an HTTP endpoint `/get-snapshot` that returns a ZIP file containing a JSON snapshot of the cluster state.
 
-The endpoint is served only by the **leader** replica. The route is registered when a scheduling
-session opens, and only the leader opens sessions — a standby replica answers on the same port but
-returns `404 page not found`. On an HA install (`global.leaderElection: true` with more than one
-replica), port-forwarding to the Deployment reaches an arbitrary ready pod, so resolve the leader
-from the scheduler lease first:
+To capture a snapshot, port-forward to the scheduler Deployment and call the endpoint:
+
+```bash
+kubectl port-forward -n kai-scheduler deployment/kai-scheduler-default 8081 &
+sleep 2
+curl -sSf "localhost:8081/get-snapshot" -o snapshot.zip
+```
+
+#### Capturing a Snapshot with Multiple Replicas
+
+When the scheduler Deployment has more than one replica, resolve the leader from the scheduler
+lease and port-forward directly to its pod:
 
 ```bash
 LEADER=$(kubectl get lease -n kai-scheduler kai-scheduler \
@@ -50,25 +57,22 @@ The lease is named after the scheduler (`kai-scheduler` by default). A shard tha
 `partitionLabelValue` uses `<scheduler-name>-<partition-label-value>` instead — for example
 `kai-scheduler-dra`.
 
-On a single-replica install with leader election disabled, port-forwarding to the Deployment is
-equivalent:
-
-```bash
-kubectl port-forward -n kai-scheduler deployment/kai-scheduler-default 8081 &
-sleep 2
-curl -sSf "localhost:8081/get-snapshot" -o snapshot.zip
-```
-
 ### Analyzing a Snapshot
 
-Use the snapshot tool to analyze a captured snapshot:
+Build the snapshot tool:
+
+```bash
+make build-go SERVICE_NAME=snapshot-tool
+```
+
+See [Building from Source](../developer/building-from-source.md) for more details. There is no
+published `snapshot-tool` release artifact.
+
+Then use the tool to analyze a captured snapshot:
+
 ```bash
 ./bin/snapshot-tool-amd64 --filename snapshot.zip --verbosity 8
 ```
-
-Build the tool first with `make build-go SERVICE_NAME=snapshot-tool` — see
-[Building from Source](../developer/building-from-source.md). There is no published
-`snapshot-tool` release artifact.
 
 See the [Snapshot Tool](#snapshot-tool) section below for more details.
 


### PR DESCRIPTION
## Description

`docs/plugins/snapshot.md` tells users to port-forward to the scheduler Deployment to capture a snapshot. That resolves to an arbitrary ready pod, but only the leader serves `/get-snapshot`:

- The plugin `mux` is created and served at `cmd/scheduler/app/server.go:125`, before leader election — so a standby replica answers on 8081 with an empty mux.
- `scheduler.Run` is wired only to `OnStartedLeading` (`cmd/scheduler/app/server.go:259`), so only the leader opens scheduling sessions.
- `/get-snapshot` is registered per session (`pkg/scheduler/plugins/snapshot/snapshot.go:95`).

Both replicas pass their probes, so on an HA install the documented command hits a standby roughly half the time and returns a bare `404 page not found` with nothing pointing at leader election.

Observed on v0.16.6, 2 replicas of the default shard, `global.leaderElection: true`:

```console
# standby replica
$ kubectl -n kai-scheduler port-forward pod/kai-scheduler-default-6ff88997-ztprt 8081:8081 &
$ curl -sS -o /dev/null -w '%{http_code}\n' localhost:8081/get-snapshot
404

# lease holder
$ kubectl -n kai-scheduler port-forward pod/kai-scheduler-default-6ff88997-c42dm 8081:8081 &
$ curl -sS -o snapshot.zip -w '%{http_code} %{size_download}\n' localhost:8081/get-snapshot
200 10393067
```

This PR resolves the leader from the scheduler lease before port-forwarding, and keeps the Deployment form documented for single-replica installs where it is equivalent.

It also fixes two smaller things on the same page:

- **`.gzip` → `.zip`.** The response is a ZIP (`Content-Type: application/zip`, `Content-Disposition: filename=snapshot.zip`), and the page already said so under **Response Format** and in the Snapshot Tool examples — but **Capturing**/**Analyzing** used `.gzip`, so the page contradicted itself and `gunzip` on the result fails.
- **`snapshot-tool` build step.** The page runs `./bin/snapshot-tool-amd64` without saying where it comes from. Added the `make build-go SERVICE_NAME=snapshot-tool` invocation (which writes exactly that path — `BUILD_DIR=bin`, `${SERVICE_NAME}-amd64`) and a link to `docs/developer/building-from-source.md`.

### Reviewer note

The lease name is keyed on the shard's `PartitionLabelValue`, not the shard name (`pkg/operator/operands/scheduler/resources_for_shard.go:398`):

```go
func LeaseName(config *kaiv1.Config, shard *kaiv1.SchedulingShard) string {
	if shard.Spec.PartitionLabelValue != "" {
		return fmt.Sprintf("%s-%s", *config.Spec.Global.SchedulerName, shard.Spec.PartitionLabelValue)
	}
	return *config.Spec.Global.SchedulerName
}
```

The doc now states that explicitly, since multi-shard installs otherwise have to guess. Worth a check that the wording matches how you'd want shards described to users.

## Related Issues

Fixes #1972

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed) — n/a, docs only
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label) — `skip-changelog`, docs only

## Breaking Changes

None.

## Additional Notes

Docs-only, so CI skips build/test per `on-pr.yaml`.
