### PR TITLE
chore(release): prepare changelog for v0.16.7

### DIFF
--- a/.changes/unreleased/fixed-20260726-152818.yaml
+++ b/.changes/unreleased/fixed-20260726-152818.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Segmented elastic PyTorchJob now respects minReplicas instead of requiring all worker segments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.16.7] - 2026-07-26
+
+### Fixed
+- Segmented elastic PyTorchJob now respects minReplicas instead of requiring all worker segments
+
 ## [v0.16.6] - 2026-07-23
 
 ### Fixed


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.16.7]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.16.7` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.16.7]` section for accuracy.
- Target branch: `v0.16`.
