### PR TITLE
ci: skip build and test for changelog-only PRs (backport #1963 to v0.12)

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -29,10 +29,12 @@ jobs:
             docs:
               - '**/*.md'
               - 'docs/**'
+              - '.changes/**'
             code:
               - '**'
               - '!**/*.md'
               - '!docs/**'
+              - '!.changes/**'
   validate-and-test:
     needs: [ check-build-and-test-required ]
     if: needs.check-build-and-test-required.outputs.code == 'true'


### PR DESCRIPTION
## Description

Backport of #1963 to the `v0.12` release branch.

CI Build and Validate&Test currently run on changelog-only PRs (e.g. the release-prepare PRs that only touch `CHANGELOG.md` and a `.changes/unreleased/*.yaml` fragment). The `code` paths-filter uses `predicate-quantifier: every`, so the `.changes/**` fragment was treated as code and triggered the full pipeline.

This adds `.changes/**` to the `docs` group and `!.changes/**` to the `code` group so changelog fragments no longer count as code on their own.

**Effect:**
- Changelog-only PRs (`CHANGELOG.md` + `.changes/**`) → `code=false`, build/test skipped.
- Normal PRs that add a fragment alongside real code → the code files still count, so build/test still run.

## Related Issues

Backport of #1963

## Checklist

- [x] Self-reviewed
- [x] CI-only change — `skip-changelog` applies.

## Additional Notes

Manual backport. Resolved a trivial context conflict (this branch lacks the `scale_tests` filter/job present on `main`); the effective change is the same two-line filter edit.
