### PR TITLE
fix(e2e): retry queue creation when admission webhook is not yet ready

### DIFF
--- a/.changes/unreleased/fixed-20260727-104153.yaml
+++ b/.changes/unreleased/fixed-20260727-104153.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Retry queue creation when admission webhook is not yet ready after install

--- a/.changes/unreleased/fixed-20260727-104153.yaml
+++ b/.changes/unreleased/fixed-20260727-104153.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
 body: |-
-  Retry queue creation when admission webhook is not yet ready after install
+  Upgrade test suite retries queue creation when admission webhook is not yet ready

--- a/test/e2e/modules/context/cluster.go
+++ b/test/e2e/modules/context/cluster.go
@@ -6,8 +6,11 @@ package context
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	v2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/resources/rd"
@@ -15,14 +18,36 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/test/e2e/modules/testconfig"
 )
 
+const (
+	webhookRetryInterval = 5 * time.Second
+	webhookRetryTimeout  = 2 * time.Minute
+)
+
 func (tc *TestContext) createClusterQueues(ctx context.Context) error {
 	for _, testQueue := range tc.Queues {
-		err := createQueueContext(ctx, testQueue)
+		err := wait.PollUntilContextTimeout(ctx, webhookRetryInterval, webhookRetryTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				err := createQueueContext(ctx, testQueue)
+				if err != nil {
+					if isWebhookUnavailable(err) {
+						return false, nil
+					}
+					return false, err
+				}
+				return true, nil
+			})
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// isWebhookUnavailable returns true for transient admission webhook connection errors
+// that occur when the webhook server hasn't finished starting yet.
+func isWebhookUnavailable(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") || strings.Contains(msg, "failed to call webhook")
 }
 
 func createQueueContext(ctx context.Context, q *v2.Queue) error {


### PR DESCRIPTION
## Description

After `helm install --wait`, the queue-controller pod passes its readiness probe before the TLS webhook listener is fully bound. The upgrade E2E `BeforeAll` immediately creates queues, which triggers the `queue-validation.kai.scheduler` validating webhook — and gets `connection refused` because the webhook server hasn't started accepting connections yet.

Fix: wrap `createClusterQueues` in a `wait.PollUntilContextTimeout` loop (5 s interval, 2 min timeout) that retries only on transient webhook-unavailable errors (`connection refused` / `failed to call webhook`). All other errors propagate immediately as before.

Reproducer: https://github.com/kai-scheduler/KAI-Scheduler/actions/runs/30244297754/job/89908899084

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None.