### PR TITLE
fix(api): allow PodGroup minMember of 0

### DIFF
--- a/.changes/unreleased/fixed-20260728-212512.yaml
+++ b/.changes/unreleased/fixed-20260728-212512.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Allow PodGroup minMember and minSubGroup of 0 for workloads with no gang requirement

--- a/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
@@ -54,17 +54,19 @@ spec:
                 description: |-
                   MinMember defines the minimal number of members to run the PodGroup;
                   if there are not enough resources to start all required members, the scheduler will not start anyone.
+                  A value of 0 means no gang requirement: all pods are scheduled elastically (e.g. scale-to-zero workloads).
                   Mutually exclusive with MinSubGroup.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               minSubGroup:
                 description: |-
                   MinSubGroup defines the minimal number of direct child SubGroups required for this PodGroup to be schedulable.
+                  A value of 0 means no gang requirement: all SubGroups are scheduled elastically.
                   Only applicable when SubGroups are defined.
                   Mutually exclusive with MinMember.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               preemptibility:
                 description: |-

--- a/pkg/apis/scheduling/v2alpha2/podgroup_types.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_types.go
@@ -35,16 +35,18 @@ import (
 type PodGroupSpec struct {
 	// MinMember defines the minimal number of members to run the PodGroup;
 	// if there are not enough resources to start all required members, the scheduler will not start anyone.
+	// A value of 0 means no gang requirement: all pods are scheduled elastically (e.g. scale-to-zero workloads).
 	// Mutually exclusive with MinSubGroup.
 	// +kubebuilder:validation:Nullable
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinMember *int32 `json:"minMember,omitempty" protobuf:"varint,1,opt,name=minMember"`
 
 	// MinSubGroup defines the minimal number of direct child SubGroups required for this PodGroup to be schedulable.
+	// A value of 0 means no gang requirement: all SubGroups are scheduled elastically.
 	// Only applicable when SubGroups are defined.
 	// Mutually exclusive with MinMember.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinSubGroup *int32 `json:"minSubGroup,omitempty"`
 
 	// Queue defines the queue to allocate resource for PodGroup; if queue does not exist,

--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook.go
@@ -113,11 +113,6 @@ func validatePodGroupSpec(spec *PodGroupSpec) *validationErrors {
 	}
 
 	if spec.MinSubGroup != nil {
-		if *spec.MinSubGroup < 1 {
-			validationErrors.minDefinitionErrors = append(validationErrors.minDefinitionErrors,
-				&invalidMinSubGroupError{msg: "minSubGroup at the podgroup level must be equal to or greater than 1"})
-			return validationErrors
-		}
 		rootCount := countRootSubGroups(spec.SubGroups)
 		if int(*spec.MinSubGroup) > rootCount {
 			validationErrors.minDefinitionErrors = append(validationErrors.minDefinitionErrors,

--- a/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_webhook_test.go
@@ -250,6 +250,17 @@ func TestValidatePodGroupSpec(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "Valid: minSubGroup of 0 (no gang requirement)",
+			spec: PodGroupSpec{
+				MinSubGroup: ptr.To(int32(0)),
+				SubGroups: []SubGroup{
+					{Name: "a", MinMember: ptr.To(int32(4))},
+					{Name: "b", MinMember: ptr.To(int32(4))},
+				},
+			},
+			want: nil,
+		},
+		{
 			name: "Invalid: both minMember and minSubGroup set on PodGroup",
 			spec: PodGroupSpec{
 				MinMember:   ptr.To(int32(24)),

--- a/pkg/podgrouper/podgrouper/plugins/knative/knative_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/knative/knative_test.go
@@ -4,7 +4,6 @@
 package knative
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,6 +112,17 @@ func TestGetPodGroupMetadata(t *testing.T) {
 }
 
 func TestGetPodGroupMetadata_MinScale(t *testing.T) {
+	for minScale, expectedMinAvailable := range map[string]int32{
+		"3": 3,
+		"0": 0, // scale-to-zero: no gang requirement
+	} {
+		t.Run("min-scale="+minScale, func(t *testing.T) {
+			testGetPodGroupMetadataMinScale(t, minScale, expectedMinAvailable)
+		})
+	}
+}
+
+func testGetPodGroupMetadataMinScale(t *testing.T, minScale string, expectedMinAvailable int32) {
 	service := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "Service",
@@ -156,7 +166,7 @@ func TestGetPodGroupMetadata_MinScale(t *testing.T) {
 			Namespace: "test_namespace",
 			UID:       "2",
 			Annotations: map[string]string{
-				"autoscaling.knative.dev/min-scale": "3",
+				"autoscaling.knative.dev/min-scale": minScale,
 			},
 		},
 		Spec:   knative.RevisionSpec{},
@@ -197,7 +207,7 @@ func TestGetPodGroupMetadata_MinScale(t *testing.T) {
 	assert.Equal(t, "pg-revision-2", metadata.Name)
 	assert.Equal(t, constants.InferencePriorityClass, metadata.PriorityClassName)
 	assert.Equal(t, "test_queue", metadata.Queue)
-	assert.Equal(t, "3", strconv.Itoa(int(metadata.MinAvailable)))
+	assert.Equal(t, expectedMinAvailable, metadata.MinAvailable)
 }
 
 func TestGetPodGroupMetadataBackwardsCompatibility(t *testing.T) {

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -284,7 +284,7 @@ func (pgi *PodGroupInfo) setSubGroups(podGroup *enginev2alpha2.PodGroup) error {
 		if defaultPodSet, found := pgi.PodSets[DefaultSubGroup]; found {
 			minAvail := int32(1)
 			if podGroup.Spec.MinMember != nil {
-				minAvail = max(*podGroup.Spec.MinMember, 1)
+				minAvail = *podGroup.Spec.MinMember
 			}
 			defaultPodSet.SetMinAvailable(minAvail)
 			rootSubGroupSet.AddPodSet(defaultPodSet)

--- a/pkg/scheduler/api/podgroup_info/job_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/job_info_test.go
@@ -178,6 +178,35 @@ func TestAddTaskInfoTracksInvalidSubGroupTask(t *testing.T) {
 	assert.Contains(t, info.TasksFitErrors[task.UID].Error(), `missing-subgroup`)
 }
 
+func TestSetPodGroupMinMember(t *testing.T) {
+	tests := []struct {
+		name             string
+		minMember        *int32
+		expectedMinAvail int32
+	}{
+		{"nil minMember defaults to 1", nil, 1},
+		{"zero minMember is honored", ptr.To(int32(0)), 0},
+		{"positive minMember is honored", ptr.To(int32(3)), 3},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			info := NewPodGroupInfo("group-1")
+			info.SetPodGroup(&enginev2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "group-1",
+					Namespace: "ns-1",
+				},
+				Spec: enginev2alpha2.PodGroupSpec{
+					Queue:     "queue-1",
+					MinMember: test.minMember,
+				},
+			})
+
+			assert.Equal(t, test.expectedMinAvail, info.PodSets[DefaultSubGroup].GetMinAvailable())
+		})
+	}
+}
+
 func TestDeleteTaskInfo(t *testing.T) {
 	// case1
 	case01_uid := common_info.PodGroupID("owner1")

--- a/test/e2e/suites/api/crds/podgroup/validations.go
+++ b/test/e2e/suites/api/crds/podgroup/validations.go
@@ -101,7 +101,7 @@ var _ = Describe("MinSubGroup validation", Ordered, func() {
 		Expect(warningCapture.Messages[0]).To(ContainSubstring("minSubGroup (5) exceeds the number of direct child SubGroups (4)"))
 	})
 
-	It("should reject minSubGroup = 0", func(ctx context.Context) {
+	It("should accept minSubGroup = 0", func(ctx context.Context) {
 		pg := createMinSubGroupPodGroup(testCtx, ptr.To[int32](0), 0,
 			[]schedulingv2alpha2.SubGroup{
 				{Name: "prefill-0", MinMember: ptr.To[int32](8)},
@@ -110,7 +110,7 @@ var _ = Describe("MinSubGroup validation", Ordered, func() {
 
 		_, err := testCtx.KubeAiSchedClientset.SchedulingV2alpha2().PodGroups(pg.Namespace).Create(ctx,
 			pg, metav1.CreateOptions{})
-		Expect(err).ToNot(Succeed())
+		Expect(err).To(Succeed())
 	})
 
 	It("should reject SubGroup with both minMember and minSubGroup", func(ctx context.Context) {

--- a/test/e2e/suites/integrations/third_party/knative/knative_specs.go
+++ b/test/e2e/suites/integrations/third_party/knative/knative_specs.go
@@ -111,6 +111,32 @@ func DescribeKnativeSpecs() bool {
 				Expect(podGroups.Items[0].Spec.MinMember).To(Equal(k8sptr.To(int32(1))),
 					"Expected minmember of podgroup to be 1")
 			})
+
+			It("knative service with scale-to-zero - minscale 0", func(ctx context.Context) {
+				namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
+				serviceName := "knative-service-" + utils.GenerateRandomK8sName(10)
+
+				knativeService := GetKnativeServiceObject(serviceName, namespace, testCtx.Queues[0].Name)
+
+				knativeService.Spec.ConfigurationSpec.Template.Annotations[minScaleAnnotation] = "0"
+
+				Expect(testCtx.ControllerClient.Create(ctx, knativeService)).To(Succeed())
+				defer func() {
+					Expect(testCtx.ControllerClient.Delete(ctx, knativeService)).To(Succeed())
+				}()
+
+				// Knative still creates the initial pod on deployment even with min-scale 0
+				pods := GetServicePods(ctx, testCtx, serviceName, namespace, 1)
+
+				wait.ForPodsScheduled(ctx, testCtx.ControllerClient, namespace, pods)
+
+				var podGroups v2alpha2.PodGroupList
+				Expect(testCtx.ControllerClient.List(ctx, &podGroups, client.InNamespace(namespace))).To(Succeed())
+				Expect(len(podGroups.Items)).To(Equal(1),
+					"Expected one podgroup for the revision")
+				Expect(podGroups.Items[0].Spec.MinMember).To(Equal(k8sptr.To(int32(0))),
+					"Expected minmember of podgroup to be 0")
+			})
 		})
 	})
 }


### PR DESCRIPTION
## Description

Knative revisions with `autoscaling.knative.dev/min-scale: "0"` produced `spec.minMember: 0`, which the CRD rejected (`minimum: 1`), breaking PodGroup reconciliation for scale-to-zero workloads.

Relaxes the top-level `minMember` validation to `minimum: 0` and stops clamping it to 1 in the scheduler, so an explicit 0 means no gang requirement (all pods scheduled elastically).

## Related Issues

Fixes #1944

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None.

## Additional Notes

No change to the Knative min-scale → MinAvailable mapping, no webhook changes, top-level `minSubGroup` still requires ≥1.
