### PR TITLE
fix(chart): Add guards for scalingpod namespace and resourcereservation sa

### DIFF
--- a/.changes/unreleased/fixed-20260729-114931.yaml
+++ b/.changes/unreleased/fixed-20260729-114931.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Helm chart skips creating resource-reservation ServiceAccount and scaling pod namespace when they already exist

--- a/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
+++ b/deployments/kai-scheduler/templates/services/resourcereservation-serviceaccount.yaml
@@ -1,12 +1,16 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+{{- $ns := .Values.global.resourceReservation.namespace }}
+{{- $sa := .Values.global.resourceReservation.serviceAccount }}
+{{- if not (lookup "v1" "ServiceAccount" $ns $sa) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.global.resourceReservation.serviceAccount }}
-  namespace: {{ .Values.global.resourceReservation.namespace }}
+  name: {{ $sa }}
+  namespace: {{ $ns }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/deployments/kai-scheduler/templates/services/scalingpod-namespace.yaml
+++ b/deployments/kai-scheduler/templates/services/scalingpod-namespace.yaml
@@ -1,11 +1,12 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.global.clusterAutoscaling }}
+{{- $ns := .Values.nodescaleadjuster.scalingPodNamespace }}
+{{- if and .Values.global.clusterAutoscaling (not (lookup "v1" "Namespace" "" $ns)) }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.nodescaleadjuster.scalingPodNamespace }}
+  name: {{ $ns }}
   {{- with .Values.nodescaleadjuster.labels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/deployments/kai-scheduler/tests/resourcereservation_serviceaccount_test.yaml
+++ b/deployments/kai-scheduler/tests/resourcereservation_serviceaccount_test.yaml
@@ -1,0 +1,73 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test resource reservation ServiceAccount template
+templates:
+  - services/resourcereservation-serviceaccount.yaml
+kubernetesProvider:
+  scheme:
+    v1/ServiceAccount:
+      gvr:
+        version: v1
+        resource: serviceaccounts
+      namespaced: true
+tests:
+  - it: should render ServiceAccount when it does not already exist
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: kai-resource-reservation
+      - equal:
+          path: metadata.namespace
+          value: kai-resource-reservation
+
+  - it: should not render ServiceAccount when it already exists
+    kubernetesProvider:
+      objects:
+        - kind: ServiceAccount
+          apiVersion: v1
+          metadata:
+            name: kai-resource-reservation
+            namespace: kai-resource-reservation
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom reservation namespace and service account values
+    set:
+      global.resourceReservation.namespace: custom-reservation-ns
+      global.resourceReservation.serviceAccount: custom-reservation-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-reservation-sa
+      - equal:
+          path: metadata.namespace
+          value: custom-reservation-ns
+
+  - it: should not render ServiceAccount when custom name already exists
+    set:
+      global.resourceReservation.namespace: custom-reservation-ns
+      global.resourceReservation.serviceAccount: custom-reservation-sa
+    kubernetesProvider:
+      objects:
+        - kind: ServiceAccount
+          apiVersion: v1
+          metadata:
+            name: custom-reservation-sa
+            namespace: custom-reservation-ns
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render imagePullSecrets when configured
+    set:
+      global.imagePullSecrets:
+        - name: reservation-pull-secret
+    asserts:
+      - equal:
+          path: imagePullSecrets
+          value:
+            - name: reservation-pull-secret

--- a/deployments/kai-scheduler/tests/scalingpod_namespace_test.yaml
+++ b/deployments/kai-scheduler/tests/scalingpod_namespace_test.yaml
@@ -1,0 +1,78 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test scaling pod namespace template
+templates:
+  - services/scalingpod-namespace.yaml
+kubernetesProvider:
+  scheme:
+    v1/Namespace:
+      gvr:
+        version: v1
+        resource: namespaces
+      namespaced: false
+tests:
+  - it: should not render namespace when cluster autoscaling is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render namespace when cluster autoscaling is enabled and namespace does not exist
+    set:
+      global.clusterAutoscaling: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: kai-scale-adjust
+
+  - it: should not render namespace when it already exists
+    set:
+      global.clusterAutoscaling: true
+    kubernetesProvider:
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: kai-scale-adjust
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use custom scaling pod namespace value
+    set:
+      global.clusterAutoscaling: true
+      nodescaleadjuster.scalingPodNamespace: custom-scaling-ns
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-scaling-ns
+
+  - it: should not render namespace when custom name already exists
+    set:
+      global.clusterAutoscaling: true
+      nodescaleadjuster.scalingPodNamespace: custom-scaling-ns
+    kubernetesProvider:
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: custom-scaling-ns
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render namespace labels when configured
+    set:
+      global.clusterAutoscaling: true
+      nodescaleadjuster.labels:
+        team: platform
+        env: staging
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.env
+          value: staging


### PR DESCRIPTION
Backport of #1733 to v0.16.

## Description

Helm skips creating bootstrap resources that already exist in the cluster, consistent with the reservation namespace template.

## Related Issues

Fixes https://github.com/kai-scheduler/KAI-Scheduler/issues/1732

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

No