### PR TITLE
chore(release): prepare changelog for v0.16.8

### DIFF
--- a/.changes/unreleased/Fixed-20260729-104549.yaml
+++ b/.changes/unreleased/Fixed-20260729-104549.yaml
@@ -1,6 +1,0 @@
-kind: Fixed
-body: Guard custom scalingpod namespaces and resource-reservation ServiceAccounts in the Helm chart
-time: 2026-07-29T10:45:49.529295176+02:00
-custom:
-    Author: dttung2905
-    Issue: "1733"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.16.8] - 2026-07-29
+
+### Fixed
+- Guard custom scalingpod namespaces and resource-reservation ServiceAccounts in the Helm chart [#1733](https://github.com/kai-scheduler/KAI-Scheduler/issues/1733) [dttung2905](https://github.com/dttung2905)
+
 ## [v0.16.7] - 2026-07-26
 
 ### Fixed


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.16.8]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.16.8` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.16.8]` section for accuracy.
- Target branch: `v0.16`.
