### PR TITLE
test: increase binder and pod-grouper scale resources

### DIFF
--- a/hack/setup-scale-test-env.sh
+++ b/hack/setup-scale-test-env.sh
@@ -45,7 +45,7 @@ kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"admissi
 kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"scheduler":{"service":{"resources":{"requests":{"cpu":"3","memory":"7Gi"},"limits":{"cpu":"5","memory":"7Gi"}}}}}}'
 
 # Binder
-kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"binder":{"service":{"resources":{"requests":{"cpu":"100m","memory":"2500Mi"},"limits":{"cpu":"400m","memory":"2500Mi"}}},"args":{"maxConcurrentReconciles": 100, "qps": 500, "burst": 2000}}}}'
+kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"binder":{"service":{"resources":{"requests":{"cpu":"1","memory":"8Gi"},"limits":{"cpu":"2","memory":"8Gi"}}},"args":{"maxConcurrentReconciles": 100, "qps": 500, "burst": 2000}}}}'
 
 # pod group controller
 kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"podGroupController":{"service":{"resources":{"requests":{"cpu":"50m","memory":"8000Mi"},"limits":{"cpu":"200m","memory":"8000Mi"}}}}}}'
@@ -54,4 +54,4 @@ kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"podGrou
 kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"queueController":{"service":{"resources":{"requests":{"cpu":"50m","memory":"1000Mi"},"limits":{"cpu":"200m","memory":"200Mi"}}}}}}'
 
 # pod grouper
-kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"podGrouper":{"service":{"resources":{"requests":{"cpu":"50m","memory":"2000Mi"},"limits":{"cpu":"200m","memory":"2000Mi"}}}}}}'
+kubectl patch config.kai.scheduler kai-config --type merge -p '{"spec":{"podGrouper":{"service":{"resources":{"requests":{"cpu":"1","memory":"2Gi"},"limits":{"cpu":"2","memory":"2Gi"}}},"maxConcurrentReconciles":50,"k8sClientConfig":{"qps":500,"burst":1000}}}}'


### PR DESCRIPTION
## Description

- Increase Binder scale-test requests to 1 CPU and 8Gi memory, with limits of 2 CPU and 8Gi memory.
- Increase pod-grouper scale-test requests to 1 CPU and 2Gi memory, with limits of 2 CPU and 2Gi memory.
- Set pod-grouper reconciliation concurrency to 50 and Kubernetes client QPS/Burst to 500/1000.

These scale-only settings prevent Binder and pod-grouper resource starvation from obscuring scheduler measurements in large scale tests.

## Related Issues

None.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (not needed; shell syntax validated)
- [x] Updated documentation (not needed)
- [x] Applied the `skip-changelog` label

## Breaking Changes

None.

## Additional Notes

Validation:

```text
bash -n hack/setup-scale-test-env.sh
git diff --check
```
