### PR TITLE
fix(scheduler): drop deleted Pod status updates

### DIFF
--- a/.changes/unreleased/fixed-20260730-235150.yaml
+++ b/.changes/unreleased/fixed-20260730-235150.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Clean deleted Pod status updates

--- a/pkg/scheduler/cache/status_updater/concurrency.go
+++ b/pkg/scheduler/cache/status_updater/concurrency.go
@@ -74,6 +74,13 @@ func (su *defaultStatusUpdater) updatePod(
 	)
 
 	if err != nil {
+		if isTerminalUpdateError(err) {
+			log.StatusUpdaterLogger.V(5).Do(func() {
+				log.StatusUpdaterLogger.V(5).Infof("Dropping non-retryable pod patch %s/%s: %v", pod.Namespace, pod.Name, err)
+			})
+			su.inFlightPods.Delete(key)
+			return
+		}
 		log.StatusUpdaterLogger.V(1).Errorf("Failed to patch pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		return
 	}

--- a/pkg/scheduler/cache/status_updater/concurrency_test.go
+++ b/pkg/scheduler/cache/status_updater/concurrency_test.go
@@ -223,4 +223,25 @@ var _ = Describe("Status Updater Concurrency - large scale: increase queue size"
 			// Expected - queue is empty, meaning no retry was scheduled
 		}
 	})
+
+	It("updatePod - Drops in-flight update after NotFound error on a deleted pod", func() {
+		kubeClient.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor(
+			"patch", "pods", func(action faketesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "test-pod")
+			},
+		)
+
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+			UID:       "test-uid",
+		}}
+		key := statusUpdater.keyForPodLabelsPayload(pod.Name, pod.Namespace, pod.UID)
+		statusUpdater.inFlightPods.Store(key, &inflightUpdate{object: pod})
+
+		statusUpdater.updatePod(context.Background(), key, []byte(`{"metadata":{"labels":{"foo":"bar"}}}`), nil, pod)
+
+		_, inFlightExists := statusUpdater.inFlightPods.Load(key)
+		Expect(inFlightExists).To(BeFalse(), "In-flight update should be dropped after NotFound error")
+	})
 })


### PR DESCRIPTION
## Description

Continues the status-updater cleanup work from #1945 for Pod updates. A deleted Pod can leave its failed status or label patch in the in-flight map indefinitely. Drop the entry on terminal NotFound or Conflict responses, while retaining transient-error behavior.

## Related Issues

Continues #1945

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None.

## Additional Notes

Focused validation: `GOCACHE=/tmp/kai-status-updater-go-cache go test ./pkg/scheduler/cache/status_updater`.