### PR TITLE
feat(binder): inherit fractional pod tolerations

### DIFF
--- a/.changes/unreleased/added-20260802-003926.yaml
+++ b/.changes/unreleased/added-20260802-003926.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: |-
+  Reservation pods inherit fractional pod tolerations

--- a/pkg/binder/binding/resourcereservation/resource_reservation.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation.go
@@ -252,7 +252,7 @@ func (rsc *service) ReserveGpuDevice(ctx context.Context, pod *v1.Pod, nodeName 
 	rsc.gpuGroupMutex.LockMutexForGroup(gpuGroup)
 	defer rsc.gpuGroupMutex.ReleaseMutex(gpuGroup)
 
-	gpuIndex, err := rsc.acquireGPUIndexByGroup(ctx, nodeName, gpuGroup)
+	gpuIndex, err := rsc.acquireGPUIndexByGroup(ctx, pod, nodeName, gpuGroup)
 	if err != nil {
 		return unknownGpuIndicator, err
 	}
@@ -332,7 +332,9 @@ func escapeJSONPointer(s string) string {
 	return s
 }
 
-func (rsc *service) acquireGPUIndexByGroup(ctx context.Context, nodeName, gpuGroup string) (string, error) {
+func (rsc *service) acquireGPUIndexByGroup(
+	ctx context.Context, sourcePod *v1.Pod, nodeName, gpuGroup string,
+) (string, error) {
 	gpuIndex, err := rsc.findGPUIndexByGroup(gpuGroup)
 	if err != nil {
 		return "", err
@@ -340,7 +342,7 @@ func (rsc *service) acquireGPUIndexByGroup(ctx context.Context, nodeName, gpuGro
 	if gpuIndex != "" {
 		return gpuIndex, err
 	}
-	return rsc.createGPUReservationPodAndGetIndex(ctx, nodeName, gpuGroup)
+	return rsc.createGPUReservationPodAndGetIndex(ctx, sourcePod, nodeName, gpuGroup)
 }
 
 func (rsc *service) findGPUIndexByGroup(gpuGroup string) (
@@ -366,10 +368,12 @@ func (rsc *service) findGPUIndexByGroup(gpuGroup string) (
 	return gpuIndex, nil
 }
 
-func (rsc *service) createGPUReservationPodAndGetIndex(ctx context.Context, nodeName, gpuGroup string) (
+func (rsc *service) createGPUReservationPodAndGetIndex(
+	ctx context.Context, sourcePod *v1.Pod, nodeName, gpuGroup string,
+) (
 	gpuIndex string, err error) {
 	logger := log.FromContext(ctx)
-	pod, err := rsc.createGPUReservationPod(ctx, nodeName, gpuGroup)
+	pod, err := rsc.createGPUReservationPod(ctx, sourcePod, nodeName, gpuGroup)
 	if err != nil {
 		return unknownGpuIndicator, err
 	}
@@ -421,7 +425,9 @@ func (rsc *service) deleteReservationPod(ctx context.Context, pod *v1.Pod) error
 	return nil
 }
 
-func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGroup string) (*v1.Pod, error) {
+func (rsc *service) createGPUReservationPod(
+	ctx context.Context, sourcePod *v1.Pod, nodeName, gpuGroup string,
+) (*v1.Pod, error) {
 	logger := log.FromContext(ctx)
 	if rsc.isScalingUp(ctx) {
 		return nil, fmt.Errorf("cluster is scaling up, could not create reservation pod")
@@ -450,7 +456,7 @@ func (rsc *service) createGPUReservationPod(ctx context.Context, nodeName, gpuGr
 		}
 	}
 
-	pod, err := rsc.createResourceReservationPod(nodeName, gpuGroup, podName, resources)
+	pod, err := rsc.createResourceReservationPod(sourcePod, nodeName, gpuGroup, podName, resources)
 	if err != nil {
 		// The reservation pod name is deterministic per (node, gpu-group). AlreadyExists
 		// means another actor (a concurrent bind, a retry, or another binder replica)
@@ -525,8 +531,14 @@ func (rsc *service) waitForGPUReservationPodAllocation(
 }
 
 func (rsc *service) createResourceReservationPod(
-	nodeName, gpuGroup, podName string, resources v1.ResourceRequirements,
+	sourcePod *v1.Pod, nodeName, gpuGroup, podName string, resources v1.ResourceRequirements,
 ) (*v1.Pod, error) {
+	var tolerations []v1.Toleration
+	if sourcePod != nil {
+		sourcePodSpec := sourcePod.Spec.DeepCopy()
+		tolerations = sourcePodSpec.Tolerations
+	}
+
 	podSpec := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -540,7 +552,8 @@ func (rsc *service) createResourceReservationPod(
 			},
 		},
 		Spec: v1.PodSpec{
-			NodeName: nodeName,
+			NodeName:    nodeName,
+			Tolerations: tolerations,
 			RuntimeClassName: func() *string {
 				if len(rsc.runtimeClassName) == 0 {
 					return nil

--- a/pkg/binder/binding/resourcereservation/resource_reservation_test.go
+++ b/pkg/binder/binding/resourcereservation/resource_reservation_test.go
@@ -910,7 +910,7 @@ var _ = Describe("ResourceReservationService", func() {
 			gpuGroup := "test-group"
 			nodeName := "node-test"
 
-			pod, err := rsc.createResourceReservationPod(nodeName, gpuGroup, podName, resources)
+			pod, err := rsc.createResourceReservationPod(nil, nodeName, gpuGroup, podName, resources)
 			Expect(err).To(BeNil())
 			Expect(pod).NotTo(BeNil())
 
@@ -952,6 +952,35 @@ var _ = Describe("ResourceReservationService", func() {
 			}
 			Expect(container.Env).To(ContainElement(Equal(podNameEnv)))
 			Expect(container.Env).To(ContainElement(Equal(podNamespaceEnv)))
+		})
+
+		It("should copy tolerations from the source pod", func() {
+			rsc := &service{
+				namespace:           "kai-resource-reservation",
+				appLabelValue:       "kai-reservation",
+				serviceAccountName:  "kai-sa",
+				reservationPodImage: "nvidia/kai-reservation:latest",
+				kubeClient:          fake.NewClientBuilder().WithScheme(testScheme).Build(),
+			}
+			sourcePod := &v1.Pod{
+				Spec: v1.PodSpec{
+					Tolerations: []v1.Toleration{{
+						Key:      "hpc",
+						Operator: v1.TolerationOpEqual,
+						Value:    "true",
+						Effect:   v1.TaintEffectNoExecute,
+					}},
+				},
+			}
+
+			pod, err := rsc.createResourceReservationPod(
+				sourcePod, "node-test", "test-group", "reservation-test", v1.ResourceRequirements{},
+			)
+			Expect(err).To(Succeed())
+			Expect(pod.Spec.Tolerations).To(Equal(sourcePod.Spec.Tolerations))
+
+			sourcePod.Spec.Tolerations[0].Value = "changed"
+			Expect(pod.Spec.Tolerations[0].Value).To(Equal("true"))
 		})
 	})
 
@@ -1116,7 +1145,7 @@ var _ = Describe("ResourceReservationService", func() {
 				scalingPodNamespace: scalingPodsNamespace,
 			}
 
-			pod, err := rsc.createGPUReservationPod(context.TODO(), "test-node", "test-gpu-group")
+			pod, err := rsc.createGPUReservationPod(context.TODO(), nil, "test-node", "test-gpu-group")
 			Expect(err).To(BeNil())
 			Expect(pod).NotTo(BeNil())
 
@@ -1146,7 +1175,7 @@ var _ = Describe("ResourceReservationService", func() {
 				scalingPodNamespace: scalingPodsNamespace,
 			}
 
-			pod, err := rsc.createGPUReservationPod(context.TODO(), "test-node", "test-gpu-group")
+			pod, err := rsc.createGPUReservationPod(context.TODO(), nil, "test-node", "test-gpu-group")
 			Expect(err).To(BeNil())
 			Expect(pod).NotTo(BeNil())
 
@@ -1188,7 +1217,7 @@ var _ = Describe("ResourceReservationService", func() {
 				scalingPodNamespace: scalingPodsNamespace,
 			}
 
-			pod, err := rsc.createGPUReservationPod(context.TODO(), "test-node", "test-gpu-group")
+			pod, err := rsc.createGPUReservationPod(context.TODO(), nil, "test-node", "test-gpu-group")
 			Expect(err).To(BeNil())
 			Expect(pod).NotTo(BeNil())
 
@@ -1227,7 +1256,7 @@ var _ = Describe("ResourceReservationService", func() {
 				scalingPodNamespace: scalingPodsNamespace,
 			}
 
-			pod, err := rsc.createGPUReservationPod(context.TODO(), "test-node", "test-gpu-group")
+			pod, err := rsc.createGPUReservationPod(context.TODO(), nil, "test-node", "test-gpu-group")
 			Expect(err).To(BeNil())
 			Expect(pod).NotTo(BeNil())
 
@@ -1505,7 +1534,7 @@ var _ = Describe("Race condition: reservation pod deleted during concurrent bind
 				nil, podSecCtx, containerSecCtx)
 
 			pod, err := svc.createResourceReservationPod(
-				nodeName, gpuGroup, "test-reservation-pod",
+				nil, nodeName, gpuGroup, "test-reservation-pod",
 				v1.ResourceRequirements{
 					Limits:   v1.ResourceList{constants.NvidiaGpuResource: *resource.NewQuantity(1, resource.DecimalSI)},
 					Requests: v1.ResourceList{constants.NvidiaGpuResource: *resource.NewQuantity(1, resource.DecimalSI)},
@@ -1525,7 +1554,7 @@ var _ = Describe("Race condition: reservation pod deleted during concurrent bind
 				nil, nil, nil)
 
 			pod, err := svc.createResourceReservationPod(
-				nodeName, gpuGroup, "test-reservation-pod",
+				nil, nodeName, gpuGroup, "test-reservation-pod",
 				v1.ResourceRequirements{
 					Limits:   v1.ResourceList{constants.NvidiaGpuResource: *resource.NewQuantity(1, resource.DecimalSI)},
 					Requests: v1.ResourceList{constants.NvidiaGpuResource: *resource.NewQuantity(1, resource.DecimalSI)},


### PR DESCRIPTION
## Description

Reservation pods created for fractional GPU allocation now inherit the tolerations of the first requesting pod. This allows them to run on selected GPU nodes with matching NoSchedule or NoExecute taints.

## Related Issues

Fixes #1986

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via make changelog (or applied the skip-changelog label). Do not edit CHANGELOG.md directly — pending fragments are folded into it at release time.

## Breaking Changes

None.

## Additional Notes

Validated with GOCACHE=/tmp/kai-reservation-tolerations-go-cache go test ./pkg/binder/binding/resourcereservation.