### PR TITLE
chore(release): prepare changelog for v0.17.0

### DIFF
--- a/.changes/unreleased/0001-added.yaml
+++ b/.changes/unreleased/0001-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added `global.resourceReservation.createNamespace` Helm value (default `true`) to allow disabling creation of the resource-reservation namespace, for embedding KAI in a parent chart that creates the namespace itself.

--- a/.changes/unreleased/0002-added.yaml
+++ b/.changes/unreleased/0002-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added `global.resourceReservation.createServiceAccount` Helm value (default `true`) to allow disabling creation of the resource-reservation ServiceAccount, for embedding KAI in a parent chart that creates the ServiceAccount itself.

--- a/.changes/unreleased/0003-added.yaml
+++ b/.changes/unreleased/0003-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.

--- a/.changes/unreleased/0004-added.yaml
+++ b/.changes/unreleased/0004-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added GitOps/ArgoCD install support ([guide](docs/gitops/README.md)): `kaiConfig.render` Helm value (default `false`) renders the `kai-config` Config CR inline as a tracked release resource (mutually exclusive with `kaiConfigDeployer.enabled`), `openshift` value (default `false`) forces OpenShift mode where `lookup` auto-detection is unavailable under offline rendering, and ArgoCD `PostDelete` hook and `Prune=false` annotations (requires ArgoCD >= 2.10). [#1794](https://github.com/kai-scheduler/KAI-Scheduler/issues/1794) [#1751](https://github.com/kai-scheduler/KAI-Scheduler/issues/1751)

--- a/.changes/unreleased/0005-added.yaml
+++ b/.changes/unreleased/0005-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added **topology level aliases**: a `Topology` level may declare an `alias` (e.g. `rack`), usable in place of the raw node label key in a workload's `requiredTopologyLevel`/`preferredTopologyLevel`. Aliases are one-to-one (unique within the Topology and must not collide with a `nodeLabel`, enforced by a new Topology validating webhook) and may be edited freely (the `levels` immutability rule now freezes only the `nodeLabel` structure). When a level has no alias, behavior is unchanged and raw label keys keep working. [#1498](https://github.com/kai-scheduler/KAI-Scheduler/issues/1498)

--- a/.changes/unreleased/0006-changed.yaml
+++ b/.changes/unreleased/0006-changed.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  Removed unused `queuecontroller.certSecretName` and `admission.certSecretName` Helm values; webhook TLS secrets are created and managed by the operator (`queue-webhook-tls-secret`, `kai-admission-webhook-tls-secret`). [#1791](https://github.com/kai-scheduler/KAI-Scheduler/pull/1791) [dttung2905](https://github.com/dttung2905)

--- a/.changes/unreleased/0007-changed.yaml
+++ b/.changes/unreleased/0007-changed.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.

--- a/.changes/unreleased/0008-fixed.yaml
+++ b/.changes/unreleased/0008-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)

--- a/.changes/unreleased/0009-fixed.yaml
+++ b/.changes/unreleased/0009-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)

--- a/.changes/unreleased/0010-fixed.yaml
+++ b/.changes/unreleased/0010-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)

--- a/.changes/unreleased/0011-fixed.yaml
+++ b/.changes/unreleased/0011-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.

--- a/.changes/unreleased/0012-fixed.yaml
+++ b/.changes/unreleased/0012-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Scheduler cache now filters terminal Pods at watch time to reduce memory use, while still watching Pods bound by other schedulers so their resource usage is counted in allocatable calculations. [#1645](https://github.com/kai-scheduler/KAI-Scheduler/issues/1645) [enoodle](https://github.com/enoodle)

--- a/.changes/unreleased/0013-fixed.yaml
+++ b/.changes/unreleased/0013-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fix the MinNodeGPUMemoryMiB calculation in the scheduler. This affected allocations for fractional pod requesting gpu "gpu-memory". [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0014-fixed.yaml
+++ b/.changes/unreleased/0014-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Use the maximum gpu size ine the cluster rather then the minimum when checking a potential overLimit or isNonPreemptebleOverquota for a pod. [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0015-fixed.yaml
+++ b/.changes/unreleased/0015-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Reduced allocation churn in the scheduler hot path: cached `Schedulable()` result as a package-level singleton and lazily formatted `logNodeSetsPluginResult` node names only when verbose logging is enabled.

--- a/.changes/unreleased/0016-fixed.yaml
+++ b/.changes/unreleased/0016-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0017-fixed.yaml
+++ b/.changes/unreleased/0017-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0018-fixed.yaml
+++ b/.changes/unreleased/0018-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0019-fixed.yaml
+++ b/.changes/unreleased/0019-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.

--- a/.changes/unreleased/0020-added.yaml
+++ b/.changes/unreleased/0020-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added a Karta fallback podgrouper plugin that lets workload owners define gang-scheduling behavior declaratively via [Karta](https://github.com/run-ai/karta) definitions, without writing a native KAI plugin. The plugin translates a Karta `gangScheduling.podGroup` instruction into a KAI PodGroup with optional SubGroups and topology constraints; native KAI plugins take precedence, and the alpha `podGroups` instruction format remains supported for compatibility. [#1877](https://github.com/kai-scheduler/KAI-Scheduler/pull/1877) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0021-added.yaml
+++ b/.changes/unreleased/0021-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Added **preemption delay**: a `kai.scheduler/preemption-delay` pod annotation (or `preemptionDelay` PodGroup spec field, `metav1.Duration` format) defines a minimal pending time before a workload may trigger eviction of others via preempt, reclaim or consolidation — giving cluster autoscalers a window to provision nodes first. The window re-arms after each eviction (`kai.scheduler/last-eviction-timestamp` annotation); allocation into free capacity and the workload's own evictability are unaffected ([docs](docs/preemption-delay/README.md), [design](docs/developer/designs/preemption-delay/README.md)). [#1832](https://github.com/kai-scheduler/KAI-Scheduler/issues/1832)

--- a/.changes/unreleased/0022-added.yaml
+++ b/.changes/unreleased/0022-added.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Publish FIPS-enabled image variants (`<version>-fips`) for every release, built with the Go toolchain's native FIPS 140-3 mode (`GOFIPS140`), and added a `global.fips` Helm value (default `false`) that appends `-fips` to every resolved image tag ([guide](docs/fips/README.md)). [#1867](https://github.com/kai-scheduler/KAI-Scheduler/issues/1867)

--- a/.changes/unreleased/0023-changed.yaml
+++ b/.changes/unreleased/0023-changed.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  Scenario search now skips re-simulating equivalent victim-set candidates that already failed simulation for the same pending job (reclaim, preempt, consolidation). Skipped candidates are recorded as `state="duplicate"` in `scenario_search_scenarios_total`. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)

--- a/.changes/unreleased/0024-fixed.yaml
+++ b/.changes/unreleased/0024-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed extended resources present on only a subset of nodes being reported as unavailable cluster-wide: `ResourceVector.SetMax` now grows the accumulator to the longer vector's length instead of silently dropping resource indices discovered after the first-iterated node, which caused pods requesting such resources to be rejected as unschedulable ("No node in the node-pool has X resources") depending on node map iteration order. [#1851](https://github.com/kai-scheduler/KAI-Scheduler/issues/1851)

--- a/.changes/unreleased/0025-fixed.yaml
+++ b/.changes/unreleased/0025-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)

--- a/.changes/unreleased/0026-fixed.yaml
+++ b/.changes/unreleased/0026-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Scoped the operator's informer cache for Pods, Leases and EndpointSlices to the KAI namespace and stripped managed fields from cached objects. Since v0.15.0 the operator cached every such object in the cluster, so its memory grew with cluster size and exceeded the default 256Mi limit on large clusters. [#1780](https://github.com/kai-scheduler/KAI-Scheduler/issues/1780)

--- a/.changes/unreleased/0027-fixed.yaml
+++ b/.changes/unreleased/0027-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Reduced transient scheduler allocations during large reclaim operations by comparing proportion queue state and cached resource vectors directly instead of repeatedly materializing resource maps.

--- a/.changes/unreleased/0028-fixed.yaml
+++ b/.changes/unreleased/0028-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed scheduler panic during reclaim when building eviction messages for jobs in root-level queues (`ParentQueue` empty) that reclaim across hierarchy branches. [#1863](https://github.com/kai-scheduler/KAI-Scheduler/issues/1863)

--- a/.changes/unreleased/Added-20260715-190926.yaml
+++ b/.changes/unreleased/Added-20260715-190926.yaml
@@ -1,6 +1,0 @@
-kind: Added
-body: Added support for configuring scheduler Pod Disruption Budget via Helm values (`scheduler.podDisruptionBudget`) when running multiple replicas per scheduling shard.
-time: 2026-07-15T19:09:26.904171476+01:00
-custom:
-    Author: dttung2905
-    Issue: "1624"

--- a/.changes/unreleased/Added-20260719-114307.yaml
+++ b/.changes/unreleased/Added-20260719-114307.yaml
@@ -1,6 +1,0 @@
-kind: Added
-body: override stale gang eviction grace period
-time: 2026-07-19T11:43:07.795476145+02:00
-custom:
-    Author: thebhdn
-    Issue: "1913"

--- a/.changes/unreleased/Added-20260722-210557.yaml
+++ b/.changes/unreleased/Added-20260722-210557.yaml
@@ -1,6 +1,0 @@
-kind: Added
-body: Added support for configuring pod-grouper Pod Disruption Budget via Helm values (`podgrouper.podDisruptionBudget`) when running multiple replicas
-time: 2026-07-22T21:05:57.616499816+01:00
-custom:
-    Author: dttung2905
-    Issue: "1477"

--- a/.changes/unreleased/Added-20260723-150619.yaml
+++ b/.changes/unreleased/Added-20260723-150619.yaml
@@ -1,6 +1,0 @@
-kind: Added
-body: Added support for DRA-backed extended resources (KEP-5004). Pods can request a DeviceClass's extendedResourceName without a ResourceClaim, and the scheduler routes it through DRA. See the design [DRA-backed extended resources](docs/developer/designs/dra-extended-resources/README.md).
-time: 2026-07-23T15:06:19.870923+03:00
-custom:
-    Author: gshaibi
-    Issue: "1943"

--- a/.changes/unreleased/Changed-20260716-101157.yaml
+++ b/.changes/unreleased/Changed-20260716-101157.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  Reduced scheduler memory allocations and improved performance on clusters using NUMA topology alignment.

--- a/.changes/unreleased/Fixed-20260715-153936.yaml
+++ b/.changes/unreleased/Fixed-20260715-153936.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Saturated the DRA GPU device-count accumulation so a ResourceClaim requesting an oversized device count can no longer overflow the queue controller's int64 GPU total to a negative value. [#1873](https://github.com/kai-scheduler/KAI-Scheduler/issues/1873) [thc1006](https://github.com/thc1006)

--- a/.changes/unreleased/Fixed-20260718-004752.yaml
+++ b/.changes/unreleased/Fixed-20260718-004752.yaml
@@ -1,9 +1,0 @@
-# Copyright 2026 NVIDIA CORPORATION
-# SPDX-License-Identifier: Apache-2.0
-
-kind: Fixed
-body: Reduce retained scheduler memory with compact fit-error counts and on-demand details.
-time: 2026-07-18T00:47:52+02:00
-custom:
-    Author: enoodle
-    Issue: "1827"

--- a/.changes/unreleased/Fixed-20260718-212943.yaml
+++ b/.changes/unreleased/Fixed-20260718-212943.yaml
@@ -1,6 +1,0 @@
-kind: Fixed
-body: Fixed admission and scheduler PodDisruptionBudget reconciliation, including drift recovery and cleanup when no longer desired.
-time: 2026-07-18T21:29:43.130860557+01:00
-custom:
-    Author: dttung2905
-    Issue: "1477"

--- a/.changes/unreleased/Fixed-20260720-215438.yaml
+++ b/.changes/unreleased/Fixed-20260720-215438.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Clear stale PodGroup `UnschedulableOnNodePool` conditions after workloads schedule.

--- a/.changes/unreleased/Fixed-20260721-174844.yaml
+++ b/.changes/unreleased/Fixed-20260721-174844.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Segmented PyTorch and LWS PodGrouper now uses minSubGroup on parent SubGroups, fixing admission webhook rejection.
-time: 2026-07-21T17:48:44.000000000Z
-custom:
-    Issue: "1927"

--- a/.changes/unreleased/Fixed-20260721-213513.yaml
+++ b/.changes/unreleased/Fixed-20260721-213513.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  NUMA plugin now aligns non-Guaranteed pods that request GPUs, matching the kubelet's device manager (device alignment is QoS-independent).

--- a/.changes/unreleased/Fixed-20260722-035020.yaml
+++ b/.changes/unreleased/Fixed-20260722-035020.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Status-updater drops status/patch updates for deleted PodGroups instead of retrying NotFound errors indefinitely, stopping log floods. [#1945](https://github.com/kai-scheduler/KAI-Scheduler/issues/1945)

--- a/.changes/unreleased/added-20260723-175006.yaml
+++ b/.changes/unreleased/added-20260723-175006.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  NUMA-aware node scoring preferring fewest-NUMA-zone placement

--- a/.changes/unreleased/added-20260727-221629.yaml
+++ b/.changes/unreleased/added-20260727-221629.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Helm value global.priorityClassName sets a PriorityClass on all KAI control-plane pods

--- a/.changes/unreleased/changed-20260719-145051.yaml
+++ b/.changes/unreleased/changed-20260719-145051.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  make changelog accepts KIND and BODY vars for non-interactive use by agents

--- a/.changes/unreleased/changed-20260727-142159.yaml
+++ b/.changes/unreleased/changed-20260727-142159.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Removed unnecessary pod-affinity pre-score allocation churn

--- a/.changes/unreleased/fixed-20260723-135338.yaml
+++ b/.changes/unreleased/fixed-20260723-135338.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Avoid repeated victim candidate allocations during reclaim, preempt, and unlimited-candidate consolidation searches [#1850](https://github.com/kai-scheduler/KAI-Scheduler/issues/1850)

--- a/.changes/unreleased/fixed-20260726-152818.yaml
+++ b/.changes/unreleased/fixed-20260726-152818.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Segmented elastic PyTorchJob now respects minReplicas instead of requiring all worker segments

--- a/.changes/unreleased/fixed-20260727-104153.yaml
+++ b/.changes/unreleased/fixed-20260727-104153.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Upgrade test suite retries queue creation when admission webhook is not yet ready

--- a/.changes/unreleased/fixed-20260727-234051.yaml
+++ b/.changes/unreleased/fixed-20260727-234051.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Prevent some scheduler OOM kills by setting Go's memory limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,62 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.17.0] - 2026-08-02
+
+### Added
+- Helm value global.priorityClassName sets a PriorityClass on all KAI control-plane pods
+- Publish FIPS-enabled image variants (`<version>-fips`) for every release, built with the Go toolchain's native FIPS 140-3 mode (`GOFIPS140`), and added a `global.fips` Helm value (default `false`) that appends `-fips` to every resolved image tag ([guide](docs/fips/README.md)). [#1867](https://github.com/kai-scheduler/KAI-Scheduler/issues/1867)
+- Added `defaultPriorityClasses.enabled` Helm value (default `true`) for installations that manage KAI PriorityClasses externally.
+- NUMA-aware node scoring preferring fewest-NUMA-zone placement
+- Added **topology level aliases**: a `Topology` level may declare an `alias` (e.g. `rack`), usable in place of the raw node label key in a workload's `requiredTopologyLevel`/`preferredTopologyLevel`. Aliases are one-to-one (unique within the Topology and must not collide with a `nodeLabel`, enforced by a new Topology validating webhook) and may be edited freely (the `levels` immutability rule now freezes only the `nodeLabel` structure). When a level has no alias, behavior is unchanged and raw label keys keep working. [#1498](https://github.com/kai-scheduler/KAI-Scheduler/issues/1498)
+- Added a Karta fallback podgrouper plugin that lets workload owners define gang-scheduling behavior declaratively via [Karta](https://github.com/run-ai/karta) definitions, without writing a native KAI plugin. The plugin translates a Karta `gangScheduling.podGroup` instruction into a KAI PodGroup with optional SubGroups and topology constraints; native KAI plugins take precedence, and the alpha `podGroups` instruction format remains supported for compatibility. [#1877](https://github.com/kai-scheduler/KAI-Scheduler/pull/1877) [davidLif](https://github.com/davidLif)
+- Added **preemption delay**: a `kai.scheduler/preemption-delay` pod annotation (or `preemptionDelay` PodGroup spec field, `metav1.Duration` format) defines a minimal pending time before a workload may trigger eviction of others via preempt, reclaim or consolidation — giving cluster autoscalers a window to provision nodes first. The window re-arms after each eviction (`kai.scheduler/last-eviction-timestamp` annotation); allocation into free capacity and the workload's own evictability are unaffected ([docs](docs/preemption-delay/README.md), [design](docs/developer/designs/preemption-delay/README.md)). [#1832](https://github.com/kai-scheduler/KAI-Scheduler/issues/1832)
+- Added GitOps/ArgoCD install support ([guide](docs/gitops/README.md)): `kaiConfig.render` Helm value (default `false`) renders the `kai-config` Config CR inline as a tracked release resource (mutually exclusive with `kaiConfigDeployer.enabled`), `openshift` value (default `false`) forces OpenShift mode where `lookup` auto-detection is unavailable under offline rendering, and ArgoCD `PostDelete` hook and `Prune=false` annotations (requires ArgoCD >= 2.10). [#1794](https://github.com/kai-scheduler/KAI-Scheduler/issues/1794) [#1751](https://github.com/kai-scheduler/KAI-Scheduler/issues/1751)
+- Added `global.resourceReservation.createServiceAccount` Helm value (default `true`) to allow disabling creation of the resource-reservation ServiceAccount, for embedding KAI in a parent chart that creates the ServiceAccount itself.
+- Added `global.resourceReservation.createNamespace` Helm value (default `true`) to allow disabling creation of the resource-reservation namespace, for embedding KAI in a parent chart that creates the namespace itself.
+- Added support for configuring scheduler Pod Disruption Budget via Helm values (`scheduler.podDisruptionBudget`) when running multiple replicas per scheduling shard. [#1624](https://github.com/kai-scheduler/KAI-Scheduler/issues/1624) [dttung2905](https://github.com/dttung2905)
+- override stale gang eviction grace period [#1913](https://github.com/kai-scheduler/KAI-Scheduler/issues/1913) [thebhdn](https://github.com/thebhdn)
+- Added support for configuring pod-grouper Pod Disruption Budget via Helm values (`podgrouper.podDisruptionBudget`) when running multiple replicas [#1477](https://github.com/kai-scheduler/KAI-Scheduler/issues/1477) [dttung2905](https://github.com/dttung2905)
+- Added support for DRA-backed extended resources (KEP-5004). Pods can request a DeviceClass's extendedResourceName without a ResourceClaim, and the scheduler routes it through DRA. See the design [DRA-backed extended resources](docs/developer/designs/dra-extended-resources/README.md). [#1943](https://github.com/kai-scheduler/KAI-Scheduler/issues/1943) [gshaibi](https://github.com/gshaibi)
+
+### Changed
+- Removed unused `queuecontroller.certSecretName` and `admission.certSecretName` Helm values; webhook TLS secrets are created and managed by the operator (`queue-webhook-tls-secret`, `kai-admission-webhook-tls-secret`). [#1791](https://github.com/kai-scheduler/KAI-Scheduler/pull/1791) [dttung2905](https://github.com/dttung2905)
+- Reduced scheduler memory allocations and improved performance on clusters using NUMA topology alignment.
+- Scenario search now skips re-simulating equivalent victim-set candidates that already failed simulation for the same pending job (reclaim, preempt, consolidation). Skipped candidates are recorded as `state="duplicate"` in `scenario_search_scenarios_total`. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
+- make changelog accepts KIND and BODY vars for non-interactive use by agents
+- Podgrouper now preserves an existing PodGroup's topology constraint when the workload does not specify one, so an externally-assigned topology is not overwritten. Workload topology annotations still take precedence when present.
+
+### Fixed
+- Scenario search no longer leaks a rejected scenario's victim nodes into the probe's feasible-node set: the solver now rolls back feasible-node additions after validator-rejected and errored simulations, not only after cleanly unsolved ones. [#1719](https://github.com/kai-scheduler/KAI-Scheduler/issues/1719)
+- Reduced scheduler memory use during large reclaim operations by removing redundant per-job-pair min-runtime protection caching; effective min-runtime durations remain cached per queue pair. [#1808](https://github.com/kai-scheduler/KAI-Scheduler/issues/1808)
+- Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)
+- In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Fixed extended resources present on only a subset of nodes being reported as unavailable cluster-wide: `ResourceVector.SetMax` now grows the accumulator to the longer vector's length instead of silently dropping resource indices discovered after the first-iterated node, which caused pods requesting such resources to be rejected as unschedulable ("No node in the node-pool has X resources") depending on node map iteration order. [#1851](https://github.com/kai-scheduler/KAI-Scheduler/issues/1851)
+- Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Scoped the operator's informer cache for Pods, Leases and EndpointSlices to the KAI namespace and stripped managed fields from cached objects. Since v0.15.0 the operator cached every such object in the cluster, so its memory grew with cluster size and exceeded the default 256Mi limit on large clusters. [#1780](https://github.com/kai-scheduler/KAI-Scheduler/issues/1780)
+- Reduced transient scheduler allocations during large reclaim operations by comparing proportion queue state and cached resource vectors directly instead of repeatedly materializing resource maps.
+- Fixed scheduler panic during reclaim when building eviction messages for jobs in root-level queues (`ParentQueue` empty) that reclaim across hierarchy branches. [#1863](https://github.com/kai-scheduler/KAI-Scheduler/issues/1863)
+- Reduced allocation churn in the scheduler hot path: cached `Schedulable()` result as a package-level singleton and lazily formatted `logNodeSetsPluginResult` node names only when verbose logging is enabled.
+- Use the maximum gpu size ine the cluster rather then the minimum when checking a potential overLimit or isNonPreemptebleOverquota for a pod. [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)
+- Fix the MinNodeGPUMemoryMiB calculation in the scheduler. This affected allocations for fractional pod requesting gpu "gpu-memory". [#1792](https://github.com/kai-scheduler/KAI-Scheduler/issues/1792) [davidLif](https://github.com/davidLif)
+- Scheduler cache now filters terminal Pods at watch time to reduce memory use, while still watching Pods bound by other schedulers so their resource usage is counted in allocatable calculations. [#1645](https://github.com/kai-scheduler/KAI-Scheduler/issues/1645) [enoodle](https://github.com/enoodle)
+- Restricted Helm post-delete cleanup to KAI operator-managed Deployments and preserved externally managed `kai-config` resources when `kaiConfigDeployer.enabled=false`.
+- Saturated the DRA GPU device-count accumulation so a ResourceClaim requesting an oversized device count can no longer overflow the queue controller's int64 GPU total to a negative value. [#1873](https://github.com/kai-scheduler/KAI-Scheduler/issues/1873) [thc1006](https://github.com/thc1006)
+- Prevent some scheduler OOM kills by setting Go's memory limit
+- Upgrade test suite retries queue creation when admission webhook is not yet ready
+- Clear stale PodGroup `UnschedulableOnNodePool` conditions after workloads schedule.
+- Segmented elastic PyTorchJob now respects minReplicas instead of requiring all worker segments
+- NUMA plugin now aligns non-Guaranteed pods that request GPUs, matching the kubelet's device manager (device alignment is QoS-independent).
+- Status-updater drops status/patch updates for deleted PodGroups instead of retrying NotFound errors indefinitely, stopping log floods. [#1945](https://github.com/kai-scheduler/KAI-Scheduler/issues/1945)
+- Fixed reclaim abandoning valid over-quota victims when an unrelated under-deserved queue appeared earlier in victim ordering. [#1750](https://github.com/kai-scheduler/KAI-Scheduler/issues/1750)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
+- Scheduler now exits on 401 Unauthorized API responses instead of retrying indefinitely with a stale ServiceAccount token. [#1817](https://github.com/kai-scheduler/KAI-Scheduler/issues/1817)
+- Removed unnecessary pod-affinity pre-score allocation churn
+- Avoid repeated victim candidate allocations during reclaim, preempt, and unlimited-candidate consolidation searches [#1850](https://github.com/kai-scheduler/KAI-Scheduler/issues/1850)
+- Reduce retained scheduler memory with compact fit-error counts and on-demand details. [#1827](https://github.com/kai-scheduler/KAI-Scheduler/issues/1827) [enoodle](https://github.com/enoodle)
+- Fixed admission and scheduler PodDisruptionBudget reconciliation, including drift recovery and cleanup when no longer desired. [#1477](https://github.com/kai-scheduler/KAI-Scheduler/issues/1477) [dttung2905](https://github.com/dttung2905)
+- Segmented PyTorch and LWS PodGrouper now uses minSubGroup on parent SubGroups, fixing admission webhook rejection. [#1927](https://github.com/kai-scheduler/KAI-Scheduler/issues/1927)
+
 ## [v0.16.0] - 2026-06-24
 
 ### Added


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.17.0]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.17.0` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.17.0]` section for accuracy.
- Target branch: `main`.
