### PR TITLE
chore(chart): rename global.fips to global.fipsMode with on/off values

### DIFF
--- a/.changes/unreleased/Changed-20260803-120000.yaml
+++ b/.changes/unreleased/Changed-20260803-120000.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Renamed Helm value global.fips to global.fipsMode with on/off options
+custom:
+  Issue: "1906"
+  Author: ""

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -25,13 +25,13 @@ argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 
 {{/*
 Resolves a component image tag: explicit tag, then global.tag, then the chart
-version. When global.fips is set, appends "-fips" to whatever tag resolves so
+version. When global.fipsMode is "on", appends "-fips" to whatever tag resolves so
 the FIPS image variants are used. Usage:
   {{ include "kai-scheduler.imageTag" (dict "root" $ "tag" .Values.<svc>.image.tag) }}
 */}}
 {{- define "kai-scheduler.imageTag" -}}
 {{- $tag := .tag | default .root.Values.global.tag | default .root.Chart.AppVersion -}}
-{{- if .root.Values.global.fips -}}{{- $tag = printf "%s-fips" $tag -}}{{- end -}}
+{{- if eq .root.Values.global.fipsMode "on" -}}{{- $tag = printf "%s-fips" $tag -}}{{- end -}}
 {{- $tag -}}
 {{- end -}}
 

--- a/deployments/kai-scheduler/tests/fips_test.yaml
+++ b/deployments/kai-scheduler/tests/fips_test.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-suite: test global.fips image tag suffix
+suite: test global.fipsMode image tag suffix
 
 set:
   kaiConfigDeployer:
@@ -31,9 +31,9 @@ tests:
           value: registry/local/kai-scheduler/crd-upgrader:0.0.0
         template: hooks/pre/crd-upgrader.yaml
 
-  - it: should suffix all image tags when global.fips is enabled
+  - it: should suffix all image tags when global.fipsMode is on
     set:
-      global.fips: true
+      global.fipsMode: "on"
     asserts:
       - equal:
           path: spec.scheduler.service.image.tag
@@ -64,9 +64,9 @@ tests:
           value: registry/local/kai-scheduler/crd-upgrader:0.0.0-fips
         template: hooks/pre/crd-upgrader.yaml
 
-  - it: should suffix explicit per-service and global tags when global.fips is enabled
+  - it: should suffix explicit per-service and global tags when global.fipsMode is on
     set:
-      global.fips: true
+      global.fipsMode: "on"
       global.tag: v1.2.3
       scheduler.image.tag: v9.9.9
     asserts:

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -11,7 +11,8 @@ global:
   tag: ""
   # Use FIPS-enabled images: appends "-fips" to every resolved image tag
   # (whether it comes from a per-service tag, global.tag or the chart version)
-  fips: false
+  # Valid values: "on" | "off"
+  fipsMode: "off"
   imagePullPolicy: IfNotPresent
   securityContext: {}
   podSecurityContext: {}


### PR DESCRIPTION
## Description

Renames the `global.fips` Helm boolean to `global.fipsMode` with explicit string values `"on"` / `"off"`.

- `values.yaml`: `fips: false` → `fipsMode: "off"`
- `_helpers.tpl`: condition updated to `eq .root.Values.global.fipsMode "on"`
- `tests/fips_test.yaml`: all test cases updated to use `global.fipsMode: "on"`

## Related Issues

Fixes #1906

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

Users setting `global.fips: true` must migrate to `global.fipsMode: "on"`.

## Additional Notes

N/A