### PR TITLE
fix(ci): preserve DCO signatures in backports

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           github_token: ${{ secrets.KAIBOT_TOKEN }}
           pull_title: "${pull_title}"
+          cherry_picking: pull_request_head
           # Backports carry the original PR's changie fragment (a new file, so no conflict).
           # Propagate changelog-exemption labels so exempt PRs still pass validate-changelog.
           copy_labels_pattern: "skip-changelog|dependencies"


### PR DESCRIPTION
## Description

Configure automated backports to cherry-pick the original pull-request commits instead of the squash-merge commit. This preserves the original author and DCO sign-off pair when the GitHub display name differs from the Git commit name.

## Related Issues

None.

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (not needed: GitHub Actions configuration only)
- [ ] Updated documentation (not needed)
- [x] Applied the `skip-changelog` label (CI-only change)

## Breaking Changes

None.

## Additional Notes

`pull_request_head` does not include edits made only in GitHub's squash-merge commit.
